### PR TITLE
test: add unit tests for core modules and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-anyio
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,5 +28,8 @@ jobs:
           pip install -r requirements.txt
           pip install pytest pytest-anyio
 
+      - name: Create data directories
+        run: mkdir -p data/config
+
       - name: Run tests
         run: python -m pytest tests/ -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(params=["asyncio"])
+def anyio_backend(request):
+    return request.param

--- a/tests/test_config_field.py
+++ b/tests/test_config_field.py
@@ -1,0 +1,272 @@
+import pytest
+
+from core.config.config_field import (
+    ConfigType,
+    StringField,
+    IntField,
+    FloatField,
+    SensitiveField,
+    ListField,
+    EnumField,
+    SwitchField,
+    JsonField,
+    MarkdownField,
+    YamlField,
+    EditorField,
+    TextareaField,
+    ModelSelectField,
+    MultiSelectField,
+    SectionField,
+    create_field_from_schema,
+    build_fields,
+)
+
+
+def test_string_field():
+    f = StringField("k", "Name", "hint", default="val")
+    assert f.type == ConfigType.String
+    d = f.to_dict()
+    assert d["type"] == "string"
+    assert d["default"] == "val"
+
+
+def test_int_field():
+    f = IntField("k", "Name", "hint", default=42)
+    d = f.to_dict()
+    assert d["type"] == "integer"
+    assert d["default"] == 42
+
+
+def test_float_field():
+    f = FloatField("k", "Name", "hint", default=3.14)
+    d = f.to_dict()
+    assert d["type"] == "float"
+
+
+def test_sensitive_field():
+    f = SensitiveField("k", "Name", "hint", default="secret")
+    d = f.to_dict()
+    assert d["type"] == "sensitive"
+
+
+def test_list_field_default_none():
+    f = ListField("k", "Name", "hint", default=None)
+    assert f.default == []
+
+
+def test_list_field_default_list():
+    f = ListField("k", "Name", "hint", default=["a", "b"])
+    assert f.default == ["a", "b"]
+
+
+def test_enum_field_with_valid_default():
+    f = EnumField("k", "Name", "hint", options=["a", "b", "c"], default="b")
+    assert f.default == "b"
+    d = f.to_dict()
+    assert d["options"] == ["a", "b", "c"]
+
+
+def test_enum_field_invalid_default_fallback():
+    f = EnumField("k", "Name", "hint", options=["a", "b"], default="z")
+    assert f.default == "a"
+
+
+def test_switch_field_default_bool():
+    f = SwitchField("k", "Name", "hint", default=True)
+    assert f.default is True
+
+
+def test_switch_field_non_bool_default():
+    f = SwitchField("k", "Name", "hint", default="yes")
+    assert f.default is False
+
+
+def test_json_field_default_none():
+    f = JsonField("k", "Name", "hint", default=None)
+    assert f.default == {}
+
+
+def test_editor_field_with_language():
+    f = EditorField("k", "Name", "hint", default="", language="json")
+    d = f.to_dict()
+    assert d["language"] == "json"
+
+
+def test_editor_field_no_language():
+    f = EditorField("k", "Name", "hint", default="")
+    d = f.to_dict()
+    assert "language" not in d
+
+
+def test_model_select_field():
+    f = ModelSelectField("k", "Name", "hint", model_type="llm")
+    d = f.to_dict()
+    assert d["model_type"] == "llm"
+
+
+def test_multi_select_field():
+    f = MultiSelectField("k", "Name", "hint", options=["a", "b"], default=["a"])
+    d = f.to_dict()
+    assert d["options"] == ["a", "b"]
+    assert f.default == ["a"]
+
+
+def test_section_field():
+    child = StringField("child_k", "Child", "hint", default="v")
+    f = SectionField("sec", "Section", "hint", fields=[child], collapsed=True)
+    d = f.to_dict()
+    assert d["collapsed"] is True
+    assert "child_k" in d["fields"]
+    assert d["fields"]["child_k"]["type"] == "string"
+
+
+def test_locales_included():
+    f = StringField("k", "Name", "hint", locales={"zh": {"name": "zh_name"}})
+    d = f.to_dict()
+    assert d["locales"] == {"zh": {"name": "zh_name"}}
+
+
+def test_locales_omitted_when_empty():
+    f = StringField("k", "Name", "hint")
+    d = f.to_dict()
+    assert "locales" not in d
+
+
+def test_create_field_string():
+    f = create_field_from_schema("k", {"type": "string", "name": "Name", "hint": "h", "default": "v"})
+    assert isinstance(f, StringField)
+    assert f.default == "v"
+
+
+def test_create_field_text_with_options_becomes_enum():
+    f = create_field_from_schema("k", {"type": "text", "options": ["a", "b"]})
+    assert isinstance(f, EnumField)
+
+
+def test_create_field_sensitive():
+    f = create_field_from_schema("k", {"type": "sensitive"})
+    assert isinstance(f, SensitiveField)
+
+
+def test_create_field_integer():
+    f = create_field_from_schema("k", {"type": "integer"})
+    assert isinstance(f, IntField)
+
+
+def test_create_field_int_alias():
+    f = create_field_from_schema("k", {"type": "int"})
+    assert isinstance(f, IntField)
+
+
+def test_create_field_float():
+    f = create_field_from_schema("k", {"type": "float"})
+    assert isinstance(f, FloatField)
+
+
+def test_create_field_list():
+    f = create_field_from_schema("k", {"type": "list"})
+    assert isinstance(f, ListField)
+
+
+def test_create_field_enum():
+    f = create_field_from_schema("k", {"type": "enum", "options": ["x", "y"], "default": "y"})
+    assert isinstance(f, EnumField)
+    assert f.default == "y"
+
+
+def test_create_field_switch():
+    f = create_field_from_schema("k", {"type": "switch", "default": True})
+    assert isinstance(f, SwitchField)
+    assert f.default is True
+
+
+def test_create_field_json():
+    f = create_field_from_schema("k", {"type": "json"})
+    assert isinstance(f, JsonField)
+
+
+def test_create_field_markdown():
+    f = create_field_from_schema("k", {"type": "markdown"})
+    assert isinstance(f, MarkdownField)
+
+
+def test_create_field_yaml():
+    f = create_field_from_schema("k", {"type": "yaml"})
+    assert isinstance(f, YamlField)
+
+
+def test_create_field_editor():
+    f = create_field_from_schema("k", {"type": "editor", "language": "css"})
+    assert isinstance(f, EditorField)
+    assert f.language == "css"
+
+
+def test_create_field_textarea():
+    f = create_field_from_schema("k", {"type": "textarea"})
+    assert isinstance(f, TextareaField)
+
+
+def test_create_field_model_select():
+    f = create_field_from_schema("k", {"type": "model_select", "model_type": "embedding"})
+    assert isinstance(f, ModelSelectField)
+    assert f.model_type == "embedding"
+
+
+def test_create_field_multi_select():
+    f = create_field_from_schema("k", {"type": "multi_select", "options": ["a"]})
+    assert isinstance(f, MultiSelectField)
+
+
+def test_create_field_section():
+    schema = {
+        "type": "section",
+        "collapsed": True,
+        "fields": {
+            "child": {"type": "string", "name": "Child"},
+        },
+    }
+    f = create_field_from_schema("sec", schema)
+    assert isinstance(f, SectionField)
+    assert f.collapsed is True
+    assert len(f.fields) == 1
+    assert isinstance(f.fields[0], StringField)
+
+
+def test_create_field_unknown_type_defaults_to_string():
+    f = create_field_from_schema("k", {"type": "unknown_xyz"})
+    assert isinstance(f, StringField)
+
+
+def test_create_field_missing_type_defaults_to_string():
+    f = create_field_from_schema("k", {"name": "N"})
+    assert isinstance(f, StringField)
+
+
+def test_create_field_name_fallback_to_key():
+    f = create_field_from_schema("my_key", {"type": "string"})
+    assert f.name == "my_key"
+
+
+def test_build_fields():
+    schema = {
+        "host": {"type": "string", "name": "Host", "default": "localhost"},
+        "port": {"type": "integer", "name": "Port", "default": 8080},
+        "debug": {"type": "switch", "name": "Debug"},
+    }
+    fields = build_fields(schema)
+    assert len(fields) == 3
+    types = {f.key: f.type for f in fields}
+    assert types["host"] == ConfigType.String
+    assert types["port"] == ConfigType.Integer
+    assert types["debug"] == ConfigType.Switch
+
+
+def test_build_fields_skips_non_dict_values():
+    schema = {
+        "valid": {"type": "string"},
+        "skip_str": "not a dict",
+        "skip_int": 123,
+    }
+    fields = build_fields(schema)
+    assert len(fields) == 1
+    assert fields[0].key == "valid"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,100 @@
+import pytest
+
+from core.config.config_loader import KiraConfig
+
+
+class MockConfig(KiraConfig):
+    """KiraConfig that skips file I/O for unit testing."""
+    def __init__(self, data: dict = None):
+        object.__setattr__(self, "default_config", data or {})
+        self.update(self.default_config)
+
+    def _load_config(self):
+        pass
+
+    def save_config(self):
+        pass
+
+
+def test_deep_update_simple():
+    c = MockConfig({"a": 1, "b": 2})
+    c._deep_update(c, {"b": 99, "c": 3})
+    assert c["a"] == 1
+    assert c["b"] == 99
+    assert c["c"] == 3
+
+
+def test_deep_update_nested():
+    c = MockConfig({"db": {"host": "localhost", "port": 5432}})
+    c._deep_update(c, {"db": {"port": 3306}})
+    assert c["db"]["host"] == "localhost"
+    assert c["db"]["port"] == 3306
+
+
+def test_deep_update_nested_new_key():
+    c = MockConfig({"db": {"host": "localhost"}})
+    c._deep_update(c, {"db": {"user": "admin"}})
+    assert c["db"]["host"] == "localhost"
+    assert c["db"]["user"] == "admin"
+
+
+def test_deep_update_overwrite_dict_with_non_dict():
+    c = MockConfig({"db": {"host": "localhost"}})
+    c._deep_update(c, {"db": "disabled"})
+    assert c["db"] == "disabled"
+
+
+def test_get_config_simple():
+    c = MockConfig({"key": "value"})
+    assert c.get_config("key") == "value"
+
+
+def test_get_config_nested():
+    c = MockConfig({"a": {"b": {"c": 42}}})
+    assert c.get_config("a.b.c") == 42
+
+
+def test_get_config_missing_returns_default():
+    c = MockConfig({})
+    assert c.get_config("no.such.key", default="fallback") == "fallback"
+
+
+def test_get_config_partial_path_returns_default():
+    c = MockConfig({"a": {"b": 1}})
+    assert c.get_config("a.b.c", default=None) is None
+
+
+def test_get_config_custom_splitter():
+    c = MockConfig({"a": {"b": "v"}})
+    assert c.get_config("a/b", splitter="/") == "v"
+
+
+def test_setattr_getattr():
+    c = MockConfig({})
+    c.foo = "bar"
+    assert c.foo == "bar"
+    assert c["foo"] == "bar"
+
+
+def test_getattr_missing_raises():
+    c = MockConfig({})
+    with pytest.raises(AttributeError, match="no attribute"):
+        _ = c.nonexistent
+
+
+def test_delattr():
+    c = MockConfig({"key": "val"})
+    del c.key
+    assert "key" not in c
+
+
+def test_delattr_missing_raises():
+    c = MockConfig({})
+    with pytest.raises(AttributeError, match="no attribute"):
+        del c.nonexistent
+
+
+def test_default_config_merged():
+    c = MockConfig({"a": 1, "b": {"x": 10}})
+    assert c["a"] == 1
+    assert c["b"]["x"] == 10

