### PR TITLE
feat: auto-install missing plugin dependencies on load and startup

### DIFF
--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -406,6 +406,9 @@ class PluginManager:
     def list_plugins(self) -> List[PluginInfo]:
         return list(_plugin_infos.values())
 
+    def get_plugin_info(self, plugin_id: str) -> Optional[PluginInfo]:
+        return _plugin_infos.get(plugin_id)
+
     def get_plugin_manifest(self, name: str) -> Dict[str, Any]:
         return _plugin_manifests.get(name, {})
 
@@ -994,6 +997,7 @@ class PluginManager:
             initialized = True
         except Exception as e:
             logger.error(f"Failed to initialize plugin {plugin_id}: {e}")
+            self.plugin_instances.pop(plugin_id, None)
         if initialized:
             self._register_plugin_tools_for(plugin_id)
             self._register_plugin_hooks_for(plugin_id)
@@ -1161,6 +1165,8 @@ class PluginManager:
 
     @staticmethod
     def _build_plugin_info(plugin_id: str, manifest: dict, error: Optional[str] = None, status: str = "pending") -> PluginInfo:
+        if status == "pending" and error:
+            status = "error"
         path = _plugin_module_paths.get(plugin_id)
         is_builtin = path is not None and path.is_relative_to(BUILTIN_PLUGINS_DIR)
         hidden = bool(manifest.get("hide", False)) if is_builtin else False
@@ -1220,6 +1226,7 @@ class PluginManager:
                     "error": error,
                 }
                 _plugin_infos[plugin_id].error = error
+                _plugin_infos[plugin_id].status = "error"
                 logger.warning(f"Plugin {plugin_id} skipped: {error}")
                 return None
 
@@ -1301,6 +1308,7 @@ class PluginManager:
                 })
                 if plugin_id in _plugin_infos:
                     _plugin_infos[plugin_id].error = "No module found"
+                    _plugin_infos[plugin_id].status = "error"
                 continue
 
             self._register_plugin_class(plugin_id, module, plugin_dir)
@@ -1469,7 +1477,7 @@ class PluginManager:
             plugin_root = self.plugin_dir / entry
             if not plugin_root.is_dir():
                 continue
-            await self.load_plugin_from_dir(plugin_root)
+            await self.load_plugin_from_dir(plugin_root, auto_install=False)
 
     @staticmethod
     async def fetch_plugin_store_data(url: str) -> Any:

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -18,6 +18,7 @@ from core.config import VERSION
 from .plugin import BasePlugin
 from .plugin_context import PluginContext
 from .plugin_handlers import Priority, event_handler_reg, EventHandler, EventType
+from .plugin_installer import install_requirements
 
 from core.tag import tag_registry, BaseTag
 
@@ -37,6 +38,7 @@ class PluginInfo:
     uninstallable: bool = False
     hidden: bool = False
     error: Optional[str] = None
+    status: str = "pending"  # "pending" | "installing" | "loading" | "ready" | "error"
 
 
 logger = get_logger("plugin_manager", "cyan")
@@ -409,6 +411,11 @@ class PluginManager:
 
     def get_plugin_load_errors(self) -> Dict[str, Dict[str, Any]]:
         return dict(_plugin_load_errors)
+
+    def _get_pypi_mirror(self) -> Optional[str]:
+        if self.ctx and hasattr(self.ctx, "config"):
+            return (self.ctx.config.get("network") or {}).get("pypi_mirror") or None
+        return None
 
     def get_plugin_module_dir(self, name: str) -> str:
         return _plugin_module_dirs.get(name, "")
@@ -883,7 +890,10 @@ class PluginManager:
 
     async def init(self):
         """
-        Initialize plugin manager and load all discovered plugins
+        Initialize plugin manager and load all discovered plugins.
+
+        Uses a two-phase approach: first attempt all loads, then install
+        dependencies for plugins that failed with import errors and retry.
         """
         self.plugin_dir.mkdir(parents=True, exist_ok=True)
         self.plugin_data_dir.mkdir(parents=True, exist_ok=True)
@@ -894,10 +904,52 @@ class PluginManager:
         discovered = list(_plugin_classes.keys())
         logger.info(f"Discovered plugins: {discovered}")
 
