### PR TITLE
feat: add v1/chat image generation

### DIFF
--- a/core/adapter/src/telegram/telegram.py
+++ b/core/adapter/src/telegram/telegram.py
@@ -434,15 +434,17 @@ class TelegramAdapter(IMAdapter):
 
             # ── Image ──
             elif isinstance(ele, Image):
-                if ele.image_type == "url":
-                    sent = await self.message_sender.send_with_retry(
-                        self.app.bot.send_photo, chat_id=chat_id, photo=ele.image, **reply_kw
-                    )
-                else:
-                    image_base64 = await ele.to_base64()
-                    sent = await self.message_sender.send_with_retry(
-                        self.app.bot.send_photo, chat_id=chat_id, photo=base64.b64decode(image_base64), **reply_kw
-                    )
+                # if ele.image_type == "url":
+                #     sent = await self.message_sender.send_with_retry(
+                #         self.app.bot.send_photo, chat_id=chat_id, photo=ele.image, **reply_kw
+                #     )
+                # else:
+
+                # Some URLs may not accessible by Telegram's servers
+                image_base64 = await ele.to_base64()
+                sent = await self.message_sender.send_with_retry(
+                    self.app.bot.send_photo, chat_id=chat_id, photo=base64.b64decode(image_base64), **reply_kw
+                )
                 message_id = str(sent.message_id)
 
             # ── Record (voice) ──

--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -137,8 +137,11 @@ class LLMClient:
         logger.info(f"Generating image using {model_id} ({provider_name})")
         try:
             img_res = await image_model.text_to_image(prompt)
-            if not img_res:
-                logger.error(f"Failed to generate image with text")
+            if img_res:
+                logger.info(f"Image generated with prompt: {prompt}")
+                logger.debug(f"type={img_res.image_type}, len={len(img_res.image or '')}, prefix={repr((img_res.image or '')[:200])}")
+            else:
+                logger.error(f"Failed to generate image with text: result is None")
             return img_res
         except Exception as e:
             logger.error(f"Failed to generate image with text: {e}")
@@ -150,8 +153,11 @@ class LLMClient:
         logger.info(f"Generating image using {model_id} ({provider_name}) with a reference image")
         try:
             img_res = await image_model.image_to_image(prompt=prompt, image=image)
-            if not img_res:
-                logger.error(f"Failed to generate image with a reference image")
+            if img_res:
+                logger.info(f"Image generated (img2img): prompt: {prompt}")
+                logger.debug(f"type={img_res.image_type}, len={len(img_res.image or '')}, prefix={repr((img_res.image or '')[:200])}")
+            else:
+                logger.error(f"Failed to generate image with a reference image: result is None")
             return img_res
         except Exception as e:
             logger.error(f"Failed to generate image with a reference image: {e}")

--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -139,9 +139,9 @@ class LLMClient:
             img_res = await image_model.text_to_image(prompt)
             if img_res:
                 logger.info(f"Image generated with prompt: {prompt}")
-                logger.debug(f"type={img_res.image_type}, len={len(img_res.image or '')}, prefix={repr((img_res.image or '')[:200])}")
+                logger.debug(f"type={img_res.image_type}, len={len(img_res.image or '')}, prefix={(img_res.image or '')[:200]!r}")
             else:
-                logger.error(f"Failed to generate image with text: result is None")
+                logger.error("Failed to generate image with text: result is None")
             return img_res
         except Exception as e:
             logger.error(f"Failed to generate image with text: {e}")
@@ -155,9 +155,9 @@ class LLMClient:
             img_res = await image_model.image_to_image(prompt=prompt, image=image)
             if img_res:
                 logger.info(f"Image generated (img2img): prompt: {prompt}")
-                logger.debug(f"type={img_res.image_type}, len={len(img_res.image or '')}, prefix={repr((img_res.image or '')[:200])}")
+                logger.debug(f"type={img_res.image_type}, len={len(img_res.image or '')}, prefix={(img_res.image or '')[:200]!r}")
             else:
