### PR TITLE
feat： add `--disable-webui-auth` parameter

### DIFF
--- a/core/launcher.py
+++ b/core/launcher.py
@@ -17,11 +17,12 @@ from webui.app import KiraWebUI
 
 class KiraLauncher:
     """KiraAI Launcher"""
-    def __init__(self, ignore_webui_version_check: bool = False):
+    def __init__(self, ignore_webui_version_check: bool = False, disable_webui_auth: bool = False):
         self.lifecycle: Optional[KiraLifecycle] = None
         self.stats: Optional[Statistics] = None
         self.webui = None
         self.ignore_webui_version_check = ignore_webui_version_check
+        self.disable_webui_auth = disable_webui_auth
         self.logger = get_logger("launcher", "blue")
 
     async def start(self):
@@ -63,13 +64,17 @@ class KiraLauncher:
         from core.utils.dist_checker import ensure_dist
         await ensure_dist(ignore_webui_version_check=self.ignore_webui_version_check)
 
-        self.webui = KiraWebUI(lifecycle=self.lifecycle)
-
-        self.logger.info(f"WebUI server started at http://{webui_config['host']}:{webui_config['port']}")
+        self.webui = KiraWebUI(lifecycle=self.lifecycle, disable_auth=self.disable_webui_auth)
 
         try:
             host = webui_config["host"]
             port = webui_config["port"]
+
+            if self.disable_webui_auth and host not in ("localhost", "127.0.0.1"):
+                self.logger.warning("Auth disabled — forcing host to 127.0.0.1 for security")
+                host = "127.0.0.1"
+
+            self.logger.info(f"WebUI server started at http://{host}:{port}")
             access_token = self.webui.access_token
 
             if host not in ("localhost", "127.0.0.1"):

--- a/main.py
+++ b/main.py
@@ -35,6 +35,12 @@ def _parse_args() -> argparse.Namespace:
         default=False,
         help="Skip frontend dist version check (useful during development with --webui-dir)",
     )
+    parser.add_argument(
+        "--disable-webui-auth",
+        action="store_true",
+        default=False,
+        help="Disable WebUI authentication (use a fixed token so Electron can auto-login)",
+    )
     return parser.parse_args()
 
 
@@ -68,10 +74,15 @@ if __name__ == "__main__":
         logger.info(f"Using data dir override: {args.data_dir}")
     if args.webui_dir:
         logger.info(f"Using webui dir override: {args.webui_dir}")
+    if args.disable_webui_auth:
+        logger.info("WebUI authentication disabled")
 
     from core.launcher import KiraLauncher
 
-    launcher = KiraLauncher(ignore_webui_version_check=args.ignore_webui_version_check)
+    launcher = KiraLauncher(
+        ignore_webui_version_check=args.ignore_webui_version_check,
+        disable_webui_auth=args.disable_webui_auth,
+    )
 
     try:
         asyncio.run(launcher.start())

