### PR TITLE
fix(plugin): disabled plugins stuck in loading status

### DIFF
--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -38,7 +38,7 @@ class PluginInfo:
     uninstallable: bool = False
     hidden: bool = False
     error: Optional[str] = None
-    status: str = "pending"  # "pending" | "installing" | "loading" | "ready" | "error"
+    status: str = "pending"  # "pending" | "installing" | "loading" | "ready" | "disabled" | "error"
 
 
 logger = get_logger("plugin_manager", "cyan")
@@ -391,7 +391,11 @@ class PluginManager:
         if enabled and not previous:
             # Toggle: plugin code unchanged, just re-initialize from existing class
             await self.init_plugin(plugin_id)
+            if plugin_id in self.plugin_instances and plugin_id in _plugin_infos:
+                _plugin_infos[plugin_id].status = "ready"
         elif not enabled and previous:
+            if plugin_id in _plugin_infos:
+                _plugin_infos[plugin_id].status = "disabled"
             try:
                 await self.terminate(plugin_id)
             except Exception as e:
@@ -968,6 +972,8 @@ class PluginManager:
 
         if not self.is_plugin_enabled(plugin_id):
             logger.debug(f"Plugin {plugin_id} is disabled, skipping initialization")
+            if plugin_id in _plugin_infos:
+                _plugin_infos[plugin_id].status = "disabled"
             return
 
         existing = self.plugin_instances.get(plugin_id)

--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -791,9 +791,9 @@ async function refreshPlugins() {
   }
 }
 
-// Auto-poll while any plugin is in a transient state
+// Auto-poll while any enabled plugin is in a transient state
 const hasTransientPlugins = computed(() =>
-  plugins.value.some(p => ['installing', 'loading'].includes(p.status || ''))
+  plugins.value.some(p => p.enabled && ['installing', 'loading'].includes(p.status || ''))
 )
 let pluginPollTimer: ReturnType<typeof setInterval> | null = null
 


### PR DESCRIPTION
## Summary

Disabled plugins retained stale status (e.g. `loading`) from before they were toggled off, causing the frontend to poll endlessly for status updates that never come.

## Type of change

- [x] fix: Bug fix

## Changes

- **Backend** (`plugin_registry.py`):
  - `set_plugin_enabled(False)` now sets `status = "disabled"` before terminating the plugin
  - `set_plugin_enabled(True)` now sets `status = "ready"` after successful re-initialization
  - `init_plugin()` now sets `status = "disabled"` when skipping a disabled plugin during startup
- **Frontend** (`PluginView.vue`):
  - `hasTransientPlugins` computed now requires `p.enabled === true`, so disabled plugins with stale status no longer trigger the 5-second polling loop

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins now include status field tracking their lifecycle states: pending, ready, disabled, installing, and loading.

* **Improvements**
  * Optimized auto-polling for plugins to activate only when at least one enabled plugin is in a transient state, reducing unnecessary system checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->