### PR TITLE
feat(ui): add link from provider view to default model configuration

### DIFF
--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -103,6 +103,7 @@ export default {
     modal_cancel: 'Cancel',
     modal_save: 'Save',
     select_provider: 'Select a provider to configure',
+    go_to_model_config: 'Configure default models',
     schema_error: 'Error loading configuration schema',
     schema_loading: 'Loading configuration...',
     schema_none: 'No configuration required',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -103,6 +103,7 @@ export default {
     modal_cancel: '取消',
     modal_save: '保存',
     select_provider: '选择一个提供商进行配置',
+    go_to_model_config: '配置默认模型',
     schema_error: '加载配置架构出错',
     schema_loading: '加载配置中...',
     schema_none: '无需配置',

--- a/webui/frontend/src/views/ConfigView.vue
+++ b/webui/frontend/src/views/ConfigView.vue
@@ -350,6 +350,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick, reactive, type Component } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
 import { notify } from '@/composables/useNotification'
 import { getConfiguration, saveConfiguration } from '@/api/config'
 import CustomSelect from '@/components/common/CustomSelect.vue'
@@ -359,6 +360,7 @@ import {
 } from '@/components/icons'
 
 const { t } = useI18n()
+const route = useRoute()
 
 const searchTerm = ref('')
 const saving = ref(false)
@@ -936,6 +938,11 @@ function handleKeydown(e: KeyboardEvent) {
 
 onMounted(async () => {
   document.addEventListener('keydown', handleKeydown)
+  // Support ?tab= query parameter to switch to a specific category tab
+  const queryTab = route.query.tab as string | undefined
+  if (queryTab && categoryTabs.some(t => t.id === queryTab)) {
+    activeTab.value = queryTab
+  }
   await loadConfig()
 })
 

--- a/webui/frontend/src/views/ProviderView.vue
+++ b/webui/frontend/src/views/ProviderView.vue
@@ -47,6 +47,12 @@
         <div class="text-center">
           <IconCpu class="w-16 h-16 text-gray-400 mx-auto mb-4" />
           <p class="text-gray-500">{{ $t('provider.select_provider') }}</p>
+          <button
+            class="mt-4 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+            @click="goToModelConfig"
+          >
+            {{ $t('provider.go_to_model_config') }}
+          </button>
         </div>
       </div>
 
@@ -333,6 +339,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useLocalized } from '@/composables/useLocalized'
 import { notify } from '@/composables/useNotification'
@@ -349,8 +356,13 @@ import Modal from '@/components/common/Modal.vue'
 import { IconClose, IconPlus, IconCpu, IconChevronDown, IconRefresh, IconSpinner, IconPulse, IconSliders, IconInfo } from '@/components/icons'
 import type { ProviderResponse } from '@/types'
 
+const router = useRouter()
 const { t } = useI18n()
 const { localize } = useLocalized()
+
+function goToModelConfig() {
+  router.push('/configuration?tab=models')
+}
 
 const configFormRef = ref<InstanceType<typeof ConfigForm>>()
 const createConfigFormRef = ref<InstanceType<typeof ConfigForm>>()


### PR DESCRIPTION
## Summary

Add a navigation link in ProviderView's empty state that takes users directly to the "Models" tab in ConfigView, improving discoverability of default model configuration.

## Type of change

- [x] feat: New feature

## Changes

- Added a link button in ProviderView's right panel empty state ("Configure default models")
- ConfigView now reads `?tab=` query parameter to activate the corresponding category tab on load
- Added i18n keys (`provider.go_to_model_config`) for both en and zh locales

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to deep-link directly to specific configuration categories via URL parameters.
  * Added "Go to Model Config" navigation option when no provider is selected, enabling quick access to model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->