### PR TITLE
feat: support multi-image path in img tag for image-to-image generation

### DIFF
--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -180,7 +180,7 @@ class LLMClient:
         except Exception as e:
             logger.error(f"Failed to generate image with text: {e}")
 
-    async def image_to_image(self, prompt, image: Image) -> Image:
+    async def image_to_image(self, prompt, image: Union[Image, list[Image]]) -> Image:
         image_model = self.provider_mgr.get_default_image()
         provider_name = image_model.model.provider_name
         model_id = image_model.model.model_id

--- a/core/plugin/builtin_plugins/kira-ai/tags.py
+++ b/core/plugin/builtin_plugins/kira-ai/tags.py
@@ -212,6 +212,8 @@ def build_file_tag():
                 name = Path(value).name
             elif value.startswith("data/"):
                 abs_path = str(get_data_path() / value.removeprefix("data/"))
+                if not os.path.exists(abs_path):
+                    return []
                 file_string = abs_path
                 name = Path(abs_path).name
             # File URL

--- a/core/plugin/builtin_plugins/kira-ai/tags.py
+++ b/core/plugin/builtin_plugins/kira-ai/tags.py
@@ -55,16 +55,37 @@ class AtTag(BaseTag):
 
 class ImgTag(BaseTag):
     name = "img"
-    description = "<img>prompt for image generator</img> # 用于发送图片。请勿滥用，仅在用户请求看照片时使用，需要详细的绘画提示词。"
+    description = "<img path=\"image_path(s)\">prompt for image generator</img> # 用于发送图片。请勿滥用，仅在用户请求看照片时使用，需要详细的绘画提示词。可选属性 path 指定参考图片路径（支持绝对路径、相对路径 data/files/*、data/temp/*），多张图片用英文逗号分隔，使用 path 属性时将基于参考图片进行图生图。"
 
     def __init__(self, ctx):
         super().__init__(ctx=ctx)
 
     async def handle(self, value: str, **kwargs) -> list[BaseMessageElement]:
-        img_res = await self.ctx.llm_api.generate_img(value)
-        if img_res:
-            return [img_res]
-        return []
+        path = kwargs.get("path")
+        if path:
+            # image-to-image mode
+            ref_images = []
+            for p in path.split(","):
+                p = p.strip()
+                if not p:
+                    continue
+                ref_file = Path(p) if Path(p).is_absolute() else get_data_path() / p
+                if not ref_file.is_file():
+                    message_logger.warning(f"Image reference not found: {ref_file}, skipped")
+                    continue
+                img_extension = ref_file.suffix.lstrip(".")
+                bs64 = await image_to_base64(str(ref_file))
+                ref_images.append(Image(image=bs64, name=p, mime=f"image/{img_extension}"))
+            if not ref_images:
+                message_logger.warning("No valid reference images found, falling back to text-to-image")
+                img_res = await self.ctx.llm_api.generate_img(value)
+                return [img_res] if img_res else []
+            img_res = await self.ctx.llm_api.image_to_image(value, image=ref_images)
+            return [img_res] if img_res else []
+        else:
+            # text-to-image mode (original behavior)
+            img_res = await self.ctx.llm_api.generate_img(value)
+            return [img_res] if img_res else []
 
 
 class VideoTag(BaseTag):

--- a/core/plugin/builtin_plugins/kira-ai/tags.py
+++ b/core/plugin/builtin_plugins/kira-ai/tags.py
@@ -66,10 +66,15 @@ class ImgTag(BaseTag):
             # image-to-image mode
             ref_images = []
             for p in path.split(","):
-                p = p.strip()
+                p = p.strip().replace("\\", "/")
                 if not p:
                     continue
-                ref_file = Path(p) if Path(p).is_absolute() else get_data_path() / p
+                if os.path.isabs(p):
+                    ref_file = Path(p)
+                elif p.startswith("data/"):
+                    ref_file = get_data_path() / p.removeprefix("data/")
+                else:
+                    ref_file = get_data_path() / p
                 if not ref_file.is_file():
                     message_logger.warning(f"Image reference not found: {ref_file}, skipped")
                     continue
