### PR TITLE
feat(provider): add extra_body and move temperature into model advanced settings

### DIFF
--- a/core/provider/src/deepseek/model_clients.py
+++ b/core/provider/src/deepseek/model_clients.py
@@ -37,6 +37,8 @@ class DeepSeekLLMClient(LLMModelClient):
         model_config = self.model.model_config or {}
         thinking_enabled = model_config.get("thinking_enabled", True)
         reasoning_effort = model_config.get("reasoning_effort", "high")
+        section_advanced = model_config.get("section_advanced") or {}
+        user_extra_body = section_advanced.get("extra_body")
 
         # Build extra_body for DeepSeek thinking mode
         extra_body = {}
@@ -44,6 +46,10 @@ class DeepSeekLLMClient(LLMModelClient):
             extra_body["thinking"] = {"type": "enabled"}
         else:
             extra_body["thinking"] = {"type": "disabled"}
+
+        # Merge user-provided extra_body
+        if isinstance(user_extra_body, dict) and user_extra_body:
+            extra_body.update(user_extra_body)
 
         # Build request kwargs
         request_kwargs = dict(
@@ -58,7 +64,7 @@ class DeepSeekLLMClient(LLMModelClient):
             request_kwargs["reasoning_effort"] = reasoning_effort
         else:
             # Non-thinking mode: use normal temperature
-            temperature = model_config.get("temperature")
+            temperature = section_advanced.get("temperature")
             request_kwargs["temperature"] = temperature if temperature is not None else 1
 
         if extra_body:

--- a/core/provider/src/deepseek/schema.json
+++ b/core/provider/src/deepseek/schema.json
@@ -51,17 +51,6 @@
           "en": { "name": "Timeout", "hint": "Timeout seconds" }
         }
       },
-      "temperature": {
-        "name": "温度",
-        "type": "float",
-        "default": null,
-        "min": 0,
-        "max": 2,
-        "hint": "模型温度（注意：思考模式下此参数不生效）",
-        "locales": {
-          "en": { "name": "Temperature", "hint": "Model temperature (Note: this parameter does not apply in thinking mode)" }
-        }
-      },
       "thinking_enabled": {
         "name": "思考模式",
         "type": "switch",
@@ -79,6 +68,37 @@
         "hint": "思考强度：high（默认）或 max（复杂 Agent 任务推荐）",
         "locales": {
           "en": { "name": "Reasoning Effort", "hint": "Reasoning intensity: high (default) or max (recommended for complex Agent tasks)" }
+        }
+      },
+      "section_advanced": {
+        "type": "section",
+        "name": "高级设置",
+        "hint": "高级模型配置选项",
+        "collapsed": true,
+        "locales": {
+          "en": { "name": "Advanced Settings", "hint": "Advanced model configuration options" }
+        },
+        "fields": {
+          "temperature": {
+            "name": "温度",
+            "type": "float",
+            "default": null,
+            "min": 0,
+            "max": 2,
+            "hint": "模型温度（注意：思考模式下此参数不生效）",
+            "locales": {
+              "en": { "name": "Temperature", "hint": "Model temperature (Note: this parameter does not apply in thinking mode)" }
+            }
+          },
+          "extra_body": {
+            "name": "自定义请求体",
+            "type": "json",
+            "default": {},
+            "hint": "合并到请求体中的额外字段（JSON 对象）",
+            "locales": {
+              "en": { "name": "Extra Body", "hint": "Additional fields merged into the request body (JSON object)" }
+            }
+          }
         }
       }
     }

--- a/core/provider/src/modelscope/schema.json
+++ b/core/provider/src/modelscope/schema.json
@@ -31,15 +31,35 @@
           "en": { "name": "Timeout", "hint": "Timeout seconds" }
         }
       },