+        # Phase 1: Attempt to initialize all discovered plugins
         for plugin_id in _plugin_classes.keys():
             if plugin_id in self.plugin_instances:
+                if plugin_id in _plugin_infos:
+                    _plugin_infos[plugin_id].status = "ready"
                 continue
             await self.init_plugin(plugin_id)
+            if plugin_id in self.plugin_instances and plugin_id in _plugin_infos:
+                _plugin_infos[plugin_id].status = "ready"
+
+        # Phase 2: Recover plugins that failed with import errors
+        import_failures = [
+            pid for pid, err_info in _plugin_load_errors.items()
+            if "Import error" in err_info.get("error", "") and pid in _plugin_module_paths
+        ]
+        if import_failures:
+            logger.info(f"Plugins with import errors, will attempt dependency install: {import_failures}")
+
+        for plugin_id in import_failures:
+            plugin_path = _plugin_module_paths.get(plugin_id)
+            if not plugin_path:
+                continue
+
+            if plugin_id in _plugin_infos:
+                _plugin_infos[plugin_id].status = "installing"
+
+            warnings = await install_requirements(plugin_path, pypi_mirror=self._get_pypi_mirror())
+            for w in warnings:
+                logger.warning(f"Dependency install warning for {plugin_id}: {w}")
+
+            # Clear old error and retry loading
+            _plugin_load_errors.pop(plugin_id, None)
+            if plugin_id in _plugin_infos:
+                _plugin_infos[plugin_id].error = None
+                _plugin_infos[plugin_id].status = "loading"
+
+            await self.load_plugin_from_dir(plugin_path, auto_install=False)
+
+            if plugin_id in self.plugin_instances:
+                if plugin_id in _plugin_infos:
+                    _plugin_infos[plugin_id].status = "ready"
+                logger.info(f"Successfully recovered plugin {plugin_id} after dependency install")
+            else:
+                if plugin_id in _plugin_infos:
+                    _plugin_infos[plugin_id].status = "error"
+                logger.warning(f"Plugin {plugin_id} still failed after dependency install")
 
     async def init_plugin(self, plugin_id: Optional[str] = None):
         if plugin_id is None:
@@ -1108,7 +1160,7 @@ class PluginManager:
         return None
 
     @staticmethod
-    def _build_plugin_info(plugin_id: str, manifest: dict, error: Optional[str] = None) -> PluginInfo:
+    def _build_plugin_info(plugin_id: str, manifest: dict, error: Optional[str] = None, status: str = "pending") -> PluginInfo:
         path = _plugin_module_paths.get(plugin_id)
         is_builtin = path is not None and path.is_relative_to(BUILTIN_PLUGINS_DIR)
         hidden = bool(manifest.get("hide", False)) if is_builtin else False
@@ -1131,6 +1183,7 @@ class PluginManager:
             uninstallable=uninstallable,
             hidden=hidden,
             error=error,
+            status=status,
         )
 
     def _load_plugin_meta(self, plugin_root: Path, entry: str):
@@ -1252,13 +1305,16 @@ class PluginManager:
 
             self._register_plugin_class(plugin_id, module, plugin_dir)
 
-    async def load_plugin_from_dir(self, plugin_root: Path) -> Optional[str]:
+    async def load_plugin_from_dir(self, plugin_root: Path, auto_install: bool = True) -> Optional[str]:
         """
         Dynamically load and initialize a single plugin from the given directory.
 
         Safe to call at runtime (e.g. after installing a new plugin). If the
         plugin was already loaded, it is terminated and reloaded cleanly.
         Returns the plugin_id on success, or None if loading failed.
+
+        When *auto_install* is True and the import fails with ModuleNotFoundError,
+        the plugin's requirements.txt is installed and the import is retried once.
         """
         entry = plugin_root.name
         if entry.startswith("_") or not plugin_root.is_dir():
@@ -1307,6 +1363,7 @@ class PluginManager:
             }
             if plugin_id in _plugin_infos:
                 _plugin_infos[plugin_id].error = "No entry script found (main.py / plugin.py / __init__.py)"
+                _plugin_infos[plugin_id].status = "error"
             return None
 
         # Clear decorator-registered components so re-import starts fresh
