### PR TITLE
refactor(agent): Replace raw dict messages with OpenAIMessage BaseModel and remove NewMemory

### DIFF
--- a/core/agent/agent_executor.py
+++ b/core/agent/agent_executor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Optional, TYPE_CHECKING, Union, Literal
+from dataclasses import dataclass
+from typing import AsyncIterator, Optional, TYPE_CHECKING, Literal
 
 from openai import APIStatusError, APITimeoutError, APIConnectionError
 
@@ -9,6 +9,7 @@ from core.logging_manager import get_logger
 from core.llm_client import LLMClient
 from core.provider import LLMRequest, LLMResponse, LLMModelClient
 from core.agent.tool import ToolSet
+from core.agent.message import OpenAIMessage
 from core.plugin.plugin_handlers import event_handler_reg, EventType
 
 if TYPE_CHECKING:
@@ -23,7 +24,7 @@ llm_logger = get_logger("llm", "purple")
 class AgentExecutionContext:
     event: KiraMessageBatchEvent
     request: LLMRequest
-    new_memory: NewMemory
+    new_messages: list[OpenAIMessage]
     model_group: list[LLMModelClient]
 
 
@@ -32,52 +33,10 @@ class AgentStepResult:
     state: Literal["success", "stopped", "error"]
     step_index: int
     llm_response: Optional[LLMResponse]
-    new_memory: NewMemory
+    new_messages: list[OpenAIMessage]
     is_final: bool
     has_tool_calls: bool
     err: Optional[str] = None
-
-
-@dataclass
-class NewMemory:
-    memory_list: list = field(default_factory=list)
-
-    def user(self, content: Union[str, dict]):
-        self.memory_list.append(
-            {
-                "role": "user",
-                "content": content
-            }
-        )
-
-    # Add reasoning_content param, defaults to blank string，to satisfy the requirements of Kimi API
-    def assistant(self, content: str, tool_calls: Optional[list[dict]] = None, reasoning_content: str = ""):
-        if not tool_calls:
-            self.memory_list.append(
-                {
-                    "role": "assistant",
-                    "content": content,
-                    "reasoning_content": reasoning_content
-                }
-            )
-        else:
-            self.memory_list.append(
-                {
-                    "role": "assistant",
-                    "content": content,
-                    "tool_calls": tool_calls,
-                    "reasoning_content": reasoning_content
-                }
-            )
-
-    def tool(self, tool_results: list[dict]):
-        self.memory_list.extend(tool_results)
-        # self.memory_list.append({
-        #     "role": "tool",
-        #     "tool_call_id": tool_call_id,
-        #     "name": name,
-        #     "content": str(result)
-        # })
 
 
 class AgentExecutor:
@@ -115,10 +74,10 @@ class AgentExecutor:
 
             # Inject last-step hint so the LLM knows to wrap up
             if is_final:
-                request.messages.append({
-                    "role": "system",
-                    "content": "⚠️ This is your last response opportunity in this turn. There will be no more conversation turns after this. If you need to communicate anything to the user, output it directly in this response. If you choose to end silently (<msg/>), no output is needed."
-                })
+                request.messages.append(OpenAIMessage(
+                    role="system",
+                    content="⚠️ This is your last response opportunity in this turn. There will be no more conversation turns after this. If you need to communicate anything to the user, output it directly in this response. If you choose to end silently (<msg/>), no output is needed."
+                ))
 
             # Try models in order, failover to next on provider/API errors.
             # Only catch provider-level exceptions (network, timeout, API status).
@@ -168,7 +127,7 @@ class AgentExecutor:
                         state="stopped",
                         step_index=step_index,
                         llm_response=llm_resp,
-                        new_memory=ctx.new_memory,
+                        new_messages=ctx.new_messages,
                         is_final=is_final,
                         has_tool_calls=has_tool_calls,
                     )
@@ -178,21 +137,19 @@ class AgentExecutor:
                 is_final = True
                 assistant_content = llm_resp.text_response or ""
                 reasoning = llm_resp.reasoning_content or ""
