### PR TITLE
feat(ui): organize config view into category tabs

### DIFF
--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -449,6 +449,12 @@ export default {
     load_failed: 'Failed to load stickers',
     retry: 'Retry',
   },
+  config_tab: {
+    life: 'Digital Life',
+    system: 'System',
+    models: 'Models',
+    all: 'All',
+  },
   configuration: {
     title: 'Configuration',
     save: 'Save',
@@ -481,6 +487,7 @@ export default {
     save_success: 'Configuration saved successfully',
     no_changes: 'No changes to save',
     load_failed: 'Failed to load configuration',
+    no_results: 'No matching settings found',
     groups: {
       bot: 'Bot Settings',
       bot_desc: 'Core bot behavior parameters',

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -488,6 +488,7 @@ export default {
     no_changes: 'No changes to save',
     load_failed: 'Failed to load configuration',
     no_results: 'No matching settings found',
+    categories_aria: 'Configuration categories',
     groups: {
       bot: 'Bot Settings',
       bot_desc: 'Core bot behavior parameters',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -449,6 +449,12 @@ export default {
     load_failed: '加载表情包失败',
     retry: '重试',
   },
+  config_tab: {
+    life: '数字生命',
+    system: '系统',
+    models: '模型',
+    all: '全部',
+  },
   configuration: {
     title: '配置项',
     save: '保存',
@@ -481,6 +487,7 @@ export default {
     save_success: '配置保存成功',
     no_changes: '没有需要保存的修改',
     load_failed: '加载配置失败',
+    no_results: '未找到匹配的设置项',
     groups: {
       bot: '机器人设置',
       bot_desc: '核心机器人行为参数',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -488,6 +488,7 @@ export default {
     no_changes: '没有需要保存的修改',
     load_failed: '加载配置失败',
     no_results: '未找到匹配的设置项',
+    categories_aria: '配置分类',
     groups: {
       bot: '机器人设置',
       bot_desc: '核心机器人行为参数',

--- a/webui/frontend/src/views/ConfigView.vue
+++ b/webui/frontend/src/views/ConfigView.vue
@@ -94,7 +94,7 @@
 
     <!-- Category Tabs -->
     <div class="mb-4 border-b border-gray-200 dark:border-gray-700">
-      <nav class="flex space-x-0 -mb-px" role="tablist" aria-label="Configuration categories">
+      <nav class="flex space-x-0 -mb-px" role="tablist" :aria-label="$t('configuration.categories_aria', 'Configuration categories')">
         <button
           v-for="(tab, index) in visibleCategoryTabs"
           :key="tab.id"
@@ -762,7 +762,10 @@ function tabHasModified(tab: CategoryTab): boolean {
 
 // Auto-switch tab when searching if current tab has no results
 watch(searchTerm, (term) => {
-  if (!term) return
+  if (!term) {
+    if (activeTab.value === 'all') activeTab.value = categoryTabs[0]?.id ?? 'life'
+    return
+  }
   if (activeTab.value === 'all') return
   const hasResults = currentTabGroups.value.length > 0
   if (!hasResults) {

--- a/webui/frontend/src/views/ConfigView.vue
+++ b/webui/frontend/src/views/ConfigView.vue
@@ -92,9 +92,35 @@
       </div>
     </div>
 
+    <!-- Category Tabs -->
+    <div class="mb-4 border-b border-gray-200 dark:border-gray-700">
+      <nav class="flex space-x-0 -mb-px" role="tablist" aria-label="Configuration categories">
+        <button
+          v-for="(tab, index) in visibleCategoryTabs"
+          :key="tab.id"
+          type="button"
+          role="tab"
+          :aria-selected="activeTab === tab.id"
+          class="relative flex items-center space-x-2 px-4 py-2.5 text-sm font-medium transition-colors duration-150 whitespace-nowrap border-b-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          :class="activeTab === tab.id
+            ? 'text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400'
+            : 'text-gray-500 dark:text-gray-400 border-transparent hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'"
+          @click="switchTab(tab.id)"
+        >
+          <component :is="tab.icon" class="w-4 h-4" />
+          <span>{{ $t(tab.labelKey, tab.labelFallback) }}</span>
+          <span
+            v-if="tabHasModified(tab)"
+            class="inline-block w-1.5 h-1.5 bg-amber-500 rounded-full ml-1"
+            aria-hidden="true"
+          ></span>
+        </button>
+      </nav>
+    </div>
+
     <!-- Groups -->
     <div
-      v-for="group in filteredAllGroups"
+      v-for="group in currentTabGroups"
       :key="group.id"
       class="mb-4"
     >
@@ -300,6 +326,15 @@
       </div>
     </div>
 
+    <!-- No results for search -->
+    <div
+      v-if="searchTerm && currentTabGroups.length === 0"
+      class="text-center py-12 text-gray-400 dark:text-gray-500"
+    >
+      <IconSearch class="w-8 h-8 mx-auto mb-2 opacity-50" />
+      <p class="text-sm">{{ $t('configuration.no_results', 'No matching settings found') }}</p>
+    </div>
+
     <!-- Bottom keyboard hints -->
     <div class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800">
       <p class="text-xs text-gray-400 dark:text-gray-500 text-center">
@@ -313,7 +348,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, nextTick, reactive, type Component } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick, reactive, type Component } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { notify } from '@/composables/useNotification'
 import { getConfiguration, saveConfiguration } from '@/api/config'
@@ -329,6 +364,7 @@ const searchTerm = ref('')
 const saving = ref(false)
 const loading = ref(false)
 const searchInputRef = ref<HTMLInputElement | null>(null)
+const activeTab = ref('life')
 
 // Data
 const originalData = ref<Record<string, any>>({})
@@ -463,6 +499,20 @@ const allGroups: ConfigGroup[] = [
       { key: 'models.default_video', labelKey: 'configuration.model.default_video', labelFallback: 'Default Video', hintKey: 'configuration.model.default_video_desc', hintFallback: 'Video generation.', type: 'model_select', modelType: 'video' },
     ],
   },
+]
+
+interface CategoryTab {
+  id: string
+  labelKey: string
+  labelFallback: string
+  icon: Component
+  groupIds: string[]
+}
+
+const categoryTabs: CategoryTab[] = [
+  { id: 'life', labelKey: 'config_tab.life', labelFallback: '数字生命', icon: IconMonitor, groupIds: ['bot', 'agent', 'selfie'] },
+  { id: 'system', labelKey: 'config_tab.system', labelFallback: '系统', icon: IconCog, groupIds: ['cache', 'logging'] },
+  { id: 'models', labelKey: 'config_tab.models', labelFallback: '模型', icon: IconFlask, groupIds: ['models'] },
 ]
 
 function escapeHtml(str: string): string {
@@ -676,6 +726,55 @@ const filteredAllGroups = computed(() => {
   )
 })
 
+// Category tabs
+const visibleCategoryTabs = computed(() => {
+  const tabs = [...categoryTabs]
+  if (searchTerm.value) {
+    const allFiltered = filteredAllGroups.value
+    const hasResultsOutsideCurrentTab = allFiltered.some(
+      g => !categoryTabs.find(t => t.id === activeTab.value)?.groupIds.includes(g.id)
+    )
+    if (hasResultsOutsideCurrentTab || currentTabGroups.value.length === 0) {
+      tabs.push({ id: 'all', labelKey: 'config_tab.all', labelFallback: '全部', icon: IconSearch, groupIds: allGroups.map(g => g.id) })
+    }
+  }
+  return tabs
+})
+
+const currentTabGroups = computed(() => {
+  if (activeTab.value === 'all') return filteredAllGroups.value
+  const tab = categoryTabs.find(t => t.id === activeTab.value)
+  if (!tab) return []
+  const groups = allGroups.filter(g => tab.groupIds.includes(g.id))
+  if (!searchTerm.value) return groups
+  return groups.filter(g => g.fields.some(f => fieldMatchesSearch(f)))
+})
+
+function switchTab(tabId: string) {
+  activeTab.value = tabId
+}
+
+function tabHasModified(tab: CategoryTab): boolean {
+  return allGroups
+    .filter(g => tab.groupIds.includes(g.id))
+    .some(g => g.fields.some(f => modifiedFields.has(f.key)))
+}
+
+// Auto-switch tab when searching if current tab has no results
+watch(searchTerm, (term) => {
+  if (!term) return
+  if (activeTab.value === 'all') return
+  const hasResults = currentTabGroups.value.length > 0
+  if (!hasResults) {
+    const firstMatch = categoryTabs.find(tab =>
+      allGroups
+        .filter(g => tab.groupIds.includes(g.id))
+        .some(g => g.fields.some(f => fieldMatchesSearch(f)))
+    )
+    if (firstMatch) activeTab.value = firstMatch.id
+  }
+})
+
 function getVisibleFields(group: ConfigGroup): ConfigField[] {
   if (!searchTerm.value) return group.fields
   return group.fields.filter(f => fieldMatchesSearch(f))
@@ -694,12 +793,11 @@ function toggleGroup(id: string) {
 }
 
 function expandAll() {
-  collapsedGroups.clear()
+  currentTabGroups.value.forEach(g => collapsedGroups.delete(g.id))
 }
 
 function collapseAll() {
-  collapsedGroups.clear()
-  allGroups.forEach(g => collapsedGroups.add(g.id))
+  currentTabGroups.value.forEach(g => collapsedGroups.add(g.id))
 }
 
 // Save


### PR DESCRIPTION
## Summary

Reorganizes the Configuration page from a single scrollable accordion layout into three top-level category tabs for better navigation and reduced visual clutter.

## Type of change

- [x] feat: New feature

## Changes

- Added category tab bar with three tabs: **数字生命** (Bot/Agent/Appearance), **系统** (Cache/Logging), **模型** (Default Models)
- Each tab displays its groups as collapsible accordion sections (existing behavior preserved)
- Dynamic **全部** tab appears during search when results span multiple categories
- Tab headers show amber dot indicator when any field in the tab has been modified
- Auto-switches to the first matching tab when searching if the current tab has no results
- Expand/Collapse buttons operate on the current tab's groups only
- Added i18n keys (`config_tab.*`, `configuration.no_results`) to both `en.ts` and `zh.ts`

## Screenshots / Logs

<!-- Tabs are visible at the top of the Configuration page. Please run `npm run dev` in `webui/frontend` and navigate to the Configuration page to verify. -->

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration settings organized into category tabs (Life, System, Models, All) for easier navigation.
  * View auto-switches to relevant tab when searching; expand/collapse actions now respect the active tab and search filters.
  * Shows "No matching settings found" when a search returns no results.

* **Localization**
  * Added English and Chinese translations for the new tabs and empty-state message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->