-      "temperature": {
-        "name": "温度",
-        "type": "float",
-        "default": null,
-        "min": 0,
-        "max": 2,
-        "hint": "模型温度",
+      "section_advanced": {
+        "type": "section",
+        "name": "高级设置",
+        "hint": "高级模型配置选项",
+        "collapsed": true,
         "locales": {
-          "en": { "name": "Temperature", "hint": "Model temperature" }
+          "en": { "name": "Advanced Settings", "hint": "Advanced model configuration options" }
+        },
+        "fields": {
+          "temperature": {
+            "name": "温度",
+            "type": "float",
+            "default": null,
+            "min": 0,
+            "max": 2,
+            "hint": "模型温度",
+            "locales": {
+              "en": { "name": "Temperature", "hint": "Model temperature" }
+            }
+          },
+          "extra_body": {
+            "name": "自定义请求体",
+            "type": "json",
+            "default": {},
+            "hint": "合并到请求体中的额外字段（JSON 对象）",
+            "locales": {
+              "en": { "name": "Extra Body", "hint": "Additional fields merged into the request body (JSON object)" }
+            }
+          }
         }
       }
     },

--- a/core/provider/src/openai/schema.json
+++ b/core/provider/src/openai/schema.json
@@ -51,15 +51,35 @@
           "zh": { "name": "超时", "hint": "超时秒数" }
         }
       },
-      "temperature": {
-        "name": "Temperature",
-        "type": "float",
-        "default": null,
-        "min": 0,
-        "max": 2,
-        "hint": "Model temperature",
+      "section_advanced": {
+        "type": "section",
+        "name": "Advanced Settings",
+        "hint": "Advanced model configuration options",
+        "collapsed": true,
         "locales": {
-          "zh": { "name": "温度", "hint": "模型温度" }
+          "zh": { "name": "高级设置", "hint": "高级模型配置选项" }
+        },
+        "fields": {
+          "temperature": {
+            "name": "Temperature",
+            "type": "float",
+            "default": null,
+            "min": 0,
+            "max": 2,
+            "hint": "Model temperature",
+            "locales": {
+              "zh": { "name": "温度", "hint": "模型温度" }
+            }
+          },
+          "extra_body": {
+            "name": "Extra Body",
+            "type": "json",
+            "default": {},
+            "hint": "Additional fields merged into the request body (JSON object)",
+            "locales": {
+              "zh": { "name": "自定义请求体", "hint": "合并到请求体中的额外字段（JSON 对象）" }
+            }
+          }
         }
       }
     },

--- a/core/provider/src/siliconflow_cn/schema.json
+++ b/core/provider/src/siliconflow_cn/schema.json
@@ -31,15 +31,35 @@
           "en": { "name": "Timeout", "hint": "Timeout seconds" }
         }
       },
-      "temperature": {
-        "name": "温度",
-        "type": "float",
-        "default": null,
-        "min": 0,
-        "max": 2,
-        "hint": "模型温度",
+      "section_advanced": {
+        "type": "section",
+        "name": "高级设置",
+        "hint": "高级模型配置选项",
+        "collapsed": true,
         "locales": {
-          "en": { "name": "Temperature", "hint": "Model temperature" }
+          "en": { "name": "Advanced Settings", "hint": "Advanced model configuration options" }
+        },
+        "fields": {
+          "temperature": {
+            "name": "温度",
+            "type": "float",
+            "default": null,
+            "min": 0,
+            "max": 2,
+            "hint": "模型温度",
+            "locales": {
+              "en": { "name": "Temperature", "hint": "Model temperature" }
+            }
+          },
+          "extra_body": {
+            "name": "自定义请求体",
+            "type": "json",
+            "default": {},
+            "hint": "合并到请求体中的额外字段（JSON 对象）",
+            "locales": {
+              "en": { "name": "Extra Body", "hint": "Additional fields merged into the request body (JSON object)" }
+            }
+          }
         }
       }
     },

--- a/core/provider/src/volcengine/schema.json
+++ b/core/provider/src/volcengine/schema.json
@@ -31,15 +31,35 @@
           "en": { "name": "Timeout", "hint": "Timeout seconds" }
         }
       },