-                # Add reasoning_content
-                request.messages.append(
-                    {
-                        "role": "assistant",
-                        "content": assistant_content,
-                        "reasoning_content": reasoning
-                    }
+                msg = OpenAIMessage(
+                    role="assistant",
+                    content=assistant_content,
+                    reasoning_content=reasoning
                 )
-                ctx.new_memory.assistant(assistant_content, reasoning_content=reasoning)
+                request.messages.append(msg)
+                ctx.new_messages.append(msg)
                 yield AgentStepResult(
                     state=state,
                     err=err,
                     step_index=step_index,
                     llm_response=llm_resp,
-                    new_memory=ctx.new_memory,
+                    new_messages=ctx.new_messages,
                     is_final=is_final,
                     has_tool_calls=has_tool_calls,
                 )
@@ -202,25 +159,24 @@ class AgentExecutor:
             reasoning = llm_resp.reasoning_content or ""
 
             await self.llm_api.execute_tool(event, llm_resp, tool_set=self.tool_set)
-            # Add reasoning_content
-            request.messages.append(
-                {
-                    "role": "assistant",
-                    "content": assistant_content,
-                    "tool_calls": llm_resp.tool_calls,
-                    "reasoning_content": reasoning
-                }
+            msg = OpenAIMessage(
+                role="assistant",
+                content=assistant_content,
+                tool_calls=llm_resp.tool_calls,
+                reasoning_content=reasoning
             )
-            ctx.new_memory.assistant(assistant_content, llm_resp.tool_calls, reasoning_content=reasoning)
-            request.messages.extend(llm_resp.tool_results)
-            ctx.new_memory.tool(llm_resp.tool_results)
+            request.messages.append(msg)
+            ctx.new_messages.append(msg)
+            tool_msgs = [OpenAIMessage(**r) for r in llm_resp.tool_results]
+            request.messages.extend(tool_msgs)
+            ctx.new_messages.extend(tool_msgs)
 
             yield AgentStepResult(
                 state=state,
                 err=err,
                 step_index=step_index,
                 llm_response=llm_resp,
-                new_memory=ctx.new_memory,
+                new_messages=ctx.new_messages,
                 is_final=is_final,
                 has_tool_calls=has_tool_calls,
             )

--- a/core/agent/message.py
+++ b/core/agent/message.py
@@ -29,7 +29,10 @@ class OpenAIMessage(BaseModel):
         return d
 
     def __getitem__(self, key: str):
-        return getattr(self, key)
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
 
     def __setitem__(self, key: str, value):
         setattr(self, key, value)

--- a/core/agent/message.py
+++ b/core/agent/message.py
@@ -4,7 +4,7 @@ from typing import Literal, Union, Optional
 
 class OpenAIMessage(BaseModel):
     role: Literal["system", "user", "assistant", "tool"]
-    content: Union[str, dict]
+    content: Union[str, list, dict, None] = None
 
     # assistant
     reasoning_content: Optional[str] = ""
@@ -15,3 +15,21 @@ class OpenAIMessage(BaseModel):
     tool_call_id: Optional[str] = None
 
     name: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        d = {"role": self.role, "content": self.content}
+        if self.reasoning_content:
+            d["reasoning_content"] = self.reasoning_content
+        if self.tool_calls:
+            d["tool_calls"] = self.tool_calls
+        if self.tool_call_id:
+            d["tool_call_id"] = self.tool_call_id
+        if self.name:
+            d["name"] = self.name
+        return d
+
+    def __getitem__(self, key: str):
+        return getattr(self, key)
+
+    def __setitem__(self, key: str, value):
+        setattr(self, key, value)

--- a/core/chat/session_manager.py
+++ b/core/chat/session_manager.py
@@ -174,8 +174,7 @@ class SessionManager:
     def update_memory(self, session: str, new_chunk):
         self._ensure_session_data(session)
         from core.agent.message import OpenAIMessage
-        if new_chunk and isinstance(new_chunk[0], OpenAIMessage):
-            new_chunk = [m.to_dict() for m in new_chunk]
+        new_chunk = [m.to_dict() if isinstance(m, OpenAIMessage) else m for m in new_chunk]
         with self.memory_lock:
             session_data = self.chat_memory[session]
 

--- a/core/chat/session_manager.py
+++ b/core/chat/session_manager.py
@@ -173,6 +173,9 @@ class SessionManager:
 
     def update_memory(self, session: str, new_chunk):
         self._ensure_session_data(session)
+        from core.agent.message import OpenAIMessage
+        if new_chunk and isinstance(new_chunk[0], OpenAIMessage):
+            new_chunk = [m.to_dict() for m in new_chunk]
         with self.memory_lock:
             session_data = self.chat_memory[session]
 

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -40,7 +40,8 @@ from .adapter import AdapterManager
 from .agent.skills_mgr import SkillsManager
 from .provider import ProviderManager, LLMRequest, LLMResponse
 from core.plugin.plugin_handlers import event_handler_reg, EventType
-from core.agent.agent_executor import AgentExecutor, AgentExecutionContext, NewMemory
+from core.agent.agent_executor import AgentExecutor, AgentExecutionContext
+from core.agent.message import OpenAIMessage
 from core.agent.tool import ToolSet
 from core.tag import tag_registry, TagSet
 from core.db.service import DatabaseService
@@ -512,9 +513,10 @@ class MessageProcessor:
         user_message = "".join(p.to_string() for p in request.user_prompt if isinstance(p, Prompt))
         logger.info(f"processing message(s) from {sid}:\n{user_message}")
 
-        # 把收到的消息放到新收到的消息内容中
-        new_memory = NewMemory()
-        new_memory.user(user_message)
+        # 把收到的消息放到新收到的消息内容中（仅持久化 persist=True 的 Prompt）
+        persist_message = "".join(p.to_string() for p in request.user_prompt if isinstance(p, Prompt) and p.persist)
+        new_messages: list[OpenAIMessage] = []
+        new_messages.append(OpenAIMessage(role="user", content=persist_message))
 
         # Get max tool loop config, defaults to 2 if not a valid integer
         # Note: This variable represents the total agent loop iterations (not just tool calls),
@@ -531,7 +533,7 @@ class MessageProcessor:
         agent_ctx = AgentExecutionContext(
             event=event,
             request=request,
-            new_memory=new_memory,
+            new_messages=new_messages,
             model_group=model_group,
         )
 
@@ -554,10 +556,10 @@ class MessageProcessor:
                 logger.info(f"LLM -> {sid}: {step_result.raw_output}")
                 llm_resp.text_response = step_result.raw_output
 
-                for idx in range(-1, -len(new_memory.memory_list), -1):
-                    if new_memory.memory_list[idx]["role"] == "assistant":
-                        new_memory.memory_list[idx]["content"] = step_result.raw_output
-                        request.messages[idx]["content"] = step_result.raw_output
+                for idx in range(-1, -len(new_messages), -1):
+                    if new_messages[idx].role == "assistant":
+                        new_messages[idx].content = step_result.raw_output
+                        request.messages[idx].content = step_result.raw_output
                         break
 
         # Iter agent executor to get LLMResponse
@@ -576,7 +578,7 @@ class MessageProcessor:
             # Process tool calls if existed
 
         # Save new memory
-        self.session_manager.update_memory(sid, new_memory.memory_list)
+        self.session_manager.update_memory(sid, new_messages)
 
     async def handle_cmt_message(self, msg: KiraCommentEvent):
         """process comment message"""
@@ -597,7 +599,7 @@ class MessageProcessor:
             llm_logger.error(f"Default LLM model not set, please set it in Configuration")
             return
 
-        llm_req = LLMRequest(messages=[{"role": "user", "content": cmt_prompt}])
+        llm_req = LLMRequest(messages=[OpenAIMessage(role="user", content=cmt_prompt)])
 
         llm_resp = await client.chat(llm_req)
 

--- a/core/prompt_manager.py
+++ b/core/prompt_manager.py
@@ -10,11 +10,13 @@ logger = get_logger("prompt_manager", "yellow")
 
 
 class Prompt:
-    def __init__(self, content: str, name: Optional[str] = None, source: Optional[str] = None, end: Optional[str] = "\n", **kwargs):
+    def __init__(self, content: str, name: Optional[str] = None, source: Optional[str] = None,
+                 end: Optional[str] = "\n", persist: bool = True, **kwargs):
         self.name = name
         self.source = source
         self.content = content
         self.end = end
+        self.persist = persist
         self.kwargs = kwargs
 
     def __str__(self):

--- a/core/provider/llm_model.py
+++ b/core/provider/llm_model.py
@@ -4,6 +4,7 @@ from typing import Optional, Callable, Literal
 from dataclasses import dataclass, field
 
 from core.agent.tool import ToolSet
+from core.agent.message import OpenAIMessage
 from core.prompt_manager import Prompt
 
 
@@ -33,6 +34,10 @@ class LLMRequest:
     tool_choice: Optional[Literal["auto", "none", "required"]] = None
 
     def __post_init__(self):
+        self.messages = [
+            m if isinstance(m, OpenAIMessage) else OpenAIMessage(**m)
+            for m in self.messages
+        ]
         if not self.tool_choice:
             if self.tools:
                 self.tool_choice = "auto"
@@ -41,14 +46,14 @@ class LLMRequest:
 
     def assemble_prompt(self):
         if self.system_prompt:
-            if self.messages and self.messages[0].get("role") == "system":
+            if self.messages and self.messages[0].role == "system":
                 self.messages.pop(0)
             system_prompt = "".join(p.to_string() for p in self.system_prompt if isinstance(p, Prompt))
-            self.messages.insert(0, {"role": "system", "content": system_prompt})
+            self.messages.insert(0, OpenAIMessage(role="system", content=system_prompt))
 
         if self.user_prompt:
             user_prompt = "".join(p.to_string() for p in self.user_prompt if isinstance(p, Prompt))
-            self.messages.append({"role": "user", "content": user_prompt})
+            self.messages.append(OpenAIMessage(role="user", content=user_prompt))
 
 
 @dataclass

--- a/core/provider/provider_manager.py
+++ b/core/provider/provider_manager.py
@@ -13,6 +13,7 @@ from .provider import (
     VideoModelClient, EmbeddingModelClient, RerankModelClient
 )
 from .llm_model import LLMRequest
+from core.agent.message import OpenAIMessage
 
 from core.utils.path_utils import get_config_path
 from core.logging_manager import get_logger
@@ -482,7 +483,7 @@ class ProviderManager:
 
             if isinstance(model_client, LLMModelClient):
                 request = LLMRequest(
-                    messages=[{"role": "user", "content": "Say 'pong'"}],
+                    messages=[OpenAIMessage(role="user", content="Say 'pong'")],
                     tools=None,
                     tool_choice="none",
                 )

--- a/core/provider/src/deepseek/model_clients.py
+++ b/core/provider/src/deepseek/model_clients.py
@@ -54,7 +54,7 @@ class DeepSeekLLMClient(LLMModelClient):
         # Build request kwargs
         request_kwargs = dict(
             model=self.model.model_id,
-            messages=request.messages,
+            messages=[m if isinstance(m, dict) else m.to_dict() for m in request.messages],
             tools=request.tools if request.tools else None,
             tool_choice=request.tool_choice if request.tool_choice != "none" else None,
         )

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -33,7 +33,7 @@ class OpenAICompatibleLLMClient(LLMModelClient):
                 extra_body = None
             request_kwargs = dict(
                 model=self.model.model_id,
-                messages=request.messages,
+                messages=[m if isinstance(m, dict) else m.to_dict() for m in request.messages],
                 tools=request.tools if request.tools else None,
                 tool_choice=request.tool_choice if request.tool_choice != "none" else None,
                 temperature=temperature if temperature is not None else NOT_GIVEN,


### PR DESCRIPTION
## Summary

Replace untyped raw dicts with Pydantic `OpenAIMessage` BaseModel for type safety in message handling, remove redundant `NewMemory` wrapper class, and add `Prompt.persist` flag for memory persistence control.

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [x] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Enhance `OpenAIMessage` with `to_dict()` serialization and dict compatibility layer (`__getitem__`/`__setitem__`)
- Auto-convert raw dicts to `OpenAIMessage` in `LLMRequest.__post_init__()` for backward compatibility
- Remove `NewMemory` class, use `list[OpenAIMessage]` directly in `AgentExecutionContext` and `AgentStepResult`
- Update provider SDK serialization to handle both dict and `OpenAIMessage` for plugin compatibility
- Add `Prompt.persist` flag to control whether Prompt content is persisted to `memory.json`
- Update `session_manager.update_memory()` to auto-convert `list[OpenAIMessage]` to dicts

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified message handling to use structured message objects across the chat and agent flows, improving consistency and persistence of conversation history.
* **New Features**
  * Prompts can opt out of being persisted.
  * Assistant/tool responses and intermediate data are now captured as structured messages for clearer display and logging.
* **Behavior**
  * Health checks and external model requests now send normalized message payloads for more reliable integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xxynet/KiraAI/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->