### PR TITLE
feat: install dependencies after update before restart

### DIFF
--- a/webui/routes/releases.py
+++ b/webui/routes/releases.py
@@ -10,6 +10,7 @@ from fastapi import Depends, HTTPException, status
 
 from core.config.default import VERSION
 from core.logging_manager import get_logger
+from core.plugin.plugin_installer import install_requirements
 from core.utils.github_api import download_asset, get_all_releases, pick_fastest_source
 from core.utils.path_utils import get_data_path, get_root_path
 from webui.models import DownloadReleaseRequest, ReleasesResponse
@@ -107,6 +108,14 @@ class ReleasesRoutes(Routes):
                     detail=f"Failed to apply update: {e}",
                 ) from e
             logger.info(f"Update {tag} applied successfully")
+
+            # Install any new dependencies from the updated requirements.txt
+            logger.info("Installing dependencies...")
+            config = getattr(self.lifecycle, "kira_config", None)
+            pypi_mirror = ((config.get("network") or {}).get("pypi_mirror") if config else None)
+            warnings = await install_requirements(get_root_path(), pypi_mirror=pypi_mirror)
+            for w in warnings:
+                logger.warning(f"Dependency install warning: {w}")
 
         # Trigger restart — let the response be sent first, then exit
         logger.info("Scheduling restart after update...")


### PR DESCRIPTION
> **⚠️ Base branch: `dev`.**

## Summary

After applying an update via the WebUI, the system now installs dependencies from the updated `requirements.txt` before restarting. This ensures any new packages required by the updated code are already available when the process restarts. Reuses `install_requirements()` from `plugin_installer` and respects the configured `pypi_mirror`.

## Type of change

- [x] feat: New feature

## Changes

- Reuse `install_requirements()` from `core/plugin/plugin_installer.py` in the update flow
- Install main program dependencies after `_apply_update()` but before restart
- Respect configured `pypi_mirror` for pip; fall back to official PyPI if not set

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dependencies are now automatically installed after each update is applied
  * PyPI mirror configuration settings are recognized and utilized during the installation process
  * Installation-related warnings are logged for visibility and troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->