@@ -159,7 +164,13 @@ class SelfieTag(BaseTag):
             if not ref_img_path:
                 message_logger.warning("Selfie reference image not set, skipped generation")
                 return []
-            ref_file = Path(ref_img_path) if Path(ref_img_path).is_absolute() else get_data_path() / ref_img_path
+            ref_img_path = ref_img_path.replace("\\", "/")
+            if os.path.isabs(ref_img_path):
+                ref_file = Path(ref_img_path)
+            elif ref_img_path.startswith("data/"):
+                ref_file = get_data_path() / ref_img_path.removeprefix("data/")
+            else:
+                ref_file = get_data_path() / ref_img_path
             if ref_file.is_file():
                 img_extension = ref_file.suffix.lstrip(".")
                 bs64 = await image_to_base64(str(ref_file))
@@ -193,11 +204,13 @@ def build_file_tag():
             if not file_type or file_type not in ("image", "record", "video"):
                 file_type = "file"
 
+            value = value.replace("\\", "/")
+
             # Absolute path
             if os.path.exists(value):
                 file_string = value
                 name = Path(value).name
-            elif value.startswith(("data/files/", "data/temp/")):
+            elif value.startswith("data/"):
                 abs_path = str(get_data_path() / value.removeprefix("data/"))
                 file_string = abs_path
                 name = Path(abs_path).name