-      "temperature": {
-        "name": "温度",
-        "type": "float",
-        "default": null,
-        "min": 0,
-        "max": 2,
-        "hint": "模型温度",
+      "section_advanced": {
+        "type": "section",
+        "name": "高级设置",
+        "hint": "高级模型配置选项",
+        "collapsed": true,
         "locales": {
-          "en": { "name": "Temperature", "hint": "Model temperature" }
+          "en": { "name": "Advanced Settings", "hint": "Advanced model configuration options" }
+        },
+        "fields": {
+          "temperature": {
+            "name": "温度",
+            "type": "float",
+            "default": null,
+            "min": 0,
+            "max": 2,
+            "hint": "模型温度",
+            "locales": {
+              "en": { "name": "Temperature", "hint": "Model temperature" }
+            }
+          },
+          "extra_body": {
+            "name": "自定义请求体",
+            "type": "json",
+            "default": {},
+            "hint": "合并到请求体中的额外字段（JSON 对象）",
+            "locales": {
+              "en": { "name": "Extra Body", "hint": "Additional fields merged into the request body (JSON object)" }
+            }
+          }
         }
       }
     },

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -24,9 +24,14 @@ class OpenAICompatibleLLMClient(LLMModelClient):
         )
         try:
             start_time = time.perf_counter()
-            temperature = self.model.model_config.get("temperature") if self.model.model_config else None
-            timeout = self.model.model_config.get("timeout") if self.model.model_config else None
-            response = await client.chat.completions.create(
+            model_config = self.model.model_config if self.model.model_config else {}
+            section_advanced = model_config.get("section_advanced") or {}
+            temperature = section_advanced.get("temperature")
+            timeout = model_config.get("timeout")
+            extra_body = section_advanced.get("extra_body")
+            if not isinstance(extra_body, dict) or not extra_body:
+                extra_body = None
+            request_kwargs = dict(
                 model=self.model.model_id,
                 messages=request.messages,
                 tools=request.tools if request.tools else None,
@@ -34,6 +39,9 @@ class OpenAICompatibleLLMClient(LLMModelClient):
                 temperature=temperature if temperature is not None else NOT_GIVEN,
                 timeout=timeout if timeout is not None else NOT_GIVEN
             )
+            if extra_body:
+                request_kwargs["extra_body"] = extra_body
+            response = await client.chat.completions.create(**request_kwargs)
             end_time = time.perf_counter()
             llm_resp = LLMResponse("")
             llm_resp.time_consumed = round(end_time - start_time, 2)


### PR DESCRIPTION
## Summary

Add a collapsible `section_advanced` (Advanced Settings) to LLM model config across all providers. Move `temperature` into it and introduce a new `extra_body` (JSON) field that lets users inject custom parameters into LLM request bodies.

## Type of change

- [x] feat: New feature

## Changes

- Add `section_advanced` collapsible section under `model_config.llm` for all 5 providers (OpenAI, DeepSeek, ModelScope, Volcengine, SiliconFlow)
- Move `temperature` from top-level into `section_advanced`
- Add `extra_body` (json type) field for merging custom fields into the request body
- Update `OpenAICompatibleLLMClient` to read `temperature` and `extra_body` from `section_advanced` and forward them to the API
- Update `DeepSeekLLMClient` to merge user `extra_body` with thinking mode `extra_body`
- Keep DeepSeek `thinking_enabled` / `reasoning_effort` at top level (not collapsed)
- Add zh/en i18n for all new fields and section labels

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `extra_body` configuration option across DeepSeek, ModelScope, OpenAI, SiliconFlow, and VolcEngine providers, enabling users to provide custom request parameters.

* **Improvements**
  * Reorganized model configuration UI across all supported providers: temperature and new extra_body fields are now grouped under a collapsible "Advanced Settings" section for improved interface clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xxynet/KiraAI/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->