### PR TITLE
fix: handle empty selfie reference image path

### DIFF
--- a/core/plugin/builtin_plugins/kira-ai/tags.py
+++ b/core/plugin/builtin_plugins/kira-ai/tags.py
@@ -47,7 +47,7 @@ def build_emoji_tag(emoji_json: dict) -> Type[BaseTag]:
 
 class AtTag(BaseTag):
     name = "at"
-    description = "<at>user_id</at> # 通过用户id使用@功能，通常出现在消息的开头，有时也会在消息中间（如果聊天中需要提及其他人），特殊的，传入字符串all代表@全体成员。at功能仅在群聊中使用，系统会将at消息解析为‘@用户昵称’显示"
+    description = "<at>user_id</at> # 通过用户id使用@功能，通常出现在消息的开头，有时也会在消息中间（如果聊天中需要提及其他人），特殊的，传入字符串all代表@全体成员。at功能仅在群聊中使用，系统会将at消息解析为'@用户昵称'显示"
 
     async def handle(self, value: str, **kwargs) -> list[BaseMessageElement]:
         return [At(value)]
@@ -135,6 +135,9 @@ class SelfieTag(BaseTag):
     async def handle(self, value: str, **kwargs) -> list[BaseMessageElement]:
         try:
             ref_img_path = self.ctx.config.get('bot_config', {}).get('selfie', {}).get('path', '')
+            if not ref_img_path:
+                message_logger.warning("Selfie reference image not set, skipped generation")
+                return []
             if os.path.exists(f"{get_data_path()}/{ref_img_path}"):
                 img_extension = ref_img_path.split(".")[-1]
                 bs64 = await image_to_base64(f"{get_data_path()}/{ref_img_path}")

--- a/core/plugin/builtin_plugins/kira-ai/tags.py
+++ b/core/plugin/builtin_plugins/kira-ai/tags.py
@@ -138,9 +138,10 @@ class SelfieTag(BaseTag):
             if not ref_img_path:
                 message_logger.warning("Selfie reference image not set, skipped generation")
                 return []
-            if os.path.exists(f"{get_data_path()}/{ref_img_path}"):
-                img_extension = ref_img_path.split(".")[-1]
-                bs64 = await image_to_base64(f"{get_data_path()}/{ref_img_path}")
+            ref_file = Path(get_data_path()) / ref_img_path
+            if ref_file.is_file():
+                img_extension = ref_file.suffix.lstrip(".")
+                bs64 = await image_to_base64(str(ref_file))
                 img_res = await self.ctx.llm_api.image_to_image(value, image=Image(image=bs64, name=ref_img_path, mime=f"image/{img_extension}"))
                 if img_res:
                     return [img_res]


### PR DESCRIPTION
Fixes #24

When `selfie` reference image path config is left blank (empty string), `os.path.exists(f"{get_data_path()}/")` checks the data directory instead of a file. Since the directory always exists, it proceeds to try reading the directory as an image file, causing `PermissionError: [Errno 13] Permission denied`.

Added an empty path check that logs a warning "Selfie reference image not set, skipped generation" and returns early.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened selfie image generation robustness by improving how missing or unconfigured reference image paths are handled, with enhanced warning messages and earlier error detection to gracefully prevent generation failures.
  * Minor text formatting update in plugin tag descriptions for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->