--- a/tests/test_db_helper.py
+++ b/tests/test_db_helper.py
@@ -1,0 +1,108 @@
+import pytest
+from sqlalchemy import Column, Integer, String, select, text
+
+from core.db.db_mgr import DatabaseManager, Base
+
+
+class SampleItem(Base):
+    __tablename__ = "sample_items"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False)
+
+
+@pytest.fixture
+async def db():
+    manager = DatabaseManager("sqlite+aiosqlite:///:memory:")
+    await manager.init()
+    yield manager
+    await manager.dispose()
+
+
+@pytest.mark.anyio
+async def test_init_and_dispose():
+    manager = DatabaseManager("sqlite+aiosqlite:///:memory:")
+    assert manager.engine is None
+    await manager.init()
+    assert manager.engine is not None
+    assert manager.session_maker is not None
+    await manager.dispose()
+    assert manager.engine is None
+    assert manager.session_maker is None
+
+
+@pytest.mark.anyio
+async def test_get_session(db):
+    async with db.get_session() as session:
+        result = await session.execute(text("SELECT 1"))
+        value = result.scalar()
+        assert value == 1
+
+
+@pytest.mark.anyio
+async def test_transaction_commit(db):
+    await db.create_all()
+    async with db.transaction() as session:
+        session.add(SampleItem(name="committed"))
+
+    async with db.get_session() as session:
+        result = await session.execute(select(SampleItem).where(SampleItem.name == "committed"))
+        item = result.scalar_one_or_none()
+        assert item is not None
+        assert item.name == "committed"
+
+
+@pytest.mark.anyio
+async def test_transaction_rollback(db):
+    await db.create_all()
+    try:
+        async with db.transaction() as session:
+            session.add(SampleItem(name="rollback"))
+            raise RuntimeError("force rollback")
+    except RuntimeError:
+        pass
+
+    async with db.get_session() as session:
+        result = await session.execute(select(SampleItem).where(SampleItem.name == "rollback"))
+        item = result.scalar_one_or_none()
+        assert item is None
+
+
+@pytest.mark.anyio
+async def test_execute_fetch_one_fetch_all(db):
+    await db.create_all()
+    async with db.transaction() as session:
+        session.add(SampleItem(name="alpha"))
+        session.add(SampleItem(name="beta"))
+
+    stmt = select(SampleItem.id, SampleItem.name).where(SampleItem.name == "alpha")
+    row = await db.fetch_one(stmt)
+    assert row is not None
+    assert row["name"] == "alpha"
+
+    stmt_all = select(SampleItem.id, SampleItem.name).order_by(SampleItem.id)
+    rows = await db.fetch_all(stmt_all)
+    assert len(rows) == 2
+    assert rows[0]["name"] == "alpha"
+    assert rows[1]["name"] == "beta"
+
+
+@pytest.mark.anyio
+async def test_create_all(db):
+    await db.create_all()
+    async with db.get_session() as session:
+        result = await session.execute(
+            text("SELECT name FROM sqlite_master WHERE type='table' AND name='sample_items'")
+        )
+        assert result.scalar_one_or_none() == "sample_items"
+
+
+@pytest.mark.anyio
+async def test_not_initialized_errors():
+    manager = DatabaseManager("sqlite+aiosqlite:///:memory:")
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        async with manager.get_session() as session:
+            pass
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await manager.create_all()

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -1,0 +1,229 @@
+import time
+
+import pytest
+
+from core.db.db_mgr import DatabaseManager
+from core.db.service import DatabaseService
+
+
+@pytest.fixture
+async def svc():
+    manager = DatabaseManager("sqlite+aiosqlite:///:memory:")
+    await manager.init()
+    service = DatabaseService(manager)
+    await service.init_tables()
+    yield service
+    await manager.dispose()
+
+
+@pytest.mark.anyio
+async def test_sticker_crud(svc):
+    await svc.add_sticker("s1", "desc1", "path1.png", extra={"tags": ["a", "b"]})
+
+    item = await svc.get_sticker("s1")
+    assert item is not None
+    assert item["id"] == "s1"
+    assert item["desc"] == "desc1"
+    assert item["path"] == "path1.png"
+    assert item["extra"] == {"tags": ["a", "b"]}
+
+    items = await svc.list_stickers()
+    assert len(items) == 1
+    assert items[0]["id"] == "s1"
+
+    deleted = await svc.delete_sticker("s1")
+    assert deleted is True
+
+    item = await svc.get_sticker("s1")
+    assert item is None
+
+    deleted = await svc.delete_sticker("s1")
+    assert deleted is False
+
+
+@pytest.mark.anyio
+async def test_image_desc_cache_crud(svc):
+    await svc.add_image_desc_cache(
+        "abc123", "a cute cat", count=1, last_seen=1000
+    )
+
+    item = await svc.get_image_desc_cache("abc123")
+    assert item is not None
+    assert item["md5"] == "abc123"
+    assert item["description"] == "a cute cat"
+    assert item["count"] == 1
+    assert item["last_seen"] == 1000
+
+    updated = await svc.update_image_desc_cache(
+        "abc123", description="a cute dog", count=5, last_seen=2000
+    )
+    assert updated is True
+
+    item = await svc.get_image_desc_cache("abc123")
+    assert item["description"] == "a cute dog"
+    assert item["count"] == 5
+    assert item["last_seen"] == 2000
+
+    deleted = await svc.delete_image_desc_cache("abc123")
+    assert deleted is True
+
+    item = await svc.get_image_desc_cache("abc123")
+    assert item is None
+
+    updated = await svc.update_image_desc_cache("not_exist", count=1)
+    assert updated is False
+
+
+@pytest.mark.anyio
+async def test_persona_crud(svc):
+    await svc.add_persona("default", "Default Persona", "Hello, I am Kira.", format="text")
+
+    item = await svc.get_persona("default")
+    assert item is not None
+    assert item["id"] == "default"
+    assert item["name"] == "Default Persona"
+    assert item["format"] == "text"
+    assert item["content"] == "Hello, I am Kira."
+
+    updated = await svc.update_persona("default", name="Updated Name", content="Updated content.", format="markdown")
+    assert updated is True
+
+    item = await svc.get_persona("default")
+    assert item["name"] == "Updated Name"
+    assert item["content"] == "Updated content."
+    assert item["format"] == "markdown"
+
+    items = await svc.list_personas()
+    assert len(items) == 1
+    assert items[0]["id"] == "default"
+
+    deleted = await svc.delete_persona("default")
+    assert deleted is True
+
+    item = await svc.get_persona("default")
+    assert item is None
+
+    updated = await svc.update_persona("not_exist", content="x")
+    assert updated is False
+
+
+@pytest.mark.anyio
+async def test_sticker_update(svc):
+    await svc.add_sticker("s1", "old desc", "old.png", extra={"v": 1})
+
+    updated = await svc.update_sticker("s1", desc="new desc", path="new.png", extra={"v": 2})
+    assert updated is True
+
+    item = await svc.get_sticker("s1")
+    assert item["desc"] == "new desc"
+    assert item["path"] == "new.png"
+    assert item["extra"] == {"v": 2}
+
+    updated = await svc.update_sticker("s1", desc="partial")
+    item = await svc.get_sticker("s1")
+    assert item["desc"] == "partial"
+    assert item["path"] == "new.png"
+
+    updated = await svc.update_sticker("not_exist", desc="x")
+    assert updated is False
+
+
+@pytest.mark.anyio
+async def test_cleanup_expired_image_desc_cache(svc):
+    now = int(time.time())
+    fifteen_days = 15 * 24 * 60 * 60
+    thirty_days = 30 * 24 * 60 * 60
+
+    await svc.add_image_desc_cache("old_low", "old low count", count=1, last_seen=now - fifteen_days - 1)
+    await svc.add_image_desc_cache("old_med", "old med count", count=2, last_seen=now - thirty_days - 1)
+    await svc.add_image_desc_cache("fresh", "fresh entry", count=1, last_seen=now)
+    await svc.add_image_desc_cache("old_high", "old high count", count=5, last_seen=now - thirty_days - 1)
+
+    deleted = await svc.cleanup_expired_image_desc_cache()
+    assert deleted == 2
+
+    assert await svc.get_image_desc_cache("old_low") is None
+    assert await svc.get_image_desc_cache("old_med") is None
+    assert await svc.get_image_desc_cache("fresh") is not None
+    assert await svc.get_image_desc_cache("old_high") is not None
+
+
+@pytest.mark.anyio
+async def test_plugin_store_source_crud(svc):
+    await svc.add_plugin_store_source(
+        "src1", "Official", "https://example.com/plugins",
+        cache_file="official.json", updated_at=1000, is_current=True, created_at=1000,
+    )
+
+    item = await svc.get_plugin_store_source("src1")
+    assert item is not None
+    assert item["id"] == "src1"
+    assert item["name"] == "Official"
+    assert item["url"] == "https://example.com/plugins"
+    assert item["cache_file"] == "official.json"
+    assert item["updated_at"] == 1000
+    assert item["is_current"] is True
+    assert item["created_at"] == 1000
+
+    by_url = await svc.get_plugin_store_source_by_url("https://example.com/plugins")
+    assert by_url is not None
+    assert by_url["id"] == "src1"
+
+    assert await svc.get_plugin_store_source_by_url("https://nope.com") is None
+
+    await svc.add_plugin_store_source(
+        "src2", "Community", "https://community.com/plugins",
+        cache_file="community.json", updated_at=2000, created_at=2000,
+    )
+
+    items = await svc.list_plugin_store_sources()
+    assert len(items) == 2
+    assert items[0]["id"] == "src1"
+    assert items[1]["id"] == "src2"
+
+    updated = await svc.update_plugin_store_source(
+        "src2", name="Community v2", url="https://community.com/v2",
+        cache_file="community_v2.json", updated_at=3000,
+    )
+    assert updated is True
+
+    item = await svc.get_plugin_store_source("src2")
+    assert item["name"] == "Community v2"
+    assert item["url"] == "https://community.com/v2"
+    assert item["cache_file"] == "community_v2.json"
+    assert item["updated_at"] == 3000
+
+    updated = await svc.update_plugin_store_source("not_exist", name="x")
+    assert updated is False
+
+    deleted = await svc.delete_plugin_store_source("src1")
+    assert deleted is True
+    assert await svc.get_plugin_store_source("src1") is None
+
+    deleted = await svc.delete_plugin_store_source("src1")
+    assert deleted is False
+
+
+@pytest.mark.anyio
+async def test_plugin_store_source_is_current_invariant(svc):
+    await svc.add_plugin_store_source("a", "A", "https://a.com", is_current=True)
+    await svc.add_plugin_store_source("b", "B", "https://b.com", is_current=False)
+
+    item_a = await svc.get_plugin_store_source("a")
+    item_b = await svc.get_plugin_store_source("b")
+    assert item_a["is_current"] is True
+    assert item_b["is_current"] is False
+
+    await svc.add_plugin_store_source("c", "C", "https://c.com", is_current=True)
+
+    item_a = await svc.get_plugin_store_source("a")
+    item_c = await svc.get_plugin_store_source("c")
+    assert item_a["is_current"] is False
+    assert item_c["is_current"] is True
+
+    await svc.update_plugin_store_source("b", is_current=True)
+
+    item_b = await svc.get_plugin_store_source("b")
+    item_c = await svc.get_plugin_store_source("c")
+    assert item_b["is_current"] is True
+    assert item_c["is_current"] is False

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,0 +1,67 @@
+import hashlib
+import pytest
+
+from core.utils.github_api import parse_github_url, verify_sha256
+
+
+def test_parse_standard_url():
+    assert parse_github_url("https://github.com/owner/repo") == ("owner", "repo")
+
+
+def test_parse_url_with_trailing_slash():
+    assert parse_github_url("https://github.com/owner/repo/") == ("owner", "repo")
+
+
+def test_parse_url_with_extra_path():
+    assert parse_github_url("https://github.com/owner/repo/tree/main/sub") == ("owner", "repo")
+
+
+def test_parse_shorthand():
+    assert parse_github_url("owner/repo") == ("owner", "repo")
+
+
+def test_parse_shorthand_with_spaces():
+    assert parse_github_url("  owner/repo  ") == ("owner", "repo")
+
+
+def test_parse_non_github_http_raises():
+    with pytest.raises(ValueError, match="Not a GitHub URL"):
+        parse_github_url("https://gitlab.com/owner/repo")
+
+
+def test_parse_incomplete_path_raises():
+    with pytest.raises(ValueError, match="Cannot parse"):
+        parse_github_url("owner")
+
+
+def test_parse_empty_owner_raises():
+    with pytest.raises(ValueError, match="Cannot parse"):
+        parse_github_url("/repo")
+
+
+def test_verify_sha256_match():
+    data = b"hello world"
+    digest = hashlib.sha256(data).hexdigest()
+    assert verify_sha256(data, digest) is True
+
+
+def test_verify_sha256_with_prefix():
+    data = b"hello world"
+    digest = hashlib.sha256(data).hexdigest()
+    assert verify_sha256(data, f"sha256:{digest}") is True
+
+
+def test_verify_sha256_mismatch():
+    assert verify_sha256(b"hello", "0" * 64) is False
+
+
+def test_verify_sha256_case_insensitive():
+    data = b"test"
+    digest = hashlib.sha256(data).hexdigest().upper()
+    assert verify_sha256(data, digest) is True
+
+
+def test_verify_sha256_strips_whitespace():
+    data = b"test"
+    digest = hashlib.sha256(data).hexdigest()
+    assert verify_sha256(data, f"  {digest}  ") is True

