### PR TITLE
fix: TagInput not adding items on mobile Enter key press

### DIFF
--- a/webui/frontend/src/components/common/TagInput.vue
+++ b/webui/frontend/src/components/common/TagInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="tag-input" ref="containerRef">
-    <div class="tag-input-wrapper" @click="focusInput">
+    <form class="tag-input-wrapper" @click="focusInput" @submit.prevent="addItem" @keydown.enter.prevent>
       <template v-for="(item, idx) in modelValue" :key="idx">
         <span
           v-if="editingIndex !== idx"
@@ -16,6 +16,8 @@
           v-else
           ref="editInputRef"
           :value="editDraft"
+          inputmode="text"
+          enterkeyhint="enter"
           class="tag-input-edit"
           @input="editDraft = ($event.target as HTMLInputElement).value"
           @keydown.enter.prevent="commitEdit"
@@ -27,12 +29,14 @@
         ref="inputRef"
         v-model="draft"
         type="text"
+        inputmode="text"
+        enterkeyhint="enter"
         class="tag-input-field"
         :placeholder="modelValue.length === 0 ? (placeholder || '') : ''"
         @keydown.enter.prevent="addItem"
         @keydown.backspace="onBackspace"
       />
-    </div>
+    </form>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary

Fix mobile TagInput: pressing Enter on the virtual keyboard now correctly adds list items instead of jumping focus to the next config field. Fixes the issue reported in ConfigForm where `list` type fields were unusable on mobile.

## Type of change

- [x] fix: Bug fix

## Changes

- Wrap `tag-input-wrapper` in `<form>` with `@submit.prevent` as fallback for mobile where `keydown.enter` may not fire
- Add `@keydown.enter.prevent` at form level to stop Enter event propagation to parent elements
- Add `inputmode="text"` and `enterkeyhint="enter"` to both inputs so mobile keyboard shows Enter key instead of Go/Next/Send

## Screenshots / Logs

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag input keyboard experience with enhanced Enter key handling, better form submission control, and optimized mobile input modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->