--- a/webui/app.py
+++ b/webui/app.py
@@ -35,7 +35,7 @@ class KiraWebUI:
     Holds lifecycle instance for accessing system components
     """
 
-    def __init__(self, lifecycle: KiraLifecycle, dist_dir: Optional[Path] = None):
+    def __init__(self, lifecycle: KiraLifecycle, dist_dir: Optional[Path] = None, disable_auth: bool = False):
         # Ensure proper MIME types on Windows (fixes .js served as text/plain)
         mimetypes.add_type("application/javascript", ".js")
         mimetypes.add_type("text/javascript", ".js")
@@ -44,7 +44,11 @@ class KiraWebUI:
         mimetypes.add_type("image/svg+xml", ".svg")
 
         self.lifecycle = lifecycle
-        self.access_token = _get_or_generate_access_token()
+        self.disable_auth = disable_auth
+        if disable_auth:
+            self.access_token = "disabled"
+        else:
+            self.access_token = _get_or_generate_access_token()
         self.app = FastAPI(
             title="KiraAI Admin Panel",
             description="Administration panel for KiraAI system",
@@ -94,7 +98,7 @@ class KiraWebUI:
         self.lifecycle.webui_app = self.app
 
     def _register_routes(self):
-        auth_routes = AuthRoutes(self.app, self.lifecycle, self.access_token, self.dist_dir)
+        auth_routes = AuthRoutes(self.app, self.lifecycle, self.access_token, self.dist_dir, self.disable_auth)
         auth_routes.register()
         OverviewRoutes(self.app, self.lifecycle).register()
         LogsRoutes(self.app, self.lifecycle).register()

--- a/webui/frontend/src/api/auth.ts
+++ b/webui/frontend/src/api/auth.ts
@@ -1,5 +1,9 @@
 import apiClient from './client'
-import type { TokenLoginRequest, LoginResponse } from '@/types'
+import type { TokenLoginRequest, LoginResponse, AuthConfigResponse } from '@/types'
+
+export function getAuthConfig() {
+  return apiClient.get<AuthConfigResponse>('/auth/config')
+}
 
 export function login(data: TokenLoginRequest) {
   return apiClient.post<LoginResponse>('/auth/login', data)

--- a/webui/frontend/src/router/index.ts
+++ b/webui/frontend/src/router/index.ts
@@ -36,9 +36,9 @@ const router = createRouter({
 // Navigation guard
 router.beforeEach(async (to) => {
   const token = localStorage.getItem('jwt_token')
-  if (token || to.meta.public) return
+  if (token) return
 
-  // If auth is disabled, auto-login with fixed token
+  // If auth is disabled, auto-login with fixed token (even for public routes)
   if (authEnabled === null) {
     try {
       const { data } = await getAuthConfig()
@@ -51,11 +51,14 @@ router.beforeEach(async (to) => {
     try {
       const { data } = await login({ access_token: 'disabled' })
       localStorage.setItem('jwt_token', data.access_token)
-      return to.fullPath
+      // If user was on a public route (e.g. /login), redirect to main page
+      return to.meta.public ? '/' : to.fullPath
     } catch {
-      // fallback: redirect to login
+      // fallback: continue to login
     }
   }
+
+  if (to.meta.public) return
   return '/login'
 })
 

--- a/webui/frontend/src/router/index.ts
+++ b/webui/frontend/src/router/index.ts
@@ -38,20 +38,24 @@ router.beforeEach(async (to) => {
   const token = localStorage.getItem('jwt_token')
   const isAutoDisabled = localStorage.getItem('jwt_auto_disabled') === 'true'
 
-  // Resolve auth config if unknown
-  if (authEnabled === null) {
+  // Resolve auth config if unknown; on failure, use a per-navigation fallback
+  // (assume auth enabled) so we don't permanently cache a wrong value and
+  // future navigations will retry the fetch.
+  let effectiveAuth = authEnabled
+  if (effectiveAuth === null) {
     try {
       const { data } = await getAuthConfig()
       authEnabled = data.auth_enabled
+      effectiveAuth = authEnabled
     } catch {
-      authEnabled = true
+      effectiveAuth = true
     }
   }
 
   // When auth is enabled, any token obtained via the "disabled" sentinel flow
   // must be invalidated — the API returns a real JWT, not the literal "disabled"
   // string, so we track it with a companion marker in localStorage.
-  if (authEnabled && isAutoDisabled) {
+  if (effectiveAuth && isAutoDisabled) {
     localStorage.removeItem('jwt_token')
     localStorage.removeItem('jwt_auto_disabled')
   }
@@ -59,10 +63,10 @@ router.beforeEach(async (to) => {
   // Allow through if we have a genuinely authenticated token
   if (token && !isAutoDisabled) return
   // Auth disabled and we already have a sentinel-obtained token
-  if (!authEnabled && token && isAutoDisabled) return
+  if (!effectiveAuth && token && isAutoDisabled) return
 
   // If auth is disabled, auto-login with sentinel token
-  if (!authEnabled) {
+  if (!effectiveAuth) {
     try {
       const { data } = await login({ access_token: 'disabled' })
       localStorage.setItem('jwt_token', data.access_token)

--- a/webui/frontend/src/router/index.ts
+++ b/webui/frontend/src/router/index.ts
@@ -1,4 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { getAuthConfig, login } from '@/api/auth'
+
+let authEnabled: boolean | null = null
 
 const router = createRouter({
   history: createWebHistory(),
@@ -31,11 +34,29 @@ const router = createRouter({
 })
 
 // Navigation guard
-router.beforeEach((to) => {
+router.beforeEach(async (to) => {
   const token = localStorage.getItem('jwt_token')
-  if (!to.meta.public && !token) {
-    return '/login'
+  if (token || to.meta.public) return
+
+  // If auth is disabled, auto-login with fixed token
+  if (authEnabled === null) {
+    try {
+      const { data } = await getAuthConfig()
+      authEnabled = data.auth_enabled
+    } catch {
+      authEnabled = true
+    }
   }
+  if (!authEnabled) {
+    try {
+      const { data } = await login({ access_token: 'disabled' })
+      localStorage.setItem('jwt_token', data.access_token)
+      return to.fullPath
+    } catch {
+      // fallback: redirect to login
+    }
+  }
+  return '/login'
 })
 
 export default router

--- a/webui/frontend/src/router/index.ts
+++ b/webui/frontend/src/router/index.ts
@@ -36,9 +36,9 @@ const router = createRouter({
 // Navigation guard
 router.beforeEach(async (to) => {
   const token = localStorage.getItem('jwt_token')
-  if (token) return
+  const isAutoDisabled = localStorage.getItem('jwt_auto_disabled') === 'true'
 
-  // If auth is disabled, auto-login with fixed token (even for public routes)
+  // Resolve auth config if unknown
   if (authEnabled === null) {
     try {
       const { data } = await getAuthConfig()
@@ -47,11 +47,26 @@ router.beforeEach(async (to) => {
       authEnabled = true
     }
   }
+
+  // When auth is enabled, any token obtained via the "disabled" sentinel flow
+  // must be invalidated — the API returns a real JWT, not the literal "disabled"
+  // string, so we track it with a companion marker in localStorage.
+  if (authEnabled && isAutoDisabled) {
+    localStorage.removeItem('jwt_token')
+    localStorage.removeItem('jwt_auto_disabled')
+  }
+
+  // Allow through if we have a genuinely authenticated token
+  if (token && !isAutoDisabled) return
+  // Auth disabled and we already have a sentinel-obtained token
+  if (!authEnabled && token && isAutoDisabled) return
+
+  // If auth is disabled, auto-login with sentinel token
   if (!authEnabled) {
     try {
       const { data } = await login({ access_token: 'disabled' })
       localStorage.setItem('jwt_token', data.access_token)
-      // If user was on a public route (e.g. /login), redirect to main page
+      localStorage.setItem('jwt_auto_disabled', 'true')
       return to.meta.public ? '/' : to.fullPath
     } catch {
       // fallback: continue to login

--- a/webui/frontend/src/stores/auth.ts
+++ b/webui/frontend/src/stores/auth.ts
@@ -13,6 +13,8 @@ export const useAuthStore = defineStore('auth', () => {
     const response = await authApi.login(data)
     token.value = response.data.access_token
     localStorage.setItem('jwt_token', response.data.access_token)
+    // Clear sentinel marker — this is a genuine user login
+    localStorage.removeItem('jwt_auto_disabled')
   }
 
   async function logout() {
@@ -21,12 +23,14 @@ export const useAuthStore = defineStore('auth', () => {
     } finally {
       token.value = null
       localStorage.removeItem('jwt_token')
+      localStorage.removeItem('jwt_auto_disabled')
     }
   }
 
   function clearAuth() {
     token.value = null
     localStorage.removeItem('jwt_token')
+    localStorage.removeItem('jwt_auto_disabled')
   }
 
   return {

--- a/webui/frontend/src/types/models.ts
+++ b/webui/frontend/src/types/models.ts
@@ -14,6 +14,10 @@ export interface LoginResponse {
   token_type: string
 }
 
+export interface AuthConfigResponse {
+  auth_enabled: boolean
+}
+
 export interface OverviewResponse {
   total_adapters: number
   active_adapters: number

--- a/webui/routes/auth.py
+++ b/webui/routes/auth.py
@@ -24,10 +24,11 @@ async def require_auth(authorization: Optional[str] = Header(None)) -> str:
 
 
 class AuthRoutes(Routes):
-    def __init__(self, app, lifecycle, access_token: str, dist_dir: Path):
+    def __init__(self, app, lifecycle, access_token: str, dist_dir: Path, disable_auth: bool = False):
         super().__init__(app, lifecycle)
         self.access_token = access_token
         self.dist_dir = dist_dir
+        self.disable_auth = disable_auth
 
     def get_routes(self):
         return [
@@ -58,6 +59,12 @@ class AuthRoutes(Routes):
                 response_model=VersionResponse,
                 tags=["system"],
                 dependencies=[Depends(require_auth)],
+            ),
+            RouteDefinition(
+                path="/api/auth/config",
+                methods=["GET"],
+                endpoint=self.get_auth_config,
+                tags=["auth"],
             ),
             RouteDefinition(
                 path="/api/auth/login",
@@ -131,6 +138,9 @@ class AuthRoutes(Routes):
             content="<h1>Frontend not built. Run <code>npm install &amp;&amp; npm run build</code> inside <code>webui/frontend/</code>.</h1>",
             status_code=503,
         )
+
+    async def get_auth_config(self):
+        return {"auth_enabled": not self.disable_auth}
 
     async def health(self):
         return {"status": "ok", "lifecycle_available": self.lifecycle is not None}

--- a/webui/utils.py
+++ b/webui/utils.py
@@ -103,11 +103,16 @@ def _save_webui_config(config: Dict):
 
 
 def _get_or_generate_access_token() -> str:
-    """Get or generate access_token"""
+    """Get or generate access_token.
+
+    The reserved sentinel "disabled" is never returned — if it appears in the
+    config file (e.g. manually edited), the token is silently regenerated.
+    """
     config = _load_webui_config()
-    if "access_token" not in config or not config["access_token"]:
+    if "access_token" not in config or not config["access_token"] or config["access_token"] == "disabled":
         config["access_token"] = _generate_strong_password()
         _save_webui_config(config)
+        logger.warning("access_token was missing or reserved, regenerated a new one")
     return config["access_token"]
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI option to disable WebUI authentication.
  * Web UI adds an unauthenticated auth-config endpoint; frontend auto-logins with a sentinel token when auth is disabled.

* **Behavior Changes**
  * If auth is disabled and a non-local host is configured, the server warns and binds to localhost.
  * The sentinel value "disabled" is treated as invalid and triggers token regeneration.
  * Frontend caches auth config and tracks an auto-disabled JWT sentinel for routing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xxynet/KiraAI/pull/35)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->