--- a/tests/test_message_elements.py
+++ b/tests/test_message_elements.py
@@ -1,0 +1,258 @@
+import os
+import base64
+import tempfile
+
+import pytest
+
+from core.chat.message_elements import (
+    _infer_mime_from_bytes,
+    check_base64,
+    ElementType,
+    Text,
+    At,
+    Reply,
+    Emoji,
+    Notice,
+    Poke,
+    Image,
+    Sticker,
+    Record,
+    File,
+    Video,
+    BaseMediaElement,
+)
+
+
+# ── _infer_mime_from_bytes ──────────────────────────────────────────
+
+def test_infer_png():
+    data = b'\x89PNG\r\n\x1a\n' + b'\x00' * 8
+    assert _infer_mime_from_bytes(data) == "image/png"
+
+
+def test_infer_gif():
+    data = b'GIF89a' + b'\x00' * 8
+    assert _infer_mime_from_bytes(data) == "image/gif"
+
+
+def test_infer_webp():
+    data = b'RIFF' + b'\x00' * 4 + b'WEBP' + b'\x00' * 4
+    assert _infer_mime_from_bytes(data) == "image/webp"
+
+
+def test_infer_jpeg():
+    data = b'\xff\xd8\xff\xe0' + b'\x00' * 8
+    assert _infer_mime_from_bytes(data) == "image/jpeg"
+
+
+def test_infer_bmp():
+    data = b'BM' + b'\x00' * 10
+    assert _infer_mime_from_bytes(data) == "image/bmp"
+
+
+def test_infer_unknown():
+    data = b'\x00\x01\x02\x03\x04'
+    assert _infer_mime_from_bytes(data) is None
+
+
+def test_infer_short_data():
+    assert _infer_mime_from_bytes(b'\x00\x01') is None
+
+
+def test_infer_empty():
+    assert _infer_mime_from_bytes(b'') is None
+
+
+# ── check_base64 ────────────────────────────────────────────────────
+
+def test_check_base64_valid():
+    encoded = base64.b64encode(b"hello world").decode()
+    assert check_base64(encoded) is True
+
+
+def test_check_base64_invalid():
+    assert check_base64("not!!!valid!!!base64!!!") is False
+
+
+def test_check_base64_empty():
+    assert check_base64("") is True
+
+
+# ── Text / At / Reply / Emoji / Notice / Poke elements ─────────────
+
+def test_text_element():
+    t = Text("hello")
+    assert t.type == ElementType.Text
+    assert t.repr == "hello"
+
+
+def test_at_element():
+    a = At("123", nickname="Alice")
+    assert a.type == ElementType.At
+    assert a.repr == "[At Alice(123)]"
+
+
+def test_at_element_no_nickname():
+    a = At("456")
+    assert a.repr == "[At 456]"
+
+
+def test_reply_element():
+    r = Reply("msg_001")
+    assert r.type == ElementType.Reply
+    assert r.repr == "[Reply msg_001]"
+
+
+def test_emoji_element():
+    e = Emoji("emoji_123", emoji_desc="smile")
+    assert e.repr == "[Emoji smile(ID: emoji_123)]"
+
+
+def test_emoji_element_no_desc():
+    e = Emoji("emoji_123")
+    assert e.repr == "[Emoji emoji_123]"
+
+
+def test_notice_element():
+    n = Notice("system notice")
+    assert n.type == ElementType.Notice
+    assert n.repr == "[Notice system notice]"
+
+
+def test_poke_element():
+    p = Poke("user_1")
+    assert p.type == ElementType.Poke
+    assert p.repr == "[Poke user_1]"
+
+
+# ── BaseMediaElement.check_file_type ────────────────────────────────
+
+def test_check_file_type_url():
+    img = Image("https://example.com/pic.png")
+    assert img.file_type == "url"
+
+
+def test_check_file_type_data_url():
+    img = Image("data:image/png;base64,AAAA")
+    assert img.file_type == "data_url"
+
+
+def test_check_file_type_base64_prefix():
+    b64 = base64.b64encode(b"test").decode()
+    img = Image(f"base64://{b64}")
+    assert img.file_type == "base64"
+
+
+def test_check_file_type_file_url():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
+        tmp.write(b'\x89PNG\r\n\x1a\n' + b'\x00' * 16)
+        tmp_path = tmp.name
+    try:
+        img = Image(f"file:///{tmp_path}")
+        assert img.file_type == "path"
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_check_file_type_local_path():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
+        tmp.write(b'\x89PNG\r\n\x1a\n' + b'\x00' * 16)
+        tmp_path = tmp.name
+    try:
+        img = Image(tmp_path)
+        assert img.file_type == "path"
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_check_file_type_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown file type"):
+        Image("not_a_real_file_xyz")
+
+
+# ── BaseMediaElement._guess_mime ────────────────────────────────────
+
+def test_guess_mime_from_data_url():
+    img = Image("data:image/png;base64,AAAA")
+    assert img.mime == "image/png"
+
+
+def test_guess_mime_from_url_extension():
+    img = Image("https://example.com/photo.jpg")
+    assert img.mime == "image/jpeg"
+
+
+def test_guess_mime_fallback_jpeg():
+    b64 = base64.b64encode(b"random").decode()
+    img = Image(f"base64://{b64}")
+    assert img.mime == "image/jpeg"
+
+
+# ── BaseMediaElement.guess_name ─────────────────────────────────────
+
+def test_guess_name_explicit():
+    img = Image("https://example.com/a.png", name="my_photo.png")
+    assert img.guess_name() == "my_photo.png"
+
+
+def test_guess_name_from_url():
+    img = Image("https://example.com/path/to/image.png")
+    assert img.guess_name() == "image.png"
+
+
+# ── Image element ───────────────────────────────────────────────────
+
+def test_image_repr():
+    img = Image("https://example.com/pic.png")
+    assert img.repr == "[Image]"
+
+
+def test_image_default_mime():
+    b64 = base64.b64encode(b"random").decode()
+    img = Image(f"base64://{b64}")
+    assert img.mime == "image/jpeg"
+
+
+# ── Sticker element ─────────────────────────────────────────────────
+
+def test_sticker_repr_with_id():
+    s = Sticker(sticker_id="abc", sticker="https://example.com/s.png")
+    assert s.repr == "[Sticker abc]"
+
+
+def test_sticker_repr_no_id():
+    s = Sticker(sticker="https://example.com/s.png")
+    assert s.repr == "[Sticker]"
+
+
+# ── Record element ──────────────────────────────────────────────────
+
+def test_record_repr():
+    r = Record(record="https://example.com/audio.mp3")
+    assert r.repr == "[Record]"
+
+
+# ── File element ────────────────────────────────────────────────────
+
+def test_file_repr_with_name():
+    f = File(file="https://example.com/doc.pdf", name="doc.pdf")
+    assert f.repr == "[File doc.pdf]"
+
+
+def test_file_repr_no_name():
+    f = File(file="https://example.com/file")
+    assert f.repr == "[File]"
+
+
+# ── Video element ───────────────────────────────────────────────────
+
+def test_video_repr_with_name():
+    v = Video(file="https://example.com/vid.mp4", name="vid.mp4")
+    assert v.repr == "[Video vid.mp4]"
+
+
+# ── Element __repr__ ────────────────────────────────────────────────
+
+def test_element_dunder_repr():
+    t = Text("hello")
+    assert repr(t) == "Text(hello)"

