### PR TITLE
feat: implement custom extra paths for file operations

### DIFF
--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -50,6 +50,9 @@ class FilePlugin(BasePlugin):
     def _is_path_allowed(self, path: str, allowed_prefixes: tuple) -> bool:
         """Check if path starts with an allowed prefix directory."""
         for prefix in allowed_prefixes:
+            prefix = self._normalize_path(prefix)
+            if prefix is None:
+                continue
             prefix = prefix.rstrip('/')
             if path == prefix or path.startswith(prefix + '/'):
                 return True

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 
 from pathlib import Path
 
@@ -52,6 +53,14 @@ class FilePlugin(BasePlugin):
             return get_data_path() / path.removeprefix("data/")
         return Path(path)
 
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        normalized = path.replace("\\", "/")
+        normalized = posixpath.normpath(normalized)
+        if normalized.startswith("../") or normalized == "..":
+            return None
+        return normalized
+
     @register.tool(
         "read_file",
         "Read a plain text file (txt, html, py, etc..) in allowed read paths",
@@ -69,12 +78,13 @@ class FilePlugin(BasePlugin):
         if event.sid not in self.allowed_sessions:
             return "Permission denied: current session not allowed to access local files"
 
+        path = self._normalize_path(path)
+        if path is None:
+            return "Permission denied: Path traversal detected"
+
         for rp in restricted_paths:
             if rp in path:
                 return "Permission denied: Path contains restricted keywords"
-
-        if "../" in path:
-            return "Permission denied: Path traversal detected"
 
         if not path.startswith(self.allowed_read_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_read_paths)}"
@@ -120,12 +130,13 @@ class FilePlugin(BasePlugin):
         if event.sid not in self.allowed_sessions:
             return "Permission denied: current session not allowed to access local files"
 
+        path = self._normalize_path(path)
+        if path is None:
+            return "Permission denied: Path traversal detected"
+
         for rp in restricted_paths:
             if rp in path:
                 return "Permission denied: Path contains restricted keywords"
-
-        if "../" in path:
-            return "Permission denied: Path traversal detected"
 
         if not path.startswith(self.allowed_write_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_write_paths)}"
@@ -160,12 +171,13 @@ class FilePlugin(BasePlugin):
         if event.sid not in self.allowed_sessions:
             return "Permission denied: current session not allowed to access local files"
 
+        path = self._normalize_path(path)
+        if path is None:
+            return "Permission denied: Path traversal detected"
+
         for rp in restricted_paths:
             if rp in path:
                 return "Permission denied: Path contains restricted keywords"
-
-        if "../" in path:
-            return "Permission denied: Path traversal detected"
 
         if not path.startswith(self.allowed_write_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_write_paths)}"
@@ -214,12 +226,13 @@ class FilePlugin(BasePlugin):
         if event.sid not in self.allowed_sessions:
             return "Permission denied: current session not allowed to access local files"
 
+        path = self._normalize_path(path)
+        if path is None:
+            return "Permission denied: Path traversal detected"
+
         for rp in restricted_paths:
             if rp in path:
                 return "Permission denied: Path contains restricted keywords"
-
-        if "../" in path:
-            return "Permission denied: Path traversal detected"
 
         if not path.startswith(self.allowed_read_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_read_paths)}"

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -37,8 +37,9 @@ class FilePlugin(BasePlugin):
         self.exec_deny_list = self.plugin_cfg.get("exec_deny_list", [])
         base_read = ["data/files", "data/temp", "data/skills"]
         base_write = ["data/files", "data/temp"]
