### PR TITLE
feat: save received images to local and pass file_path to LLM

### DIFF
--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -246,7 +246,18 @@ class MessageProcessor:
                             await self.image_desc_cache.set(md5, ele.caption)
                     except Exception as e:
                         logger.warning(f"Failed to cache image desc: {e}")
-                message_str += f"[Image {str(ele.caption)}]"
+                try:
+                    path = Path(await ele.to_path())
+                    data_dir = get_data_path()
+                    try:
+                        rel = path.relative_to(data_dir)
+                        path_result = f"data/{rel}"
+                    except ValueError:
+                        path_result = str(path)
+                    message_str += f"[Image {str(ele.caption)}, file_path: {path_result}]"
+                except Exception as e:
+                    logger.warning(f"Failed to save image: {e}")
+                    message_str += f"[Image {str(ele.caption)}]"
             elif isinstance(ele, Sticker):
                 if ele.caption is None:
                     try:


### PR DESCRIPTION
Fixes #29

Save images received from adapters to local storage and pass the file path to LLM for further processing, matching the existing behavior of File and Video elements.

Changes:
- In `core/message_manager.py` `message_format_to_text()`, Image elements now call `ele.to_path()` to save the image locally
- Include `file_path` in the message string like `[Image {description}, file_path: data/...]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced image handling in message display. Image references now automatically include resolved file paths alongside captions, providing improved clarity and better reference identification. The implementation maintains stable performance by gracefully handling cases where path resolution is unavailable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xxynet/KiraAI/pull/32)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->