--- a/tests/test_message_utils.py
+++ b/tests/test_message_utils.py
@@ -1,0 +1,311 @@
+import copy
+import pytest
+
+from core.chat.message_elements import Text, At, Image, Emoji, Notice, Poke, Sticker, Record
+from core.chat.message_utils import MessageChain, KiraMessageEvent, KiraIMMessage
+from core.chat.session import Session, User, Group
+
+
+# ── MessageChain basics ─────────────────────────────────────────────
+
+def test_chain_init_empty():
+    c = MessageChain()
+    assert c.is_empty()
+    assert len(c) == 0
+    assert bool(c) is False
+
+
+def test_chain_init_with_elements():
+    t1 = Text("a")
+    t2 = Text("b")
+    c = MessageChain([t1, t2])
+    assert len(c) == 2
+    assert bool(c) is True
+
+
+def test_chain_getitem():
+    t = Text("x")
+    c = MessageChain([t])
+    assert c[0] is t
+
+
+def test_chain_setitem():
+    t1 = Text("a")
+    t2 = Text("b")
+    c = MessageChain([t1])
+    c[0] = t2
+    assert c[0] is t2
+
+
+def test_chain_delitem():
+    c = MessageChain([Text("a"), Text("b")])
+    del c[0]
+    assert len(c) == 1
+    assert c[0].text == "b"
+
+
+def test_chain_contains():
+    t = Text("hi")
+    c = MessageChain([t])
+    assert t in c
+    assert Text("no") not in c
+
+
+def test_chain_iter():
+    elems = [Text("a"), Text("b")]
+    c = MessageChain(elems)
+    assert list(c) == elems
+
+
+def test_chain_copy():
+    t = Text("orig")
+    c1 = MessageChain([t])
+    c2 = c1.__copy__()
+    assert c1 is not c2
+    assert c1[0] is c2[0]
+    assert len(c2) == 1
+
+
+# ── MessageChain + operator ─────────────────────────────────────────
+
+def test_chain_add_chain():
+    c1 = MessageChain([Text("a")])
+    c2 = MessageChain([Text("b")])
+    c3 = c1 + c2
+    assert len(c3) == 2
+    assert c3[0].text == "a"
+    assert c3[1].text == "b"
+
+
+def test_chain_add_element():
+    c1 = MessageChain([Text("a")])
+    c2 = c1 + Text("b")
+    assert len(c2) == 2
+    assert c2[1].text == "b"
+
+
+def test_chain_add_list():
+    c1 = MessageChain([Text("a")])
+    c2 = c1 + [Text("b"), Text("c")]
+    assert len(c2) == 3
+
+
+def test_chain_add_unsupported():
+    c = MessageChain()
+    with pytest.raises(TypeError):
+        c + "string"
+
+
+# ── MessageChain += operator ────────────────────────────────────────
+
+def test_chain_iadd_chain():
+    c = MessageChain([Text("a")])
+    c += MessageChain([Text("b")])
+    assert len(c) == 2
+
+
+def test_chain_iadd_element():
+    c = MessageChain([Text("a")])
+    c += Text("b")
+    assert len(c) == 2
+    assert c[1].text == "b"
+
+
+def test_chain_iadd_list():
+    c = MessageChain()
+    c += [Text("x")]
+    assert len(c) == 1
+
+
+def test_chain_iadd_unsupported():
+    c = MessageChain()
+    result = c.__iadd__("bad")
+    assert result is NotImplemented
+
+
+# ── MessageChain helper methods ─────────────────────────────────────
+
+def test_chain_append():
+    c = MessageChain()
+    c.append(Text("x"))
+    assert len(c) == 1
+
+
+def test_chain_extend():
+    c = MessageChain()
+    c.extend([Text("a"), Text("b")])
+    assert len(c) == 2
+
+
+def test_chain_builder_text():
+    c = MessageChain()
+    c.text("hello")
+    assert c[0].text == "hello"
+
+
+def test_chain_builder_at():
+    c = MessageChain()
+    c.at("123", "Alice")
+    assert c[0].pid == "123"
+
+
+def test_chain_builder_emoji():
+    c = MessageChain()
+    c.emoji("e1")
+    assert c[0].emoji_id == "e1"
+
+
+def test_chain_builder_notice():
+    c = MessageChain()
+    c.notice("test notice")
+    assert c[0].text == "test notice"
+
+
+def test_chain_builder_poke():
+    c = MessageChain()
+    c.poke("user1")
+    assert c[0].pid == "user1"
+
+
+def test_chain_builder_sticker():
+    c = MessageChain()
+    c.message_list.append(Sticker(sticker_id="s1", sticker="https://example.com/sticker.png"))
+    assert c[0].sticker_id == "s1"
+
+
+def test_chain_builder_record():
+    c = MessageChain()
+    c.record("https://example.com/audio.mp3")
+    assert c[0].file == "https://example.com/audio.mp3"
+
+
+def test_chain_builder_reply_empty():
+    c = MessageChain()
+    c.reply("msg_1")
+    assert len(c) == 1
+    assert c[0].message_id == "msg_1"
+
+
+def test_chain_builder_reply_non_empty():
+    c = MessageChain([Text("hi")])
+    c.reply("msg_1")
+    assert len(c) == 1
+
+
+# ── MessageChain repr ───────────────────────────────────────────────
+
+def test_chain_repr():
+    c = MessageChain([Text("a")])
+    assert "MessageChain" in repr(c)
+
+
+# ── KiraIMMessage ───────────────────────────────────────────────────
+
+def test_im_message_is_group():
+    msg = KiraIMMessage(
+        message_id="m1", self_id="bot",
+        chain=MessageChain(), timestamp=0,
+        group=Group(group_id="g1"),
+    )
+    assert msg.is_group_message() is True
+
+
+def test_im_message_is_not_group():
+    msg = KiraIMMessage(
+        message_id="m1", self_id="bot",
+        chain=MessageChain(), timestamp=0,
+    )
+    assert msg.is_group_message() is False
+
+
+# ── Session ─────────────────────────────────────────────────────────
+
+def test_session_sid():
+    s = Session(adapter_name="tg", session_type="gm", session_id="g1")
+    assert s.sid == "tg:gm:g1"
+
+
+def test_session_str():
+    s = Session(adapter_name="tg", session_type="dm", session_id="u1")
+    assert str(s) == "tg:dm:u1"
+
+
+# ── KiraMessageEvent process_strategy ───────────────────────────────
+
+def _make_event():
+    user = User(user_id="u1", nickname="Alice")
+    group = Group(group_id="g1", group_name="TestGroup")
+    msg = KiraIMMessage(
+        message_id="m1", self_id="bot",
+        chain=MessageChain([Text("hi")]),
+        timestamp=1, sender=user, group=group,
+    )
+    adapter = type("A", (), {"name": "test_adapter"})()
+    return KiraMessageEvent(
+        message_types=[], timestamp=1, message=msg, adapter=adapter
+    )
+
+
+def test_event_default_strategy_is_discard():
+    evt = _make_event()
+    assert evt.process_strategy == "discard"
+
+
+def test_event_trigger():
+    evt = _make_event()
+    assert evt.trigger() is True
+    assert evt.process_strategy == "trigger"
+
+
+def test_event_buffer():
+    evt = _make_event()
+    assert evt.buffer() is True
+    assert evt.process_strategy == "buffer"
+
+
+def test_event_flush():
+    evt = _make_event()
+    assert evt.flush() is True
+    assert evt.process_strategy == "flush"
+
+
+def test_event_discard():
+    evt = _make_event()
+    evt.trigger()
+    assert evt.discard() is True
+    assert evt.process_strategy == "discard"
+
+
+def test_event_force_locks_strategy():
+    evt = _make_event()
+    evt.trigger(force=True)
+    assert evt.trigger() is False
+    assert evt.buffer() is False
+    assert evt.flush() is False
+    assert evt.discard() is False
+    assert evt.process_strategy == "trigger"
+
+
+def test_event_stop():
+    evt = _make_event()
+    assert evt.is_stopped is False
+    evt.stop()
+    assert evt.is_stopped is True
+
+
+def test_event_is_group_message():
+    evt = _make_event()
+    assert evt.is_group_message() is True
+
+
+def test_event_properties():
+    evt = _make_event()
+    assert evt.extra is None
+    assert evt.raw_message is None
+    assert evt.is_mentioned is None
+    assert evt.is_notice is False
+
+
+def test_event_message_repr():
+    evt = _make_event()
+    assert "hi" in evt.message_repr