@@ -1325,22 +1382,59 @@ class PluginManager:
             }
             if plugin_id in _plugin_infos:
                 _plugin_infos[plugin_id].error = "Failed to create module spec"
+                _plugin_infos[plugin_id].status = "error"
             return None
+
+        if plugin_id in _plugin_infos:
+            _plugin_infos[plugin_id].status = "loading"
 
         try:
             module = importlib.util.module_from_spec(spec)
             sys.modules[module_name] = module
             spec.loader.exec_module(module)
         except Exception as e:
-            logger.error(f"Error loading plugin from {plugin_root}: {e}")
-            sys.modules.pop(module_name, None)
-            _plugin_load_errors[plugin_id] = {
-                "manifest": _plugin_manifests.get(plugin_id, {}),
-                "error": f"Import error: {e}",
-            }
-            if plugin_id in _plugin_infos:
-                _plugin_infos[plugin_id].error = f"Import error: {e}"
-            return None
+            if auto_install and isinstance(e, ModuleNotFoundError):
+                logger.info(f"ModuleNotFoundError in {plugin_root}, attempting dependency install: {e}")
+                if plugin_id in _plugin_infos:
+                    _plugin_infos[plugin_id].status = "installing"
+                    _plugin_infos[plugin_id].error = None
+
+                warnings = await install_requirements(plugin_root, pypi_mirror=self._get_pypi_mirror())
+                for w in warnings:
+                    logger.warning(f"Dependency install warning for {plugin_id}: {w}")
+
+                if plugin_id in _plugin_infos:
+                    _plugin_infos[plugin_id].status = "loading"
+
+                # Clean up and retry (once)
+                sys.modules.pop(module_name, None)
+                _plugin_load_errors.pop(plugin_id, None)
+                try:
+                    module = importlib.util.module_from_spec(spec)
+                    sys.modules[module_name] = module
+                    spec.loader.exec_module(module)
+                except Exception as retry_e:
+                    logger.error(f"Retry after dep install also failed for {plugin_root}: {retry_e}")
+                    sys.modules.pop(module_name, None)
+                    _plugin_load_errors[plugin_id] = {
+                        "manifest": _plugin_manifests.get(plugin_id, {}),
+                        "error": f"Import error (after retry): {retry_e}",
+                    }
+                    if plugin_id in _plugin_infos:
+                        _plugin_infos[plugin_id].error = f"Import error (after retry): {retry_e}"
+                        _plugin_infos[plugin_id].status = "error"
+                    return None
+            else:
+                logger.error(f"Error loading plugin from {plugin_root}: {e}")
+                sys.modules.pop(module_name, None)
+                _plugin_load_errors[plugin_id] = {
+                    "manifest": _plugin_manifests.get(plugin_id, {}),
+                    "error": f"Import error: {e}",
+                }
+                if plugin_id in _plugin_infos:
+                    _plugin_infos[plugin_id].error = f"Import error: {e}"
+                    _plugin_infos[plugin_id].status = "error"
+                return None
 
         registered = self._register_plugin_class(plugin_id, module, plugin_root)
         if not registered:
@@ -1351,9 +1445,12 @@ class PluginManager:
             }
             if plugin_id in _plugin_infos:
                 _plugin_infos[plugin_id].error = "No BasePlugin subclass found"
+                _plugin_infos[plugin_id].status = "error"
             return None
 
         await self.init_plugin(plugin_id)
+        if plugin_id in self.plugin_instances and plugin_id in _plugin_infos:
+            _plugin_infos[plugin_id].status = "ready"
         return plugin_id
 
     async def _discover_user_plugins(self):

--- a/webui/frontend/src/components/common/PluginCard.vue
+++ b/webui/frontend/src/components/common/PluginCard.vue
@@ -12,6 +12,18 @@
         <div v-if="coreVersion" class="mt-1 text-xs text-gray-400 dark:text-gray-500">
           {{ $t('plugin.core_version') }}: {{ coreVersion }}
         </div>
