### PR TITLE
feat: optimize disk free calculation

### DIFF
--- a/webui/frontend/src/views/SettingsView.vue
+++ b/webui/frontend/src/views/SettingsView.vue
@@ -66,7 +66,7 @@
               </div>
               <div class="flex justify-between text-sm">
                 <span class="text-gray-500 dark:text-gray-400">{{ $t('settings.storage_disk_free') }}</span>
-                <span class="font-medium text-gray-800 dark:text-gray-200">{{ formatBytes(storageInfo.disk_free_bytes) }}</span>
+                <span class="font-medium text-gray-800 dark:text-gray-200">{{ formatBytes(diskFreeBytes) }}</span>
               </div>
               <!-- Progress bar -->
               <div class="w-full bg-gray-200 dark:bg-gray-600 rounded-full h-3 mt-2">
@@ -480,11 +480,16 @@ const diskUsagePercent = computed(() => {
   return (storageInfo.value.disk_used_bytes / storageInfo.value.disk_total_bytes) * 100
 })
 
+const diskFreeBytes = computed(() => {
+  if (!storageInfo.value) return 0
+  return Math.max(0, storageInfo.value.disk_total_bytes - storageInfo.value.disk_used_bytes)
+})
+
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B'
   const k = 1024
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  const i = Math.max(0, Math.floor(Math.log(bytes) / Math.log(k)))
   return (bytes / Math.pow(k, i)).toFixed(i > 0 ? 2 : 0) + ' ' + sizes[i]
 }
 

--- a/webui/frontend/src/views/SettingsView.vue
+++ b/webui/frontend/src/views/SettingsView.vue
@@ -480,13 +480,17 @@ const diskUsagePercent = computed(() => {
   return (storageInfo.value.disk_used_bytes / storageInfo.value.disk_total_bytes) * 100
 })
 
+// Compute free from total - used instead of using the API's disk_free_bytes
+// (shutil.disk_usage().free). On Linux the OS-reported free can be 0 when ext4
+// reserved blocks fill the remaining space, causing a mismatch with the
+// used/total progress bar. Clamped to 0 to guard against negative deltas.
 const diskFreeBytes = computed(() => {
   if (!storageInfo.value) return 0
   return Math.max(0, storageInfo.value.disk_total_bytes - storageInfo.value.disk_used_bytes)
 })
 
 function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B'
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
   const k = 1024
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
   const i = Math.min(Math.max(0, Math.floor(Math.log(bytes) / Math.log(k))), sizes.length - 1)

--- a/webui/frontend/src/views/SettingsView.vue
+++ b/webui/frontend/src/views/SettingsView.vue
@@ -489,7 +489,7 @@ function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B'
   const k = 1024
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
-  const i = Math.max(0, Math.floor(Math.log(bytes) / Math.log(k)))
+  const i = Math.min(Math.max(0, Math.floor(Math.log(bytes) / Math.log(k))), sizes.length - 1)
   return (bytes / Math.pow(k, i)).toFixed(i > 0 ? 2 : 0) + ' ' + sizes[i]
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected disk free space calculation in Settings so displayed storage no longer goes negative and reflects available space accurately.
  * Prevented negative indexing in byte-size formatting to ensure units (B, KB, MB, etc.) are chosen reliably for all values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xxynet/KiraAI/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->