-        extra_read = self.plugin_cfg.get("extra_read_paths", [])
-        extra_write = self.plugin_cfg.get("extra_write_paths", [])
+        extra_paths_cfg = self.plugin_cfg.get("extra_paths", {})
+        extra_read = extra_paths_cfg.get("extra_read_paths", [])
+        extra_write = extra_paths_cfg.get("extra_write_paths", [])
         self.allowed_read_paths = tuple(base_read + extra_read)
         self.allowed_write_paths = tuple(base_write + extra_write)
     

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -58,7 +58,7 @@ class FilePlugin(BasePlugin):
         {
             "type": "object",
             "properties": {
-                "path": {"type": "string", "description": "File path, must start with `data/`"},
+                "path": {"type": "string", "description": "File path, must start with an allowed path prefix"},
                 "offset": {"type": "integer", "description": "Which line to start reading, defaults to 1"},
                 "limit": {"type": "integer", "description": "Maximum lines to read, defaults to 200"},
             },
@@ -110,7 +110,7 @@ class FilePlugin(BasePlugin):
         {
             "type": "object",
             "properties": {
-                "path": {"type": "string", "description": "File path, must start with `data/`"},
+                "path": {"type": "string", "description": "File path, must start with an allowed path prefix"},
                 "content": {"type": "string", "description": "Content to write to the file"},
             },
             "required": ["path", "content"]
@@ -148,7 +148,7 @@ class FilePlugin(BasePlugin):
         {
             "type": "object",
             "properties": {
-                "path": {"type": "string", "description": "File path, must start with `data/`"},
+                "path": {"type": "string", "description": "File path, must start with an allowed path prefix"},
                 "old_text": {"type": "string",
                              "description": "Exact text to find and replace (must match exactly, including whitespace)"},
                 "new_text": {"type": "string", "description": "New text to replace the old text with"},
@@ -203,7 +203,7 @@ class FilePlugin(BasePlugin):
         {
             "type": "object",
             "properties": {
-                "path": {"type": "string", "description": "Directory path, must start with `data/`"},
+                "path": {"type": "string", "description": "Directory path, must start with an allowed path prefix"},
                 "offset": {"type": "integer", "description": "Which index to start displaying file or folder name, defaults to 1"},
                 "limit": {"type": "integer", "description": "Maximum file count to display, defaults to 20"},
             },

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -28,18 +28,32 @@ class FilePlugin(BasePlugin):
         self.allowed_sessions = list()
         self.allowed_exec_sessions = list()
         self.exec_deny_list = list()
-    
+        self.allowed_read_paths = tuple()
+        self.allowed_write_paths = tuple()
+
     async def initialize(self):
         self.allowed_sessions = self.plugin_cfg.get("allowed_sessions", [])
         self.allowed_exec_sessions = self.plugin_cfg.get("allowed_exec_sessions", [])
         self.exec_deny_list = self.plugin_cfg.get("exec_deny_list", [])
+        base_read = ["data/files", "data/temp", "data/skills"]
+        base_write = ["data/files", "data/temp"]
+        extra_read = self.plugin_cfg.get("extra_read_paths", [])
+        extra_write = self.plugin_cfg.get("extra_write_paths", [])
+        self.allowed_read_paths = tuple(base_read + extra_read)
+        self.allowed_write_paths = tuple(base_write + extra_write)
     
     async def terminate(self):
         pass
 
+    @staticmethod
+    def _resolve_path(path: str) -> Path:
+        if path.startswith("data/"):
+            return get_data_path() / path.removeprefix("data/")
+        return Path(path)
+
     @register.tool(
         "read_file",
-        "Read a plain text file (txt, html, py, etc..) in `data/files` `data/temp` or `data/skills`",
+        "Read a plain text file (txt, html, py, etc..) in allowed read paths",
         {
             "type": "object",
             "properties": {
@@ -61,15 +75,15 @@ class FilePlugin(BasePlugin):
         if "../" in path:
             return "Permission denied: Path traversal detected"
 
-        if not path.startswith(("data/files", "data/temp", "data/skills")):
-            return "Permission denied: Path must start with data/files, data/temp or data/skills"
+        if not path.startswith(self.allowed_read_paths):
+            return f"Permission denied: Path must start with one of: {', '.join(self.allowed_read_paths)}"
 
         ext = Path(path).suffix.lower()
         if ext in blocked_extensions:
             return "Multimedia and binary files are not allowed"
 
         try:
-            abs_path = get_data_path() / path.removeprefix("data/")
+            abs_path = self._resolve_path(path)
             with open(abs_path, 'r', encoding="utf-8") as f:
                 file_lines = f.readlines()
             if offset > len(file_lines) or offset < 1:
@@ -91,7 +105,7 @@ class FilePlugin(BasePlugin):
 
     @register.tool(
         "write_file",
-        "Write content to a plain text file in `data/files` or `data/temp`. Creates the file if it doesn't exist, overwrites if it does.",
+        "Write content to a plain text file in allowed write paths. Creates the file if it doesn't exist, overwrites if it does.",
         {
             "type": "object",
             "properties": {
@@ -112,15 +126,15 @@ class FilePlugin(BasePlugin):
         if "../" in path:
             return "Permission denied: Path traversal detected"
 
-        if not path.startswith(("data/files", "data/temp")):
-            return "Permission denied: Path must start with data/files or data/temp"
+        if not path.startswith(self.allowed_write_paths):
+            return f"Permission denied: Path must start with one of: {', '.join(self.allowed_write_paths)}"
 
         ext = Path(path).suffix.lower()
         if ext in blocked_extensions:
             return "Multimedia and binary files are not allowed"
 
         try:
-            abs_path = get_data_path() / path.removeprefix("data/")
+            abs_path = self._resolve_path(path)
             with open(abs_path, 'w', encoding="utf-8") as f:
                 f.write(content)
             return "File written successfully"
@@ -152,15 +166,15 @@ class FilePlugin(BasePlugin):
         if "../" in path:
             return "Permission denied: Path traversal detected"
 
-        if not path.startswith(("data/files", "data/temp")):
-            return "Permission denied: Path must start with data/files or data/temp"
+        if not path.startswith(self.allowed_write_paths):
+            return f"Permission denied: Path must start with one of: {', '.join(self.allowed_write_paths)}"
 
         ext = Path(path).suffix.lower()
         if ext in blocked_extensions:
             return "Permission denied: Multimedia and binary files are not allowed"
 
         try:
-            abs_path = get_data_path() / path.removeprefix("data/")
+            abs_path = self._resolve_path(path)
 
             with open(abs_path, 'r', encoding="utf-8") as f:
                 content = f.read()
@@ -184,7 +198,7 @@ class FilePlugin(BasePlugin):
 
     @register.tool(
         "list_files",
-        "List files in a specified directory, could be `data/files` `data/temp` `data/skills` or their sub directories",
+        "List files in a specified directory within allowed read paths",
         {
             "type": "object",
             "properties": {
@@ -206,11 +220,11 @@ class FilePlugin(BasePlugin):
         if "../" in path:
             return "Permission denied: Path traversal detected"
 
-        if not path.startswith(("data/files", "data/temp", "data/skills")):
-            return "Permission denied: Path must start with data/files, data/temp or data/skills"
+        if not path.startswith(self.allowed_read_paths):
+            return f"Permission denied: Path must start with one of: {', '.join(self.allowed_read_paths)}"
 
         try:
-            abs_path = get_data_path() / path.removeprefix("data/")
+            abs_path = self._resolve_path(path)
 
             files = sorted(os.listdir(abs_path))
 

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -47,6 +47,14 @@ class FilePlugin(BasePlugin):
     async def terminate(self):
         pass
 
+    def _is_path_allowed(self, path: str, allowed_prefixes: tuple) -> bool:
+        """Check if path starts with an allowed prefix directory."""
+        for prefix in allowed_prefixes:
+            prefix = prefix.rstrip('/')
+            if path == prefix or path.startswith(prefix + '/'):
+                return True
+        return False
+
     @staticmethod
     def _resolve_path(path: str) -> Path:
         if path.startswith("data/"):
@@ -86,7 +94,7 @@ class FilePlugin(BasePlugin):
             if rp in path:
                 return "Permission denied: Path contains restricted keywords"
 
-        if not path.startswith(self.allowed_read_paths):
+        if not self._is_path_allowed(path, self.allowed_read_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_read_paths)}"
 
         ext = Path(path).suffix.lower()
@@ -138,7 +146,7 @@ class FilePlugin(BasePlugin):
             if rp in path:
                 return "Permission denied: Path contains restricted keywords"
 
-        if not path.startswith(self.allowed_write_paths):
+        if not self._is_path_allowed(path, self.allowed_write_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_write_paths)}"
 
         ext = Path(path).suffix.lower()
@@ -179,7 +187,7 @@ class FilePlugin(BasePlugin):
             if rp in path:
                 return "Permission denied: Path contains restricted keywords"
 
-        if not path.startswith(self.allowed_write_paths):
+        if not self._is_path_allowed(path, self.allowed_write_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_write_paths)}"
 
         ext = Path(path).suffix.lower()
@@ -234,7 +242,7 @@ class FilePlugin(BasePlugin):
             if rp in path:
                 return "Permission denied: Path contains restricted keywords"
 
-        if not path.startswith(self.allowed_read_paths):
+        if not self._is_path_allowed(path, self.allowed_read_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_read_paths)}"
 
         try:

--- a/core/plugin/builtin_plugins/file/schema.json
+++ b/core/plugin/builtin_plugins/file/schema.json
@@ -25,5 +25,23 @@
     "locales": {
       "zh": { "name": "命令黑名单", "hint": "禁止执行的命令列表" }
     }
+  },
+  "extra_read_paths": {
+    "name": "Extra Read Paths",
+    "type": "list",
+    "default": [],
+    "hint": "Additional allowed path prefixes for read_file and list_files (data/files, data/temp and data/skills are always allowed)",
+    "locales": {
+      "zh": { "name": "额外允许读取的路径", "hint": "read_file 和 list_files 额外允许的路径前缀（data/files、data/temp 和 data/skills 始终允许）" }
+    }
+  },
+  "extra_write_paths": {
+    "name": "Extra Write Paths",
+    "type": "list",
+    "default": [],
+    "hint": "Additional allowed path prefixes for write_file and edit_file",
+    "locales": {
+      "zh": { "name": "额外允许写入的路径", "hint": "write_file 和 edit_file 额外允许的路径前缀" }
+    }
   }
 }

--- a/core/plugin/builtin_plugins/file/schema.json
+++ b/core/plugin/builtin_plugins/file/schema.json
@@ -26,22 +26,33 @@
       "zh": { "name": "命令黑名单", "hint": "禁止执行的命令列表" }
     }
   },
-  "extra_read_paths": {
-    "name": "Extra Read Paths",
-    "type": "list",
-    "default": [],
-    "hint": "Additional allowed path prefixes for read_file and list_files (data/files, data/temp and data/skills are always allowed)",
+  "extra_paths": {
+    "type": "section",
+    "name": "Extra Allowed Paths",
+    "hint": "Configure additional allowed path prefixes",
+    "collapsed": true,
     "locales": {
-      "zh": { "name": "额外允许读取的路径", "hint": "read_file 和 list_files 额外允许的路径前缀（data/files、data/temp 和 data/skills 始终允许）" }
-    }
-  },
-  "extra_write_paths": {
-    "name": "Extra Write Paths",
-    "type": "list",
-    "default": [],
-    "hint": "Additional allowed path prefixes for write_file and edit_file",
-    "locales": {
-      "zh": { "name": "额外允许写入的路径", "hint": "write_file 和 edit_file 额外允许的路径前缀" }
+      "zh": { "name": "额外允许的路径", "hint": "配置额外允许的路径前缀" }
+    },
+    "fields": {
+      "extra_read_paths": {
+        "name": "Extra Read Paths",
+        "type": "list",
+        "default": [],
+        "hint": "Additional allowed path prefixes for read_file and list_files",
+        "locales": {
+          "zh": { "name": "额外允许读取的路径", "hint": "read_file 和 list_files 额外允许的路径前缀" }
+        }
+      },
+      "extra_write_paths": {
+        "name": "Extra Write Paths",
+        "type": "list",
+        "default": [],
+        "hint": "Additional allowed path prefixes for write_file and edit_file",
+        "locales": {
+          "zh": { "name": "额外允许写入的路径", "hint": "write_file 和 edit_file 额外允许的路径前缀" }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Resolves #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File operations can now be extended with configurable extra read/write path prefixes.

* **Bug Fixes**
  * Incoming paths are normalized; directory-traversal attempts and restricted keywords are blocked.
  * Permission checks consistently enforce allowed path prefixes; denial messages now enumerate configured allowed prefixes.

* **Documentation**
  * File-operation descriptions and permission messages updated to explain allowed-path prefix behavior and configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xxynet/KiraAI/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->