+        <div v-if="status === 'installing'" class="mt-2 flex items-center gap-1.5 text-xs">
+          <IconSpinner class="animate-spin h-3.5 w-3.5 text-yellow-500" />
+          <span class="text-yellow-600 dark:text-yellow-400">{{ $t('plugin.status_installing') }}</span>
+        </div>
+        <div v-else-if="status === 'loading'" class="mt-2 flex items-center gap-1.5 text-xs">
+          <IconSpinner class="animate-spin h-3.5 w-3.5 text-blue-500" />
+          <span class="text-blue-600 dark:text-blue-400">{{ $t('plugin.status_loading') }}</span>
+        </div>
+        <div v-else-if="status === 'pending'" class="mt-2 flex items-center gap-1.5 text-xs">
+          <span class="inline-block h-2 w-2 rounded-full bg-gray-400"></span>
+          <span class="text-gray-500 dark:text-gray-400">{{ $t('plugin.status_pending') }}</span>
+        </div>
         <div v-if="error" class="mt-2 flex items-start gap-1.5 rounded-md bg-red-50 dark:bg-red-900/20 px-2 py-1.5 text-xs text-red-600 dark:text-red-400">
           <IconInfo class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
           <span>{{ error }}</span>
@@ -138,6 +150,7 @@ const props = withDefaults(defineProps<{
   tags?: string[]
   coreVersion?: string | null
   error?: string | null
+  status?: string
   reloading?: boolean
   // store mode
   installed?: boolean
@@ -153,6 +166,7 @@ const props = withDefaults(defineProps<{
   tags: () => [],
   coreVersion: null,
   error: null,
+  status: 'ready',
   reloading: false,
   installed: false,
   installing: false,

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -3,6 +3,7 @@ export default {
     on: 'On',
     off: 'Off',
     delete: 'Delete',
+    refresh: 'Refresh',
   },
   app: {
     title: 'KiraAI',
@@ -268,6 +269,9 @@ export default {
     name: 'Name',
     version: 'Version',
     status: 'Status',
+    status_installing: 'Installing dependencies...',
+    status_loading: 'Loading...',
+    status_pending: 'Pending',
     actions: 'Actions',
     tab_plugins: 'Plugins',
     tab_mcp: 'MCP',
@@ -376,6 +380,8 @@ export default {
     reloading: 'Reloading...',
     reload_success: 'Plugin reloaded successfully',
     reload_failed: 'Failed to reload plugin',
+    refresh_success: 'Plugins refreshed',
+    refresh_failed: 'Failed to refresh plugins',
   },
   pluginStore: {
     title: 'Plugin Store',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -3,6 +3,7 @@ export default {
     on: '启用',
     off: '禁用',
     delete: '删除',
+    refresh: '刷新',
   },
   app: {
     title: 'KiraAI',
@@ -268,6 +269,9 @@ export default {
     name: '名称',
     version: '版本',
     status: '状态',
+    status_installing: '正在安装依赖...',
+    status_loading: '加载中...',
+    status_pending: '等待中',
     actions: '操作',
     tab_plugins: '插件',
     tab_mcp: 'MCP',
@@ -376,6 +380,8 @@ export default {
     reloading: '重载中...',
     reload_success: '插件重载成功',
     reload_failed: '插件重载失败',
+    refresh_success: '插件已刷新',
+    refresh_failed: '刷新插件失败',
   },
   pluginStore: {
     title: '插件商店',

--- a/webui/frontend/src/types/models.ts
+++ b/webui/frontend/src/types/models.ts
@@ -113,6 +113,7 @@ export interface PluginItem {
   tags: string[]
   core_version?: string | null
   error?: string | null
+  status?: string
 }
 
 export interface PluginConfigUpdateRequest {

--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -634,7 +634,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useLocalized } from '@/composables/useLocalized'
 import { notify } from '@/composables/useNotification'
@@ -790,6 +790,33 @@ async function refreshPlugins() {
     refreshingPlugins.value = false
   }
 }
+
+// Auto-poll while any plugin is in a transient state
+const hasTransientPlugins = computed(() =>
+  plugins.value.some(p => ['installing', 'loading'].includes(p.status || ''))
+)
+let pluginPollTimer: ReturnType<typeof setInterval> | null = null
+
+watch(hasTransientPlugins, (hasTransient) => {
+  if (hasTransient && !pluginPollTimer) {
+    pluginPollTimer = setInterval(async () => {
+      try {
+        const res = await getPlugins()
+        plugins.value = Array.isArray(res.data) ? res.data : plugins.value
+      } catch { /* keep stale data during poll */ }
+    }, 5000)
+  } else if (!hasTransient && pluginPollTimer) {
+    clearInterval(pluginPollTimer)
+    pluginPollTimer = null
+  }
+})
+
+onUnmounted(() => {
+  if (pluginPollTimer) {
+    clearInterval(pluginPollTimer)
+    pluginPollTimer = null
+  }
+})
 
 async function loadMcpServers() {
   try {

--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -52,6 +52,15 @@
           <span class="mr-1">+</span>
           <span>{{ $t('plugin.install_add') }}</span>
         </button>
+        <button
+          type="button"
+          class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors ml-2"
+          :disabled="refreshingPlugins"
+          @click="refreshPlugins"
+        >
+          <IconRefresh class="w-4 h-4 mr-1" :class="{ 'animate-spin': refreshingPlugins }" />
+          <span>{{ $t('common.refresh') }}</span>
+        </button>
       </div>
 
       <div v-if="pluginsError" class="flex justify-center items-center py-12">
@@ -85,6 +94,7 @@
           :tags="plugin.tags"
           :core-version="plugin.core_version"
           :error="plugin.error"
+          :status="plugin.status"
           :reloading="reloadingPlugins.has(plugin.id)"
           @toggle="togglePlugin(plugin)"
           @configure="openPluginConfig(plugin)"
@@ -193,7 +203,7 @@
           @click="refreshSkillList"
         >
           <IconRefresh class="w-4 h-4 mr-1" />
-          <span>{{ $t('plugin.skills_refresh') }}</span>
+          <span>{{ $t('common.refresh') }}</span>
         </button>
       </div>
 
@@ -264,7 +274,7 @@
           @click="() => fetchStorePlugins(true)"
         >
           <IconRefresh class="w-4 h-4 mr-1" :class="{ 'animate-spin': storeLoading }" />
-          <span>{{ $t('pluginStore.refresh') }}</span>
+          <span>{{ $t('common.refresh') }}</span>
         </button>
         <span v-if="currentStoreSource" class="ml-3 text-sm text-gray-500 dark:text-gray-400">
           {{ $t('pluginStore.current_source') }}: <span class="font-medium text-gray-700 dark:text-gray-300">{{ currentStoreSource.name }}</span>
@@ -281,7 +291,7 @@
             class="mt-3 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
             @click="() => fetchStorePlugins()"
           >
-            {{ $t('plugin.skills_refresh') }}
+            {{ $t('common.refresh') }}
           </button>
         </div>
       </div>
@@ -669,6 +679,7 @@ const uploadFile = ref<File | null>(null)
 const installDropzoneRef = ref<InstanceType<typeof FileDropzone> | null>(null)
 const installing = ref(false)
 const reloadingPlugins = ref(new Set<string>())
+const refreshingPlugins = ref(false)
 
 // Proxy strategy
 const GH_PROXY_LIST = [
@@ -762,10 +773,20 @@ async function loadPlugins() {
     pluginsError.value = null
   } catch (e: any) {
     plugins.value = []
-    // Prefer backend detail when useful; always default to the localized
-    // message so Chinese users don't see an English fallback.
     pluginsError.value = e?.message || t('plugin.load_failed')
     notify(pluginsError.value!, 'error')
+  }
+}
+
+async function refreshPlugins() {
+  refreshingPlugins.value = true
+  try {
+    await loadPlugins()
+    notify(t('plugin.refresh_success'), 'success')
+  } catch {
+    notify(t('plugin.refresh_failed'), 'error')
+  } finally {
+    refreshingPlugins.value = false
   }
 }
 

--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -766,25 +766,26 @@ function onCancelAction() {
 const pluginsError = ref<string | null>(null)
 const mcpServersError = ref<string | null>(null)
 
-async function loadPlugins() {
+async function loadPlugins(): Promise<boolean> {
   try {
     const res = await getPlugins()
     plugins.value = Array.isArray(res.data) ? res.data : []
     pluginsError.value = null
+    return true
   } catch (e: any) {
     plugins.value = []
     pluginsError.value = e?.message || t('plugin.load_failed')
     notify(pluginsError.value!, 'error')
+    return false
   }
 }
 
 async function refreshPlugins() {
   refreshingPlugins.value = true
   try {
-    await loadPlugins()
-    notify(t('plugin.refresh_success'), 'success')
-  } catch {
-    notify(t('plugin.refresh_failed'), 'error')
+    if (await loadPlugins()) {
+      notify(t('plugin.refresh_success'), 'success')
+    }
   } finally {
     refreshingPlugins.value = false
   }

--- a/webui/models.py
+++ b/webui/models.py
@@ -133,6 +133,7 @@ class PluginItem(BaseModel):
     tags: List[str] = Field(default_factory=list)
     core_version: Optional[str] = None
     error: Optional[str] = None
+    status: str = "pending"
 
 
 class PluginConfigUpdateRequest(BaseModel):

--- a/webui/routes/plugins.py
+++ b/webui/routes/plugins.py
@@ -347,17 +347,19 @@ class PluginsRoutes(Routes):
 
     @staticmethod
     def _build_install_result(plugin_manager, plugin_id: str, warnings: List[str]) -> PluginInstallResult:
-        manifest = plugin_manager.get_plugin_manifest(plugin_id) or {}
-        tags = manifest.get("tags") or []
+        info = plugin_manager.get_plugin_info(plugin_id)
         return PluginInstallResult(
             id=plugin_id,
-            name=str(manifest.get("display_name") or plugin_id),
-            version=str(manifest.get("version") or ""),
-            author=str(manifest.get("author") or ""),
-            description=str(manifest.get("description") or ""),
-            repo=manifest.get("repo") if isinstance(manifest.get("repo"), str) else None,
+            name=info.display_name if info else plugin_id,
+            version=info.version if info else "",
+            author=info.author if info else "",
+            description=info.description if info else "",
+            repo=info.repo if info else None,
             enabled=plugin_manager.is_plugin_enabled(plugin_id),
-            tags=[str(t) for t in tags if t],
+            tags=info.tags if info else [],
+            core_version=info.core_version if info else None,
+            error=info.error if info else None,
+            status=info.status if info else "pending",
             warnings=warnings,
         )
 

--- a/webui/routes/plugins.py
+++ b/webui/routes/plugins.py
@@ -148,6 +148,7 @@ class PluginsRoutes(Routes):
                         tags=info.tags,
                         core_version=info.core_version,
                         error=info.error,
+                        status=info.status,
                     )
                 )
             return items


### PR DESCRIPTION
## Summary

When a plugin fails to load with `ModuleNotFoundError`, the system now automatically installs its `requirements.txt` and retries once. On startup, Phase 2 scans all import-error plugins, installs their dependencies, and retries loading. This fixes the Docker container rebuild scenario where pip packages are lost but plugin files persist.

Closes #72 

## Type of change

- [x] feat: New feature

## Changes

- `load_plugin_from_dir` now detects `ModuleNotFoundError`, calls `install_requirements`, and retries loading (new `auto_install` parameter, default `True`)
- `init()` adds Phase 2 recovery: scans `_plugin_load_errors` for import failures, installs deps, retries loading
- Adds `_get_pypi_mirror()` helper to `PluginManager` for reading config
- Adds `status` field to `PluginInfo` (`pending` | `installing` | `loading` | `ready` | `error`), exposed via `/api/plugins` API
- `PluginCard` shows yellow spinner for "Installing dependencies...", blue spinner for "Loading...", gray dot for "Pending"
- Adds refresh button to the plugins tab for manual status re-fetch
- Extracts "Refresh" label into `common.refresh` i18n key, used by plugins, skills, and plugin store tabs

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI and API surface now show plugin lifecycle statuses (pending, installing, loading, ready, error).
  * Plugins that fail due to missing dependencies can auto-install and retry loading.
  * Plugins view adds a Refresh action with spinner, success/failure notifications, and auto-polling while plugins are transient.
* **Bug Fixes**
  * Partial plugin instances are cleared on initialization failure to avoid stale state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->