### PR TITLE
feat(update): backend auto-restarts after update

### DIFF
--- a/webui/frontend/src/components/layout/ReleasesModal.vue
+++ b/webui/frontend/src/components/layout/ReleasesModal.vue
@@ -143,7 +143,7 @@ import Modal from '@/components/common/Modal.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import { notify } from '@/composables/useNotification'
 import { downloadRelease } from '@/api/auth'
-import { restartAndWait } from '@/composables/useRestart'
+import { waitUntilReady } from '@/composables/useRestart'
 import type { ReleaseItem } from '@/types'
 
 const props = defineProps<{
@@ -235,9 +235,9 @@ async function handleConfirm() {
   try {
     await downloadRelease(release.tag_name)
     notify(isNew ? t('header.update_success') : t('header.switch_success'), 'success')
-    // Auto restart
+    // Backend restarts automatically after update — just wait for it to come back
     try {
-      await restartAndWait()
+      await waitUntilReady()
     } catch {
       notify(t('header.restart_timeout'), 'warning', 600000)
     }

--- a/webui/frontend/src/composables/useRestart.ts
+++ b/webui/frontend/src/composables/useRestart.ts
@@ -17,7 +17,6 @@ function resolveOptions(options: RestartOptions): Required<RestartOptions> {
 
 async function pollUntilReady(opts: Required<RestartOptions>): Promise<void> {
   for (let i = 0; i < opts.maxRetries; i++) {
-    await new Promise(r => setTimeout(r, opts.intervalMs))
     try {
       await apiClient.get(opts.probeEndpoint)
       window.location.reload()
@@ -25,6 +24,7 @@ async function pollUntilReady(opts: Required<RestartOptions>): Promise<void> {
     } catch {
       // server not ready yet
     }
+    await new Promise(r => setTimeout(r, opts.intervalMs))
   }
 
   throw new Error('Restart timed out')

--- a/webui/frontend/src/composables/useRestart.ts
+++ b/webui/frontend/src/composables/useRestart.ts
@@ -8,6 +8,31 @@ export interface RestartOptions {
 }
 
 /**
+ * Poll the server until it comes back (used when the server is restarting on its own).
+ * Resolves when the server responds, rejects on timeout.
+ */
+export async function waitUntilReady(options: RestartOptions = {}): Promise<void> {
+  const {
+    maxRetries = 60,
+    intervalMs = 1000,
+    probeEndpoint = '/overview',
+  } = options
+
+  for (let i = 0; i < maxRetries; i++) {
+    await new Promise(r => setTimeout(r, intervalMs))
+    try {
+      await apiClient.get(probeEndpoint)
+      window.location.reload()
+      return
+    } catch {
+      // server not ready yet
+    }
+  }
+
+  throw new Error('Restart timed out')
+}
+
+/**
  * Trigger a server restart and poll until it comes back.
  * Resolves when the server responds, rejects on timeout.
  */

--- a/webui/frontend/src/composables/useRestart.ts
+++ b/webui/frontend/src/composables/useRestart.ts
@@ -7,21 +7,19 @@ export interface RestartOptions {
   probeEndpoint?: string
 }
 
-/**
- * Poll the server until it comes back (used when the server is restarting on its own).
- * Resolves when the server responds, rejects on timeout.
- */
-export async function waitUntilReady(options: RestartOptions = {}): Promise<void> {
-  const {
-    maxRetries = 60,
-    intervalMs = 1000,
-    probeEndpoint = '/overview',
-  } = options
+function resolveOptions(options: RestartOptions): Required<RestartOptions> {
+  return {
+    maxRetries: options.maxRetries ?? 60,
+    intervalMs: options.intervalMs ?? 1000,
+    probeEndpoint: options.probeEndpoint ?? '/overview',
+  }
+}
 
-  for (let i = 0; i < maxRetries; i++) {
-    await new Promise(r => setTimeout(r, intervalMs))
+async function pollUntilReady(opts: Required<RestartOptions>): Promise<void> {
+  for (let i = 0; i < opts.maxRetries; i++) {
+    await new Promise(r => setTimeout(r, opts.intervalMs))
     try {
-      await apiClient.get(probeEndpoint)
+      await apiClient.get(opts.probeEndpoint)
       window.location.reload()
       return
     } catch {
@@ -33,16 +31,18 @@ export async function waitUntilReady(options: RestartOptions = {}): Promise<void
 }
 
 /**
+ * Poll the server until it comes back (used when the server is restarting on its own).
+ * Resolves when the server responds, rejects on timeout.
+ */
+export async function waitUntilReady(options: RestartOptions = {}): Promise<void> {
+  return pollUntilReady(resolveOptions(options))
+}
+
+/**
  * Trigger a server restart and poll until it comes back.
  * Resolves when the server responds, rejects on timeout.
  */
 export async function restartAndWait(options: RestartOptions = {}): Promise<void> {
-  const {
-    maxRetries = 60,
-    intervalMs = 1000,
-    probeEndpoint = '/overview',
-  } = options
-
   try {
     await restartApplication()
   } catch (err: any) {
@@ -51,16 +51,5 @@ export async function restartAndWait(options: RestartOptions = {}): Promise<void
     if (err?.response) throw err
   }
 
-  for (let i = 0; i < maxRetries; i++) {
-    await new Promise(r => setTimeout(r, intervalMs))
-    try {
-      await apiClient.get(probeEndpoint)
-      window.location.reload()
-      return
-    } catch {
-      // server not ready yet
-    }
-  }
-
-  throw new Error('Restart timed out')
+  return pollUntilReady(resolveOptions(options))
 }

--- a/webui/routes/releases.py
+++ b/webui/routes/releases.py
@@ -19,6 +19,7 @@ from webui.routes.base import RouteDefinition, Routes
 logger = get_logger("releases", "green")
 
 RESTART_EXIT_CODE = 42
+RESTART_DELAY_SECONDS = 0.5  # Allow HTTP response to flush before hard exit
 _install_lock = asyncio.Lock()
 
 
@@ -112,7 +113,7 @@ class ReleasesRoutes(Routes):
         await self.lifecycle.stop()
         if self.lifecycle.uvicorn_server:
             self.lifecycle.uvicorn_server.should_exit = True
-        asyncio.get_running_loop().call_later(0.5, os._exit, RESTART_EXIT_CODE)
+        asyncio.get_running_loop().call_later(RESTART_DELAY_SECONDS, os._exit, RESTART_EXIT_CODE)
         return {"status": "restarting"}
 
     @staticmethod

--- a/webui/routes/releases.py
+++ b/webui/routes/releases.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import re
 import shutil
 import tempfile
@@ -17,6 +18,7 @@ from webui.routes.base import RouteDefinition, Routes
 
 logger = get_logger("releases", "green")
 
+RESTART_EXIT_CODE = 42
 _install_lock = asyncio.Lock()
 
 
@@ -105,7 +107,13 @@ class ReleasesRoutes(Routes):
                 ) from e
             logger.info(f"Update {tag} applied successfully")
 
-        return {"status": "ok"}
+        # Trigger restart — let the response be sent first, then exit
+        logger.info("Scheduling restart after update...")
+        await self.lifecycle.stop()
+        if self.lifecycle.uvicorn_server:
+            self.lifecycle.uvicorn_server.should_exit = True
+        asyncio.get_running_loop().call_later(0.5, os._exit, RESTART_EXIT_CODE)
+        return {"status": "restarting"}
 
     @staticmethod
     def _apply_update(zip_path: Path) -> None:


### PR DESCRIPTION
## Summary

After the WebUI triggers an update, the restart step is now handled entirely by the backend. Previously the frontend had to call `/system/restart` separately after the download; now the `/releases/download` endpoint triggers the restart itself and returns `{"status": "restarting"}`. The frontend simply polls for the server to come back up.

Fixes the dependency on the frontend to initiate the restart — the update flow is now self-contained on the backend side.

## Type of change

- [x] refactor: Code refactor (no functional change)

## Changes

- **`webui/routes/releases.py`**: After `_apply_update()` succeeds, schedule a restart (`lifecycle.stop()` → `os._exit(42)`) and return `{"status": "restarting"}` instead of `{"status": "ok"}`
- **`webui/frontend/src/composables/useRestart.ts`**: Add `waitUntilReady()` — polls for server recovery without calling `/system/restart`
- **`webui/frontend/src/components/layout/ReleasesModal.vue`**: Use `waitUntilReady()` instead of `restartAndWait()` after a successful update download

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update flow: after installing a release the app now waits for the backend to be ready before reloading, reducing partial-load states.

* **New Features**
  * Update endpoint now signals a restart and returns a "restarting" status; the restart is scheduled with a short delay to ensure the response is delivered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xxynet/KiraAI/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->