-                logger.error(f"Failed to generate image with a reference image: result is None")
+                logger.error("Failed to generate image with a reference image: result is None")
             return img_res
         except Exception as e:
             logger.error(f"Failed to generate image with a reference image: {e}")

--- a/core/provider/src/openai/model_clients.py
+++ b/core/provider/src/openai/model_clients.py
@@ -248,10 +248,9 @@ class OpenAIImageClient(ImageModelClient):
             images_response = await client.images.generate(
                 model=self.model.model_id,
                 prompt=prompt,
-                image=[image_data_url],
                 size=image_size if image_size else None,
                 response_format="url",
-                extra_body={"watermark": False},
+                extra_body={"watermark": False, "image": [image_data_url]},
             )
             return Image(image=images_response.data[0].url)
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:

--- a/core/provider/src/openai/model_clients.py
+++ b/core/provider/src/openai/model_clients.py
@@ -40,13 +40,18 @@ class OpenAIImageClient(ImageModelClient):
 
     def _build_client(self) -> AsyncOpenAI:
         """Build the AsyncOpenAI client (shared by both modes)."""
+        from httpx import Timeout
+
         default_headers = self.model.provider_config.get("headers", {})
         if not isinstance(default_headers, dict) or not default_headers:
             default_headers = None
+        timeout_val = self.model.model_config.get("timeout", 120)
+        timeout = Timeout(timeout_val, connect=10)
         return AsyncOpenAI(
             base_url=self.model.provider_config.get("base_url", ""),
             api_key=self.model.provider_config.get("api_key", ""),
             default_headers=default_headers,
+            timeout=timeout,
         )
 
     async def text_to_image(self, prompt) -> Image:
@@ -329,57 +334,3 @@ class OpenAIEmbeddingClient(EmbeddingModelClient):
             logger.error(f"Embedding error: {e}")
             return []
 
-
-# class OpenAIEmbeddingClient(EmbeddingModelClient):
-#     def __init__(self, model: ModelInfo):
-#         super().__init__(model)
-#         self._client: Optional[AsyncOpenAI] = None
-
-#     async def generate(self, text: str) -> list[float]:
-#         if self._client is None:
-#             self._client = AsyncOpenAI(
-#                 api_key=self.model.provider_config.get("api_key", ""),
-#                 base_url=self.model.provider_config.get("base_url", "")
-#             )
-#         try:
-#             response = await self._client.embeddings.create(
-#                 model=self.model.model_id,
-#                 input=text
-#             )
-#             return response.data[0].embedding
-#         except APIStatusError as e:
-#             # the model does not support function calling etc.
-#             # 403 Authorization failed (api key error)
-#             logger.error(f"APIStatusError: {e}")
-#         except APITimeoutError as e:
-#             logger.error(f"APITimeoutError: {e}")
-#         except APIConnectionError as e:
-#             # APIConnectionError: Connection error.(base_url error)
-#             logger.error(f"APIConnectionError: {e}")
-#         except Exception as e:
-#             logger.error(f"Error: {e}")
-
-#     async def generate_batch(self, texts: list[str]) -> list[list[float]]:
-#         if self._client is None:
-#             self._client = AsyncOpenAI(
-#                 api_key=self.model.provider_config.get("api_key", ""),
-#                 base_url=self.model.provider_config.get("base_url", "")
-#             )
-#         try:
-#             response = await self._client.embeddings.create(
-#                 model=self.model.model_id,
-#                 input=texts
-#             )
-#             sorted_data = sorted(response.data, key=lambda x: x.index)
-#             return [item.embedding for item in sorted_data]
-#         except APIStatusError as e:
-#             # the model does not support function calling etc.
-#             # 403 Authorization failed (api key error)
-#             logger.error(f"APIStatusError: {e}")
-#         except APITimeoutError as e:
-#             logger.error(f"APITimeoutError: {e}")
-#         except APIConnectionError as e:
-#             # APIConnectionError: Connection error.(base_url error)
-#             logger.error(f"APIConnectionError: {e}")
-#         except Exception as e:
-#             logger.error(f"Error: {e}")

