### PR TITLE
feat(config): add network settings with PyPI mirror and HTTP proxy

### DIFF
--- a/core/config/config_loader.py
+++ b/core/config/config_loader.py
@@ -27,7 +27,7 @@ class KiraConfig(dict):
     def _load_config(self):
         """Load config from JSON or create default file"""
         self.update(self.default_config)
-        
+
         if os.path.exists(CONFIG_PATH):
             try:
                 with open(CONFIG_PATH, "r", encoding="utf-8") as f:
@@ -35,7 +35,7 @@ class KiraConfig(dict):
                 self._deep_update(self, data)
             except Exception as e:
                 logger.error(f"Error loading JSON config: {e}")
-        
+
         self.save_config()
 
     def _deep_update(self, target: dict, source: dict):

--- a/core/config/default.py
+++ b/core/config/default.py
@@ -41,7 +41,8 @@ DEFAULT_CONFIG = {
     },
     "adapters": {},  # ID: Adapter config dict
     "network": {
-        "pypi_mirror": None
+        "pypi_mirror": None,
+        "http_proxy": None
     },
     "telemetry": {
         "enabled": True,

--- a/core/config/default.py
+++ b/core/config/default.py
@@ -40,6 +40,9 @@ DEFAULT_CONFIG = {
         "default_video": None
     },
     "adapters": {},  # ID: Adapter config dict
+    "network": {
+        "pypi_mirror": None
+    },
     "telemetry": {
         "enabled": True,
         "client_uuid": None,

--- a/core/lifecycle.py
+++ b/core/lifecycle.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import time
 from typing import Optional
 
@@ -84,6 +85,13 @@ class KiraLifecycle:
                 task = self.tasks[i]
                 logger.error(f"Scheduled task '{task.get_name()}' failed: {result}")
 
+    def _apply_network_env(self):
+        proxy = (self.kira_config.get("network") or {}).get("http_proxy")
+        if proxy:
+            os.environ["HTTP_PROXY"] = proxy
+            os.environ["HTTPS_PROXY"] = proxy
+            logger.info(f"HTTP proxy set from config: {proxy}")
+
     async def init_and_run_system(self):
         """主函数：负责启动和初始化各个模块"""
         logger.info(f"✨ Starting KiraAI {VERSION}...")
@@ -93,6 +101,9 @@ class KiraLifecycle:
 
         # ====== init KiraAI config ======
         self.kira_config = KiraConfig()
+
+        # ====== apply network proxy config ======
+        self._apply_network_env()
 
         # ====== apply logging config ======
         setup_logging(

--- a/core/lifecycle.py
+++ b/core/lifecycle.py
@@ -86,11 +86,18 @@ class KiraLifecycle:
                 logger.error(f"Scheduled task '{task.get_name()}' failed: {result}")
 
     def _apply_network_env(self):
-        proxy = (self.kira_config.get("network") or {}).get("http_proxy")
+        network = self.kira_config.get("network") or {}
+        proxy = network.get("http_proxy")
         if proxy:
-            os.environ["HTTP_PROXY"] = proxy
-            os.environ["HTTPS_PROXY"] = proxy
-            logger.info(f"HTTP proxy set from config: {proxy}")
+            if not proxy.startswith(("http://", "https://")):
+                logger.warning(f"Ignoring invalid http_proxy (must start with http:// or https://): {proxy}")
+            else:
+                os.environ["HTTP_PROXY"] = proxy
+                os.environ["HTTPS_PROXY"] = proxy
+                logger.info(f"HTTP proxy set from config: {proxy}")
+        mirror = network.get("pypi_mirror")
+        if mirror and not mirror.startswith(("http://", "https://")):
+            logger.warning(f"Ignoring invalid pypi_mirror (must start with http:// or https://): {mirror}")
 
     async def init_and_run_system(self):
         """主函数：负责启动和初始化各个模块"""

--- a/core/plugin/plugin_installer.py
+++ b/core/plugin/plugin_installer.py
@@ -107,7 +107,7 @@ async def install_from_zip(
     return await _extract_and_install(temp_zip, plugins_dir, preferred_name=preferred_name)
 
 
-async def install_requirements(plugin_dir: Path) -> List[str]:
+async def install_requirements(plugin_dir: Path, pypi_mirror: Optional[str] = None) -> List[str]:
     """
     Install dependencies listed in the plugin's requirements.txt using pip.
 
@@ -120,9 +120,12 @@ async def install_requirements(plugin_dir: Path) -> List[str]:
         return []
 
     logger.info(f"Installing requirements for plugin at {plugin_dir}")
+    pip_cmd = [sys.executable, "-m", "pip", "install", "-r", str(req_file)]
+    if pypi_mirror:
+        pip_cmd.extend(["-i", pypi_mirror])
     try:
         proc = await asyncio.create_subprocess_exec(
-            sys.executable, "-m", "pip", "install", "-r", str(req_file),
+            *pip_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )

--- a/core/plugin/plugin_installer.py
+++ b/core/plugin/plugin_installer.py
@@ -122,7 +122,10 @@ async def install_requirements(plugin_dir: Path, pypi_mirror: Optional[str] = No
     logger.info(f"Installing requirements for plugin at {plugin_dir}")
     pip_cmd = [sys.executable, "-m", "pip", "install", "-r", str(req_file)]
     if pypi_mirror:
-        pip_cmd.extend(["-i", pypi_mirror])
+        if pypi_mirror.startswith(("http://", "https://")):
+            pip_cmd.extend(["-i", pypi_mirror])
+        else:
+            logger.warning(f"Ignoring invalid pypi_mirror (must start with http:// or https://): {pypi_mirror}")
     try:
         proc = await asyncio.create_subprocess_exec(
             *pip_cmd,

--- a/webui/frontend/src/components/icons.ts
+++ b/webui/frontend/src/components/icons.ts
@@ -204,6 +204,11 @@ export const IconUser = svgIcon(
   '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />',
 )
 
+// ── Network & Connectivity ───────────────────────────────────────────
+export const IconGlobe = svgIcon(
+  '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />',
+)
+
 // ── Settings & Configuration ──────────────────────────────────────────
 export const IconCog = svgIcon(
   '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />',

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -523,6 +523,7 @@ export default {
       log_file_path: 'Path to the log file, leave empty for default',
       log_file_max_size: 'Maximum size of a single log file in megabytes',
       pypi_mirror: 'Custom PyPI package index URL for plugin dependency installation. Leave empty to use the default',
+      http_proxy: 'HTTP proxy address, sets HTTP_PROXY and HTTPS_PROXY environment variables for all network requests. Leave empty to use system default',
     },
     validation: {
       required: 'This field is required',
@@ -555,6 +556,7 @@ export default {
       log_file_path: 'Log File Path',
       log_file_max_size: 'Max Log File Size (MB)',
       pypi_mirror: 'PyPI Mirror',
+      http_proxy: 'HTTP Proxy',
     },
     model: {
       section_title: 'Default Models',

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -503,6 +503,8 @@ export default {
       cache_desc: 'Temporary file cache management parameters',
       logging: 'Logging Settings',
       logging_desc: 'Terminal and file logging configuration',
+      network: 'Network Settings',
+      network_desc: 'Network and package source configuration',
     },
     hints: {
       max_memory_length: 'Maximum number of messages retained in context window',
@@ -520,6 +522,7 @@ export default {
       log_level: 'Minimum log level displayed in the terminal',
       log_file_path: 'Path to the log file, leave empty for default',
       log_file_max_size: 'Maximum size of a single log file in megabytes',
+      pypi_mirror: 'Custom PyPI package index URL for plugin dependency installation. Leave empty to use the default',
     },
     validation: {
       required: 'This field is required',
@@ -551,6 +554,7 @@ export default {
       log_level: 'Log Level',
       log_file_path: 'Log File Path',
       log_file_max_size: 'Max Log File Size (MB)',
+      pypi_mirror: 'PyPI Mirror',
     },
     model: {
       section_title: 'Default Models',

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -523,7 +523,7 @@ export default {
       log_file_path: 'Path to the log file, leave empty for default',
       log_file_max_size: 'Maximum size of a single log file in megabytes',
       pypi_mirror: 'Custom PyPI package index URL for plugin dependency installation. Leave empty to use the default',
-      http_proxy: 'HTTP proxy address, sets HTTP_PROXY and HTTPS_PROXY environment variables for all network requests. Leave empty to use system default',
+      http_proxy: 'HTTP proxy address, sets HTTP_PROXY and HTTPS_PROXY environment variables. Restart required to take effect. Leave empty to use system default',
     },
     validation: {
       required: 'This field is required',
@@ -532,6 +532,7 @@ export default {
       min: 'Minimum value is',
       max: 'Maximum value is',
       has_errors: 'Please fix validation errors',
+      url_invalid: 'Please enter a valid URL starting with http:// or https://',
     },
     tab_message: 'Message',
     tab_model: 'Model',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -503,6 +503,8 @@ export default {
       cache_desc: '临时文件缓存管理参数',
       logging: '日志设置',
       logging_desc: '终端和文件日志配置',
+      network: '网络设置',
+      network_desc: '网络和包源配置',
     },
     hints: {
       max_memory_length: '上下文窗口中保留的最大消息数',
@@ -520,6 +522,7 @@ export default {
       log_level: '终端显示的最低日志等级',
       log_file_path: '日志文件路径，留空使用默认路径',
       log_file_max_size: '单个日志文件的最大体积（MB）',
+      pypi_mirror: '自定义 PyPI 包索引 URL，用于安装插件依赖。留空使用默认源',
     },
     validation: {
       required: '此字段为必填项',
@@ -551,6 +554,7 @@ export default {
       log_level: '日志等级',
       log_file_path: '日志文件路径',
       log_file_max_size: '日志文件最大体积（MB）',
+      pypi_mirror: 'PyPI 镜像源',
     },
     model: {
       section_title: '默认模型',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -523,7 +523,7 @@ export default {
       log_file_path: '日志文件路径，留空使用默认路径',
       log_file_max_size: '单个日志文件的最大体积（MB）',
       pypi_mirror: '自定义 PyPI 包索引 URL，用于安装插件依赖。留空使用默认源',
-      http_proxy: 'HTTP 代理地址，设置 HTTP_PROXY 和 HTTPS_PROXY 环境变量，影响所有网络请求。留空使用系统默认',
+      http_proxy: 'HTTP 代理地址，设置 HTTP_PROXY 和 HTTPS_PROXY 环境变量，重启程序后生效。留空使用系统默认',
     },
     validation: {
       required: '此字段为必填项',
@@ -532,6 +532,7 @@ export default {
       min: '最小值为',
       max: '最大值为',
       has_errors: '请先修复验证错误',
+      url_invalid: '请输入有效的 URL，以 http:// 或 https:// 开头',
     },
     tab_message: '消息',
     tab_model: '模型',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -523,6 +523,7 @@ export default {
       log_file_path: '日志文件路径，留空使用默认路径',
       log_file_max_size: '单个日志文件的最大体积（MB）',
       pypi_mirror: '自定义 PyPI 包索引 URL，用于安装插件依赖。留空使用默认源',
+      http_proxy: 'HTTP 代理地址，设置 HTTP_PROXY 和 HTTPS_PROXY 环境变量，影响所有网络请求。留空使用系统默认',
     },
     validation: {
       required: '此字段为必填项',
@@ -555,6 +556,7 @@ export default {
       log_file_path: '日志文件路径',
       log_file_max_size: '日志文件最大体积（MB）',
       pypi_mirror: 'PyPI 镜像源',
+      http_proxy: 'HTTP 代理',
     },
     model: {
       section_title: '默认模型',

--- a/webui/frontend/src/views/ConfigView.vue
+++ b/webui/frontend/src/views/ConfigView.vue
@@ -458,6 +458,7 @@ const allGroups: ConfigGroup[] = [
     icon: IconGlobe,
     fields: [
       { key: 'network.pypi_mirror', labelKey: 'configuration.message.pypi_mirror', labelFallback: 'PyPI Mirror', hintKey: 'configuration.hints.pypi_mirror', hintFallback: 'Custom PyPI package index URL for plugin dependency installation. Leave empty to use the default', type: 'string', default: '' },
+      { key: 'network.http_proxy', labelKey: 'configuration.message.http_proxy', labelFallback: 'HTTP Proxy', hintKey: 'configuration.hints.http_proxy', hintFallback: 'HTTP proxy address, sets HTTP_PROXY and HTTPS_PROXY environment variables for all network requests. Leave empty to use system default', type: 'string', default: '' },
     ],
   },
   {

--- a/webui/frontend/src/views/ConfigView.vue
+++ b/webui/frontend/src/views/ConfigView.vue
@@ -359,7 +359,7 @@ import {
   IconSearch, IconUndo, IconRedo, IconRefresh, IconExpand, IconCollapse, IconCheck, IconChevronDown,
 } from '@/components/icons'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const route = useRoute()
 
 const searchTerm = ref('')
@@ -395,7 +395,7 @@ interface ConfigField {
   default?: any
   modelType?: string
   selectOptions?: { value: string; label: string }[]
-  validation?: { min?: number; max?: number; required?: boolean }
+  validation?: { min?: number; max?: number; required?: boolean; pattern?: RegExp; patternMessageKey?: string }
 }
 
 interface ConfigGroup {
@@ -457,8 +457,8 @@ const allGroups: ConfigGroup[] = [
     descFallback: 'Network and package source configuration',
     icon: IconGlobe,
     fields: [
-      { key: 'network.pypi_mirror', labelKey: 'configuration.message.pypi_mirror', labelFallback: 'PyPI Mirror', hintKey: 'configuration.hints.pypi_mirror', hintFallback: 'Custom PyPI package index URL for plugin dependency installation. Leave empty to use the default', type: 'string', default: '' },
-      { key: 'network.http_proxy', labelKey: 'configuration.message.http_proxy', labelFallback: 'HTTP Proxy', hintKey: 'configuration.hints.http_proxy', hintFallback: 'HTTP proxy address, sets HTTP_PROXY and HTTPS_PROXY environment variables for all network requests. Leave empty to use system default', type: 'string', default: '' },
+      { key: 'network.pypi_mirror', labelKey: 'configuration.message.pypi_mirror', labelFallback: 'PyPI Mirror', hintKey: 'configuration.hints.pypi_mirror', hintFallback: 'Custom PyPI package index URL for plugin dependency installation. Leave empty to use the default', type: 'string', default: '', validation: { pattern: /^https?:\/\/.+/, patternMessageKey: 'configuration.validation.url_invalid' } },
+      { key: 'network.http_proxy', labelKey: 'configuration.message.http_proxy', labelFallback: 'HTTP Proxy', hintKey: 'configuration.hints.http_proxy', hintFallback: 'HTTP proxy address, sets HTTP_PROXY and HTTPS_PROXY environment variables. Restart required to take effect. Leave empty to use system default', type: 'string', default: '', validation: { pattern: /^https?:\/\/.+/, patternMessageKey: 'configuration.validation.url_invalid' } },
     ],
   },
   {
@@ -717,6 +717,10 @@ function validateField(key: string) {
     validationErrors.value[key] = t('configuration.validation.max', { max: v.max })
     return
   }
+  if (v.pattern && value && !v.pattern.test(String(value))) {
+    validationErrors.value[key] = v.patternMessageKey ? t(v.patternMessageKey) : t('configuration.validation.url_invalid')
+    return
+  }
   delete validationErrors.value[key]
 }
 
@@ -789,6 +793,13 @@ watch(searchTerm, (term) => {
         .some(g => g.fields.some(f => fieldMatchesSearch(f)))
     )
     if (firstMatch) activeTab.value = firstMatch.id
+  }
+})
+
+// Re-validate fields with errors when locale changes
+watch(locale, () => {
+  for (const key of Object.keys(validationErrors.value)) {
+    validateField(key)
   }
 })
 

--- a/webui/frontend/src/views/ConfigView.vue
+++ b/webui/frontend/src/views/ConfigView.vue
@@ -355,7 +355,7 @@ import { notify } from '@/composables/useNotification'
 import { getConfiguration, saveConfiguration } from '@/api/config'
 import CustomSelect from '@/components/common/CustomSelect.vue'
 import {
-  IconMonitor, IconCog, IconImage, IconDatabase, IconFileText, IconFlask,
+  IconMonitor, IconCog, IconImage, IconDatabase, IconFileText, IconFlask, IconGlobe,
   IconSearch, IconUndo, IconRedo, IconRefresh, IconExpand, IconCollapse, IconCheck, IconChevronDown,
 } from '@/components/icons'
 
@@ -450,6 +450,17 @@ const allGroups: ConfigGroup[] = [
     ],
   },
   {
+    id: 'network',
+    labelKey: 'configuration.groups.network',
+    labelFallback: 'Network Settings',
+    descKey: 'configuration.groups.network_desc',
+    descFallback: 'Network and package source configuration',
+    icon: IconGlobe,
+    fields: [
+      { key: 'network.pypi_mirror', labelKey: 'configuration.message.pypi_mirror', labelFallback: 'PyPI Mirror', hintKey: 'configuration.hints.pypi_mirror', hintFallback: 'Custom PyPI package index URL for plugin dependency installation. Leave empty to use the default', type: 'string', default: '' },
+    ],
+  },
+  {
     id: 'cache',
     labelKey: 'configuration.groups.cache',
     labelFallback: 'Cache Settings',
@@ -513,7 +524,7 @@ interface CategoryTab {
 
 const categoryTabs: CategoryTab[] = [
   { id: 'life', labelKey: 'config_tab.life', labelFallback: '数字生命', icon: IconMonitor, groupIds: ['bot', 'agent', 'selfie'] },
-  { id: 'system', labelKey: 'config_tab.system', labelFallback: '系统', icon: IconCog, groupIds: ['cache', 'logging'] },
+  { id: 'system', labelKey: 'config_tab.system', labelFallback: '系统', icon: IconCog, groupIds: ['network', 'cache', 'logging'] },
   { id: 'models', labelKey: 'config_tab.models', labelFallback: '模型', icon: IconFlask, groupIds: ['models'] },
 ]
 

--- a/webui/routes/config.py
+++ b/webui/routes/config.py
@@ -108,6 +108,8 @@ class ConfigRoutes(Routes):
             updated = True
         if updated:
             config.save_config()
+            if isinstance(network_config, dict) and self.lifecycle:
+                self.lifecycle._apply_network_env()
             logger.info("Configuration saved")
         return {
             "status": "ok",

--- a/webui/routes/config.py
+++ b/webui/routes/config.py
@@ -61,6 +61,8 @@ class ConfigRoutes(Routes):
                 "bot_config": bot_config,
                 "models": models,
                 "logging": config.get("logging", {}),
+                "adapters": config.get("adapters", {}),
+                "network": config.get("network", {}),
             },
             "providers": providers,
             "provider_models": provider_models,
@@ -73,6 +75,8 @@ class ConfigRoutes(Routes):
         bot_config = payload.get("bot_config")
         models = payload.get("models")
         logging_config = payload.get("logging")
+        adapters_config = payload.get("adapters")
+        network_config = payload.get("network")
         updated = False
         if isinstance(bot_config, dict):
             config["bot_config"] = bot_config
@@ -96,6 +100,12 @@ class ConfigRoutes(Routes):
                     logger.info("Logging configuration applied")
                 except Exception as e:
                     logger.error(f"Failed to apply logging config, not saving: {e}")
+        if isinstance(adapters_config, dict):
+            config["adapters"] = adapters_config
+            updated = True
+        if isinstance(network_config, dict):
+            config["network"] = network_config
+            updated = True
         if updated:
             config.save_config()
             logger.info("Configuration saved")
@@ -105,5 +115,7 @@ class ConfigRoutes(Routes):
                 "bot_config": config.get("bot_config", {}),
                 "models": config.get("models", {}),
                 "logging": config.get("logging", {}),
+                "adapters": config.get("adapters", {}),
+                "network": config.get("network", {}),
             },
         }

--- a/webui/routes/plugins.py
+++ b/webui/routes/plugins.py
@@ -307,7 +307,7 @@ class PluginsRoutes(Routes):
         except ConnectionError as e:
             raise HTTPException(status_code=422, detail=str(e))
 
-        warnings = await install_requirements(plugin_dir)
+        warnings = await install_requirements(plugin_dir, pypi_mirror=self._get_pypi_mirror())
 
         plugin_id = await plugin_manager.load_plugin_from_dir(plugin_dir)
         if not plugin_id:
@@ -330,13 +330,19 @@ class PluginsRoutes(Routes):
         except (ValueError, IOError) as e:
             raise HTTPException(status_code=422, detail=str(e))
 
-        warnings = await install_requirements(plugin_dir)
+        warnings = await install_requirements(plugin_dir, pypi_mirror=self._get_pypi_mirror())
 
         plugin_id = await plugin_manager.load_plugin_from_dir(plugin_dir)
         if not plugin_id:
             raise HTTPException(status_code=500, detail="Plugin files were installed but failed to load")
 
         return self._build_install_result(plugin_manager, plugin_id, warnings)
+
+    def _get_pypi_mirror(self) -> Optional[str]:
+        config = getattr(self.lifecycle, "kira_config", None)
+        if not config:
+            return None
+        return (config.get("network") or {}).get("pypi_mirror") or None
 
     @staticmethod
     def _build_install_result(plugin_manager, plugin_id: str, warnings: List[str]) -> PluginInstallResult:


### PR DESCRIPTION
## Summary

Add network configuration section to the config view under the system tab, including PyPI mirror URL and HTTP proxy settings. The HTTP proxy sets `HTTP_PROXY`/`HTTPS_PROXY` environment variables so all network requests (httpx, pip, etc.) automatically use it.

## Type of change

- [x] feat: New feature

## Changes

- Add `network` config section (`pypi_mirror`, `http_proxy`) to `default.py`
- Expose `network` config in GET/POST `/api/configuration` API
- Apply `http_proxy` as `HTTP_PROXY`/`HTTPS_PROXY` env vars in `lifecycle.py` on startup and config save
- Pass configured `pypi_mirror` to pip via `-i` flag when installing plugin requirements
- Add "Network Settings" group to config UI (system tab, before cache/logging)
- Add `IconGlobe` icon for the network settings group
- Add i18n translations (zh/en) for all new fields

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable Network Settings (PyPI Mirror, HTTP Proxy) with UI panel and globe icon
  * Proxy settings auto-applied at startup and used when installing plugin dependencies
  * URL format validation for network fields with localized validation messages; UI re-validates on language change
  * API now exposes and accepts the new network configuration section

* **Localization**
  * Added English and Chinese translations for Network Settings and validation text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->