### PR DESCRIPTION
## Summary

Add 162 unit tests covering 5 core modules, and a GitHub Actions CI workflow to run them automatically.

## Type of change

- [x] test: Adding or updating tests
- [x] chore: Build, CI, dependencies, or other maintenance

## Changes

- **New test files:**
  - `tests/test_github_api.py` — `parse_github_url` (8 URL formats + error cases), `verify_sha256` (5 edge cases)
  - `tests/test_config_field.py` — all 15 field types construction and serialization, `create_field_from_schema` factory dispatch, `build_fields`
  - `tests/test_config_loader.py` — `_deep_update` recursive merge, `get_config` dot-path traversal with defaults, `__getattr__`/`__setattr__`/`__delattr__`
  - `tests/test_message_elements.py` — MIME magic-byte detection, base64 validation, file type inference, `guess_name`
  - `tests/test_message_utils.py` — `MessageChain` all dunder methods and builders, `KiraMessageEvent` 4 strategy modes, `Session.sid`
- **New config files:**
  - `tests/conftest.py` — restrict anyio to asyncio backend only (aiosqlite does not support trio)
  - `.github/workflows/tests.yml` — run tests on push/PR to main/dev (Python 3.10-3.12)

## Checklist

- [x] I have tested these changes locally (`pytest tests/ -v` — 162 passed, 0 warnings)
- [ ] I have updated documentation if needed (N/A)
- [ ] New dependencies have been added to `requirements.txt` (if applicable) (N/A)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer (N/A)
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive test suites covering configuration fields and loader behavior, database manager/service operations, message elements/utilities, and GitHub API utilities; includes async and sync tests and fixtures.
* **Chores**
  * Added CI workflow to run the full test suite on push and pull requests against main and dev across Python 3.10–3.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->