--- a/core/provider/src/openai/model_clients.py
+++ b/core/provider/src/openai/model_clients.py
@@ -1,4 +1,5 @@
 from openai import AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionError
+import re
 import time
 from typing import Optional
 
@@ -12,34 +13,282 @@ logger = get_logger("provider", "purple")
 
 
 class OpenAIImageClient(ImageModelClient):
+    """Image generation client with two on-the-wire shapes.
+
+    Original ``/v1/images/generations`` is the OpenAI standard image
+    endpoint. ``/v1/chat/completions`` mode handles the increasingly
+    common pattern where multimodal chat models (e.g. some Tongyi /
+    Doubao / 3rd-party-compatible APIs) return images embedded in
+    chat content — either as Markdown ``![alt](url)``, data URIs, or
+    typed ``output_image`` / ``image_url`` content parts.
+
+    The chat path is kept defensively conservative:
+      * Bare URLs in text content are NEVER promoted to images
+        (would let prompt injection fabricate result URLs).
+      * ``type="text"`` content parts are explicitly skipped before
+        URL extraction.
+      * Data URIs must literally start with ``data:image/``.
+    """
+
+    # Markdown image regex: ![alt](url). Used only inside chat mode,
+    # only when the entire content is a string AND no structured part
+    # was found. Greedy URL match capped at first whitespace.
+    _MD_IMAGE_RE = re.compile(r'!\[.*?\]\((https?://\S+?)\)')
+
     def __init__(self, model: ModelInfo):
         super().__init__(model)
 
-    async def text_to_image(self, prompt) -> Image:
+    def _build_client(self) -> AsyncOpenAI:
+        """Build the AsyncOpenAI client (shared by both modes)."""
         default_headers = self.model.provider_config.get("headers", {})
         if not isinstance(default_headers, dict) or not default_headers:
             default_headers = None
