### PR TITLE
fix(auth): replace jwt_auto_disabled marker with server-side auth_mode claim

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -57,6 +57,8 @@ class KiraWebUI:
             openapi_url="/api/openapi.json",
             docs_url="/api/docs",
         )
+        # require_auth reads this to detect mode-mismatched JWTs.
+        self.app.state.disable_auth = disable_auth
 
         # Paths
         self.webui_dir = Path(__file__).parent

--- a/webui/frontend/src/router/index.ts
+++ b/webui/frontend/src/router/index.ts
@@ -36,7 +36,6 @@ const router = createRouter({
 // Navigation guard
 router.beforeEach(async (to) => {
   const token = localStorage.getItem('jwt_token')
-  const isAutoDisabled = localStorage.getItem('jwt_auto_disabled') === 'true'
 
   // Resolve auth config if unknown; on failure, use a per-navigation fallback
   // (assume auth enabled) so we don't permanently cache a wrong value and
@@ -52,31 +51,29 @@ router.beforeEach(async (to) => {
     }
   }
 
-  // When auth is enabled, any token obtained via the "disabled" sentinel flow
-  // must be invalidated — the API returns a real JWT, not the literal "disabled"
-  // string, so we track it with a companion marker in localStorage.
-  if (effectiveAuth && isAutoDisabled) {
-    localStorage.removeItem('jwt_token')
-    localStorage.removeItem('jwt_auto_disabled')
-  }
-
-  // Allow through if we have a genuinely authenticated token
-  if (token && !isAutoDisabled) return
-  // Auth disabled and we already have a sentinel-obtained token
-  if (!effectiveAuth && token && isAutoDisabled) return
-
-  // If auth is disabled, auto-login with sentinel token
+  // Auth disabled: the user must never see the login form. Mint a fresh
+  // sentinel JWT whenever we have no token, OR whenever we land directly on
+  // /login (e.g. Electron shell loads ${BACKEND_URL}/login on startup) — in
+  // that case any cached token may be stale from a prior enabled-mode session
+  // and there's no API call on this page to surface the mode mismatch.
   if (!effectiveAuth) {
-    try {
-      const { data } = await login({ access_token: 'disabled' })
-      localStorage.setItem('jwt_token', data.access_token)
-      localStorage.setItem('jwt_auto_disabled', 'true')
-      return to.meta.public ? '/' : to.fullPath
-    } catch {
-      // fallback: continue to login
+    if (!token || to.path === '/login') {
+      try {
+        const { data } = await login({ access_token: 'disabled' })
+        localStorage.setItem('jwt_token', data.access_token)
+        return to.path === '/login' ? '/' : to.fullPath
+      } catch {
+        // sentinel login shouldn't fail; fall through and keep whatever
+        // token we had (if any) so the user isn't blocked entirely.
+      }
     }
+    return
   }
 
+  // Auth enabled: trust whatever token we have. If it was issued under the
+  // wrong auth_mode (cached sentinel JWT) the next API call will 401 and the
+  // response interceptor will clear the token and route back to /login.
+  if (token) return
   if (to.meta.public) return
   return '/login'
 })

--- a/webui/frontend/src/stores/auth.ts
+++ b/webui/frontend/src/stores/auth.ts
@@ -13,8 +13,6 @@ export const useAuthStore = defineStore('auth', () => {
     const response = await authApi.login(data)
     token.value = response.data.access_token
     localStorage.setItem('jwt_token', response.data.access_token)
-    // Clear sentinel marker — this is a genuine user login
-    localStorage.removeItem('jwt_auto_disabled')
   }
 
   async function logout() {
@@ -23,14 +21,12 @@ export const useAuthStore = defineStore('auth', () => {
     } finally {
       token.value = null
       localStorage.removeItem('jwt_token')
-      localStorage.removeItem('jwt_auto_disabled')
     }
   }
 
   function clearAuth() {
     token.value = null
     localStorage.removeItem('jwt_token')
-    localStorage.removeItem('jwt_auto_disabled')
   }
 
   return {

--- a/webui/routes/auth.py
+++ b/webui/routes/auth.py
@@ -11,8 +11,18 @@ from webui.routes.base import RouteDefinition, Routes
 from webui.utils import _create_jwt_token, _verify_jwt_token
 
 
-async def require_auth(authorization: Optional[str] = Header(None)) -> str:
-    """Authenticate requests using JWT Bearer token."""
+async def require_auth(
+    request: Request,
+    authorization: Optional[str] = Header(None),
+) -> str:
+    """Authenticate requests using JWT Bearer token.
+
+    Beyond signature/expiry, also rejects JWTs whose auth_mode claim doesn't
+    match the current server mode — so a sentinel JWT issued under
+    --disable-webui-auth becomes invalid the moment the server restarts with
+    auth enabled (and vice versa). Truth lives in the JWT, not in a client-side
+    marker.
+    """
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -20,6 +30,14 @@ async def require_auth(authorization: Optional[str] = Header(None)) -> str:
         )
     token = authorization.split(" ", 1)[1]
     payload = _verify_jwt_token(token)
+
+    current_mode = "disabled" if getattr(request.app.state, "disable_auth", False) else "enabled"
+    token_mode = payload.get("auth_mode", "enabled")
+    if token_mode != current_mode:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token issued under a different auth mode, please re-login",
+        )
     return payload.get("sub", "admin")
 
 
@@ -154,8 +172,14 @@ class AuthRoutes(Routes):
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid access token",
             )
+        # auth_mode claim lets require_auth reject JWTs issued under the opposite
+        # mode after a restart (e.g. a sentinel JWT cached in localStorage from a
+        # prior --disable-webui-auth run, when auth is now back on).
         access_token = _create_jwt_token(
-            data={"sub": "admin"},
+            data={
+                "sub": "admin",
+                "auth_mode": "disabled" if self.disable_auth else "enabled",
+            },
             expires_delta=timedelta(days=5),
         )
         return LoginResponse(access_token=access_token)


### PR DESCRIPTION
The client-side `jwt_auto_disabled` localStorage flag and `jwt_token` were two parallel state variables that could drift out of sync, causing the `--disable-webui-auth` auto-login to silently fail and force users to type `disabled` by hand whenever a stale token sat in localStorage from a prior session.

Move the source of truth into the JWT itself:

- `/api/auth/login` embeds `auth_mode` ("disabled" | "enabled") in the JWT
- `require_auth` rejects 401 when the JWT's `auth_mode` doesn't match the current server mode (read from `app.state.disable_auth`)
- Router guard drops the marker, simplifies to: in disabled mode always mint a fresh sentinel JWT when there's no token OR when landing on `/login` (covers the Electron-shell-loads-/login direct-load case where no API call would surface a mode mismatch); in enabled mode trust the token and let the 401 interceptor handle stale ones
- Auth store stops writing the now-defunct marker

A sentinel JWT cached from a `--disable-webui-auth` session is now automatically invalidated the moment the server restarts with auth re-enabled (and vice versa), without any client-side bookkeeping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JWT tokens becoming invalid when authentication mode changes between enabled and disabled states. Tokens now include mode information and users will be prompted to re-login if a mode mismatch is detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xxynet/KiraAI/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->