--- a/core/prompts/agent_tmpl.py
+++ b/core/prompts/agent_tmpl.py
@@ -105,6 +105,11 @@ format_tmpl = """\
     <img>an island near sea, with seagulls, moon shining over the sea</img>
 </msg>
 
+基于参考图片生图示例（支持多张参考图，逗号分隔）：
+<msg>
+    <img path="data/files/ref.png">make the character wear a red hat</img>
+</msg>
+
 错误示例（绝对不要这样写）：
 - 裸文本：你好啊（缺少<msg><text>包裹，消息不会发出）
 - 嵌套标签：<msg><text>hello<emoji>21</emoji></text></msg>（emoji在text内部，会解析失败）

--- a/core/provider/provider.py
+++ b/core/provider/provider.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod, ABC
 from enum import Enum, auto
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Union
 import asyncio
 
 from .llm_model import LLMRequest, LLMResponse, RerankResult
@@ -105,7 +105,7 @@ class ImageModelClient(BaseModelClient):
     async def text_to_image(self, prompt: str) -> Image:
         pass
 
-    async def image_to_image(self, prompt: str, image: Image) -> Image:
+    async def image_to_image(self, prompt: str, image: Union[Image, list[Image]]) -> Image:
         pass
 
 

--- a/core/provider/src/openai/model_clients.py
+++ b/core/provider/src/openai/model_clients.py
@@ -1,7 +1,7 @@
 from openai import AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionError
 import re
 import time
-from typing import Optional
+from typing import Optional, Union
 
 from core.provider import ModelInfo
 from core.provider import LLMModelClient, ImageModelClient, EmbeddingModelClient
@@ -232,7 +232,9 @@ class OpenAIImageClient(ImageModelClient):
             ("http://", "https://")
         )
 
-    async def image_to_image(self, prompt: str, image: Image) -> Image:
+    async def image_to_image(self, prompt: str, image: Union[Image, list[Image]]) -> Image:
+        if isinstance(image, Image):
+            image = [image]
         endpoint = self.model.model_config.get("endpoint", "v1/image")
         if endpoint == "v1/chat":
             return await self._image_to_image_via_chat(prompt, image)
@@ -240,18 +242,17 @@ class OpenAIImageClient(ImageModelClient):
 
     # ──────── image-to-image Mode A: /v1/images/generations ────────
 
-    async def _image_to_image_via_generations(self, prompt: str, image: Image) -> Image:
+    async def _image_to_image_via_generations(self, prompt: str, images: list[Image]) -> Image:
         client = self._build_client()
         image_size = self.model.model_config.get("size", None)
-        # Convert the input image to a data URL that the API can consume
-        image_data_url = await image.to_data_url()
+        image_data_urls = [await img.to_data_url() for img in images]
         try:
             images_response = await client.images.generate(
                 model=self.model.model_id,
                 prompt=prompt,
                 size=image_size if image_size else None,
                 response_format="url",
-                extra_body={"watermark": False, "image": [image_data_url]},
+                extra_body={"watermark": False, "image": image_data_urls},
             )
             return Image(image=images_response.data[0].url)
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:
@@ -263,16 +264,13 @@ class OpenAIImageClient(ImageModelClient):
 
     # ──────── image-to-image Mode B: /v1/chat/completions ────────
 
-    async def _image_to_image_via_chat(self, prompt: str, image: Image) -> Image:
+    async def _image_to_image_via_chat(self, prompt: str, images: list[Image]) -> Image:
         client = self._build_client()
-        image_data_url = await image.to_data_url()
-        messages = [{
-            "role": "user",
-            "content": [
-                {"type": "text", "text": prompt},
-                {"type": "image_url", "image_url": {"url": image_data_url}},
-            ],
-        }]
+        content = [{"type": "text", "text": prompt}]
+        for img in images:
+            image_data_url = await img.to_data_url()
+            content.append({"type": "image_url", "image_url": {"url": image_data_url}})
+        messages = [{"role": "user", "content": content}]
         try:
             response = await client.chat.completions.create(
                 model=self.model.model_id,

--- a/core/provider/src/volcengine/model_clients.py
+++ b/core/provider/src/volcengine/model_clients.py
@@ -1,7 +1,7 @@
 from openai import AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionError
 import time
 import httpx
-from typing import Optional
+from typing import Optional, Union
 
 from core.provider import ModelInfo, ImageModelClient, VideoModelClient, EmbeddingModelClient
 from core.logging_manager import get_logger
@@ -38,14 +38,10 @@ class VolcengineImageClient(ImageModelClient):
 
         return Image(image=images_response.data[0].url)
 
-    async def image_to_image(self, prompt: str, image: Image) -> Image:
-        # if url:
-        #     ref_img = url
-        # elif base64:
-        #     ref_img = base64
-        # else:
-        #     ref_img = None
-        ref_img = await image.to_data_url()
+    async def image_to_image(self, prompt: str, image: Union[Image, list[Image]]) -> Image:
+        if isinstance(image, Image):
+            image = [image]
+        ref_imgs = [await img.to_data_url() for img in image]
 
         client = AsyncOpenAI(
             base_url=self.model.provider_config.get("base_url", "https://ark.cn-beijing.volces.com/api/v3"),
@@ -58,7 +54,7 @@ class VolcengineImageClient(ImageModelClient):
             size=image_size if image_size else None,
             response_format="url",
             extra_body={
-                "image": ref_img,
+                "image": ref_imgs,
                 "watermark": False
             }
         )


### PR DESCRIPTION
> **⚠️ Base branch: `dev`**

## Summary

Add `path` attribute to `<img>` tag, enabling AI to specify reference image path(s) for image-to-image generation. Supports multiple images via comma-separated paths.

## Type of change

- [x] feat: New feature

## Changes

- `core/plugin/builtin_plugins/kira-ai/tags.py` — ImgTag parses `path` attr, loads images, calls `image_to_image`; falls back to text-to-image if no valid images found
- `core/provider/provider.py` — Base class signature updated to `Union[Image, list[Image]]`
- `core/provider/src/openai/model_clients.py` — Both generations and chat mode support multi-image
- `core/provider/src/volcengine/model_clients.py` — Same multi-image support
- `core/llm_client.py` — Signature sync
- `core/prompts/agent_tmpl.py` — Add img2img usage example in prompt

## Usage

```xml
<!-- Text-to-image (unchanged) -->
<img>a cute cat</img>

<!-- Single reference image -->
<img path="data/files/ref.png">make it wear a hat</img>

<!-- Multiple reference images -->
<img path="data/files/a.png,data/files/b.png">combine these styles</img>
```

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image-to-image generation now accepts multiple reference images (comma-separated) for richer results.
  * Image tag gains an optional path attribute to load one or more reference images for generation.

* **Improvements**
  * Reference path handling normalized (slashes) and expanded to recognize data/... local files.
  * Missing or invalid reference files are skipped with warnings and fallback to text-to-image when none remain.

* **Documentation**
  * Agent templates updated with examples showing reference-image workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->