-        client = AsyncOpenAI(
+        return AsyncOpenAI(
             base_url=self.model.provider_config.get("base_url", ""),
             api_key=self.model.provider_config.get("api_key", ""),
-            default_headers=default_headers
+            default_headers=default_headers,
         )
+
+    async def text_to_image(self, prompt) -> Image:
+        endpoint = self.model.model_config.get("endpoint", "v1/image")
+        if endpoint == "v1/chat":
+            return await self._text_to_image_via_chat(prompt)
+        return await self._text_to_image_via_generations(prompt)
+
+    # ──────── Mode A: /v1/images/generations ────────
+
+    async def _text_to_image_via_generations(self, prompt: str) -> Image:
+        client = self._build_client()
         image_size = self.model.model_config.get("size", None)
-        images_response = await client.images.generate(
-            model=self.model.model_id,
-            prompt=prompt,
-            size=image_size if image_size else None,
-            response_format="url",
-            extra_body={
-                "watermark": False,
-            },
+        try:
+            images_response = await client.images.generate(
+                model=self.model.model_id,
+                prompt=prompt,
+                size=image_size if image_size else None,
+                response_format="url",
+                extra_body={"watermark": False},
+            )
+            return Image(image=images_response.data[0].url)
+        except (APIStatusError, APITimeoutError, APIConnectionError) as e:
+            logger.error(f"Image generation API error: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Image generation error: {e}")
+            raise
+
+    # ──────── Mode B: /v1/chat/completions (non-stream) ────────
+
+    async def _text_to_image_via_chat(self, prompt: str) -> Image:
+        client = self._build_client()
+        messages = [{"role": "user", "content": prompt}]
+
+        try:
+            response = await client.chat.completions.create(
+                model=self.model.model_id,
+                messages=messages,
+            )
+        except (APIStatusError, APITimeoutError, APIConnectionError) as e:
+            logger.error(f"Image generation (chat) API error: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Image generation (chat) error: {e}")
+            raise
+
+        if not response.choices:
+            raise ValueError("Chat completions returned empty choices")
+
+        message = response.choices[0].message
+        image_result = self._extract_image_from_message(message)
+        if image_result is not None:
+            return image_result
+
+        raise ValueError(
+            "Chat completions response carried no recognisable image."
+            f" content={getattr(message, 'content', None)!r}"
         )
 
-        return Image(image=images_response.data[0].url)
+    # ──────── image extraction helpers ────────
 
-    async def image_to_image(self, prompt: str, url: Optional[str] = None,
-                             base64: Optional[str] = None) -> Image:
-        pass
+    def _extract_image_from_message(self, message) -> Optional[Image]:
+        """
+        Walk a ChatCompletionMessage in the most-specific-first order:
+          1. content as multimodal list (list[content_part])
+          2. model_extra.content (some SDKs / 3rd-party APIs stash here)
+          3. content as plain string —
+             a) starts with data:image/  → wrap as data URI
+             b) contains Markdown ![alt](url) → extract URL
+             Bare URLs / plain text NEVER become images.
+        """
+        content = message.content
+
+        # 1) content itself is a multimodal list
+        if isinstance(content, list):
+            img = self._scan_parts(content)
+            if img:
+                return img
+
+        # 2) model_extra.content (SDK version / 3rd-party-compat fallback)
+        if hasattr(message, "model_extra") and isinstance(
+            message.model_extra, dict
+        ):
+            extra_content = message.model_extra.get("content")
+            if isinstance(extra_content, list):
+                img = self._scan_parts(extra_content)
+                if img:
+                    return img
+
+        # 3) plain string fallbacks
+        if isinstance(content, str):
+            stripped = content.strip()
+
+            # 3a) entire content is a data:image/ base64 URI
+            if stripped.startswith("data:image/"):
+                return Image(image=stripped)
+
+            # 3b) Markdown image syntax — extract URL only from this
+            # syntax, never from random URLs in text content
+            md_match = self._MD_IMAGE_RE.search(stripped)
+            if md_match:
+                url = md_match.group(1)
+                # Strip a stray closing paren that the prompt sometimes
+                # appends right after the URL.
+                url = url.rstrip(")")
+                return Image(image=url)
+
+        return None
+
+    def _scan_parts(self, parts: list) -> Optional[Image]:
+        """Return the first extractable image among content parts."""
+        for part in parts:
+            img = self._try_extract_image_part(part)
+            if img:
+                return img
+        return None
+
+    def _try_extract_image_part(self, part) -> Optional[Image]:
+        """
+        Pull an image out of one content part.
+        ``part`` may be a dict (raw JSON) or a pydantic model (parsed SDK).
+        Explicitly skip ``type="text"`` to avoid hoisting URLs from text.
+        """
+        # Normalise to dict
+        if hasattr(part, "model_dump"):
+            part = part.model_dump()
+        elif not isinstance(part, dict) and hasattr(part, "__dict__"):
+            part = vars(part)
+        if not isinstance(part, dict):
+            return None
+
+        part_type = part.get("type", "")
+
+        # type=text — never extract URLs from this
+        if part_type == "text":
+            return None
+
+        # ── image_url ──
+        if part_type == "image_url":
+            url = self._get_nested_url(part, "image_url")
+            if url and self._is_valid_image_source(url):
+                return Image(image=url)
+
+        # ── output_image ──
+        if part_type == "output_image":
+            # url field first
+            url = part.get("url", "")
+            if url and self._is_valid_image_source(url):
+                return Image(image=url)
+            # fall back to base64 / data field → build data URI
+            b64 = part.get("base64", "") or part.get("data", "")
+            if b64:
+                media_type = (
+                    part.get("media_type")
+                    or part.get("content_type")
+                    or "image/png"
+                )
+                return Image(image=f"data:{media_type};base64,{b64}")
+
+        return None
+
+    @staticmethod
+    def _get_nested_url(part: dict, key: str) -> str:
+        """Read url from a possibly-nested dict-or-attr structure."""
+        obj = part.get(key, {})
+        if isinstance(obj, dict):
+            return obj.get("url", "")
+        if hasattr(obj, "url"):
+            return obj.url or ""
+        return ""
+
+    @staticmethod
+    def _is_valid_image_source(url: str) -> bool:
+        """Accept only data:image/ base64 URIs and HTTP(S) URLs."""
+        return url.startswith("data:image/") or url.startswith(
+            ("http://", "https://")
+        )
+
+    async def image_to_image(self, prompt: str, image: Image) -> Image:
+        endpoint = self.model.model_config.get("endpoint", "v1/image")
+        if endpoint == "v1/chat":
+            return await self._image_to_image_via_chat(prompt, image)
+        return await self._image_to_image_via_generations(prompt, image)
+
+    # ──────── image-to-image Mode A: /v1/images/generations ────────
+
+    async def _image_to_image_via_generations(self, prompt: str, image: Image) -> Image:
+        client = self._build_client()
+        image_size = self.model.model_config.get("size", None)
+        # Convert the input image to a data URL that the API can consume
+        image_data_url = await image.to_data_url()
+        try:
+            images_response = await client.images.generate(
+                model=self.model.model_id,
+                prompt=prompt,
+                image=[image_data_url],
+                size=image_size if image_size else None,
+                response_format="url",
+                extra_body={"watermark": False},
+            )
+            return Image(image=images_response.data[0].url)
+        except (APIStatusError, APITimeoutError, APIConnectionError) as e:
+            logger.error(f"Image-to-image generation API error: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Image-to-image generation error: {e}")
+            raise
+
+    # ──────── image-to-image Mode B: /v1/chat/completions ────────
+
+    async def _image_to_image_via_chat(self, prompt: str, image: Image) -> Image:
+        client = self._build_client()
+        image_data_url = await image.to_data_url()
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {"type": "image_url", "image_url": {"url": image_data_url}},
+            ],
+        }]
+        try:
+            response = await client.chat.completions.create(
+                model=self.model.model_id,
+                messages=messages,
+            )
+        except (APIStatusError, APITimeoutError, APIConnectionError) as e:
+            logger.error(f"Image-to-image (chat) API error: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Image-to-image (chat) error: {e}")
+            raise
+        if not response.choices:
+            raise ValueError("Chat completions returned empty choices")
+        message = response.choices[0].message
+        image_result = self._extract_image_from_message(message)
+        if image_result is not None:
+            return image_result
+        raise ValueError(
+            "Chat completions response carried no recognisable image."
+            f" content={getattr(message, 'content', None)!r}"
+        )
 
 
 class OpenAIEmbeddingClient(EmbeddingModelClient):

--- a/core/provider/src/openai/schema.json
+++ b/core/provider/src/openai/schema.json
@@ -38,12 +38,19 @@
       }
     },
     "image": {
+      "endpoint": {
+        "name": "Endpoint",
+        "type": "enum",
+        "default": "v1/image",
+        "options": ["v1/image", "v1/chat"],
+        "hint": "Endpoint to send image generation requests. Use v1/chat for multimodal chat models that return images via chat completions."
+      },
       "size": {
         "name": "Image Size",
         "type": "string",
         "default": null,
         "enum": ["256x256", "512x512", "1024x1024", "1024x1792", "1792x1024"],
-        "hint": "Image size (e.g., 1024x1024)"
+        "hint": "Image size (e.g., 1024x1024). Only applies to v1/image endpoint."
       }
     },
     "embedding": {

--- a/core/provider/src/openai/schema.json
+++ b/core/provider/src/openai/schema.json
@@ -38,6 +38,13 @@
       }
     },
     "image": {
+      "timeout": {
+        "name": "Timeout",
+        "type": "integer",
+        "default": 120,
+        "min": 1,
+        "hint": "Timeout seconds"
+      },
       "endpoint": {
         "name": "Endpoint",
         "type": "enum",


### PR DESCRIPTION
feat: add v1/chat image generation (#23 )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image generation and image-to-image now support two API modes (generations or chat) with a configurable endpoint (defaults to generations).
  * Image-to-image API updated to accept Image objects directly.

* **Bug Fixes**
  * Stricter validation rejects unrecognized chat-mode image responses.
  * Telegram now consistently sends decoded image bytes.
  * Improved logging for image-generation success and failure diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->