### PR TITLE
feat(plugin): add ON_MESSAGE_SENT hook & fix ON_STEP_RESULT trigger

### DIFF
--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -548,23 +548,26 @@ class MessageProcessor:
 
         async def send_llm_text(resp: LLMResponse):
             text = resp.text_response
-            session_lock = self.get_session_lock(sid)
-            async with session_lock:
-                message_results = await self.send_xml_messages(event, text.strip(), tag_set)
-                if message_results is None:
-                    return
-                response_with_ids = self._add_message_ids(text, message_results)
-                step_result = KiraStepResult(message_results=message_results, raw_output=response_with_ids)
-                # EventType.ON_STEP_RESULT
-                step_handlers = event_handler_reg.get_handlers(event_type=EventType.ON_STEP_RESULT)
-                for step_handler in step_handlers:
-                    await step_handler.exec_handler(event, step_result)
-                    if event.is_stopped:
-                        logger.info(f"Event {event.event_id} stopped while ON_STEP_RESULT stage")
+            message_results = []
+            raw_output = ""
+            if text:
+                session_lock = self.get_session_lock(sid)
+                async with session_lock:
+                    message_results = await self.send_xml_messages(event, text.strip(), tag_set)
+                    if message_results is None:
                         return
-                logger.info(f"LLM -> {sid}: {step_result.raw_output}")
+                    raw_output = self._add_message_ids(text, message_results)
+                    logger.info(f"LLM -> {sid}: {raw_output}")
+            step_result = KiraStepResult(message_results=message_results, raw_output=raw_output)
+            # EventType.ON_STEP_RESULT
+            step_handlers = event_handler_reg.get_handlers(event_type=EventType.ON_STEP_RESULT)
+            for step_handler in step_handlers:
+                await step_handler.exec_handler(event, step_result)
+                if event.is_stopped:
+                    logger.info(f"Event {event.event_id} stopped while ON_STEP_RESULT stage")
+                    return
+            if raw_output:
                 llm_resp.text_response = step_result.raw_output
-
                 for idx in range(-1, -len(new_messages), -1):
                     if new_messages[idx].role == "assistant":
                         new_messages[idx].content = step_result.raw_output
@@ -578,8 +581,7 @@ class MessageProcessor:
             if not llm_resp:
                 break
 
-            if llm_resp.text_response:
-                await send_llm_text(llm_resp)
+            await send_llm_text(llm_resp)
 
             if not step.has_tool_calls or step.is_final:
                 break
@@ -658,10 +660,17 @@ class MessageProcessor:
                     result = await self.send_message_chain(event.sid, action)
                     if not result.ok and result.err:
                         logger.error(result.err)
-                    message_results.append(result)
-                    await asyncio.sleep(random.uniform(self.min_message_delay, self.max_message_delay))
                 else:
-                    message_results.append(KiraIMSentResult(ok=False, err="Blank message list detected"))
+                    result = KiraIMSentResult(ok=False, err="Blank message list detected")
+                message_results.append(result)
+                # EventType.ON_MESSAGE_SENT
+                sent_handlers = event_handler_reg.get_handlers(event_type=EventType.ON_MESSAGE_SENT)
+                for handler in sent_handlers:
+                    await handler.exec_handler(event, action, result)
+                    if event.is_stopped:
+                        logger.info(f"Event {event.event_id} stopped while ON_MESSAGE_SENT stage")
+                        return message_results
+                await asyncio.sleep(random.uniform(self.min_message_delay, self.max_message_delay))
             elif isinstance(action, RootTagAction):
                 try:
                     await action.tag.handle(action.value, **action.attrs)

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -546,7 +546,8 @@ class MessageProcessor:
             model_group=model_group,
         )
 
-        async def send_llm_text(resp: LLMResponse):
+        async def send_llm_text(resp: LLMResponse) -> bool:
+            """Process and send LLM text response. Returns False if stopped, True to continue."""
             text = resp.text_response
             message_results = []
             raw_output = ""
@@ -555,7 +556,7 @@ class MessageProcessor:
                 async with session_lock:
                     message_results = await self.send_xml_messages(event, text.strip(), tag_set)
                     if message_results is None:
-                        return
+                        return False
                     raw_output = self._add_message_ids(text, message_results)
                     logger.info(f"LLM -> {sid}: {raw_output}")
             step_result = KiraStepResult(message_results=message_results, raw_output=raw_output)
@@ -565,7 +566,7 @@ class MessageProcessor:
                 await step_handler.exec_handler(event, step_result)
                 if event.is_stopped:
                     logger.info(f"Event {event.event_id} stopped while ON_STEP_RESULT stage")
-                    return
+                    return False
             if raw_output:
                 llm_resp.text_response = step_result.raw_output
                 for idx in range(-1, -len(new_messages), -1):
@@ -573,6 +574,7 @@ class MessageProcessor:
                         new_messages[idx].content = step_result.raw_output
                         request.messages[idx].content = step_result.raw_output
                         break
+            return True
 
         # Iter agent executor to get LLMResponse
         # TODO use llm_semaphore to restrict concurrent LLM requests
@@ -581,7 +583,8 @@ class MessageProcessor:
             if not llm_resp:
                 break
 
-            await send_llm_text(llm_resp)
+            if not await send_llm_text(llm_resp):
+                break
 
             if not step.has_tool_calls or step.is_final:
                 break

--- a/core/plugin/plugin_handlers.py
+++ b/core/plugin/plugin_handlers.py
@@ -25,6 +25,7 @@ class EventType(Enum):
     ON_LLM_RESPONSE = "on_llm_response"  # LLM 原始输出
     AFTER_XML_PARSE = "after_xml_parse"  # XML 解析后 (list[MessageChain | RootTagAction])
     ON_TOOL_RESULT = "on_tool_result"  # 工具调用结果
+    ON_MESSAGE_SENT = "on_message_sent"  # 单条消息发送后
     ON_STEP_RESULT = "on_step_result"  # Agent 步骤结果
     ON_FINAL_RESULT = "on_final_result"  # 最终消息结果
     ON_EXCEPTION = "on_exception"  # 异常发生时

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -282,6 +282,12 @@ class OnEventDeco:
             return func
         return decorator
 
+    def message_sent(self, priority: Union[Priority, int] = Priority.MEDIUM):
+        def decorator(func: Callable):
+            self._register_hook(func, priority, EventType.ON_MESSAGE_SENT)
+            return func
+        return decorator
+
     def step_result(self, priority: Union[Priority, int] = Priority.MEDIUM):
         def decorator(func: Callable):
             self._register_hook(func, priority, EventType.ON_STEP_RESULT)


### PR DESCRIPTION
## Summary

Adds a new `ON_MESSAGE_SENT` hook that fires after each individual message is sent to the platform, giving plugins per-message access to `MessageChain` and `KiraIMSentResult` (including `message_id`). Fixes `ON_STEP_RESULT` to fire on every agent step regardless of text output, so plugins can react to tool-call-only steps as well.

## Type of change

- [x] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- `core/plugin/plugin_handlers.py` — Add `EventType.ON_MESSAGE_SENT`
- `core/plugin/plugin_registry.py` — Add `@on.message_sent()` decorator to `OnEventDeco`
- `core/message_manager.py` — Fire `ON_MESSAGE_SENT` after each message is sent inside the `send_xml_messages` loop; restructure `send_llm_text` so `ON_STEP_RESULT` triggers unconditionally on every agent step

## Screenshots / Logs

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message-sent events so plugins can register handlers that run when a message is sent, including a convenience decorator for registering those handlers.

* **Refactor**
  * Centralized LLM-response processing per step with stop-aware early exit.
  * Empty/blank message sequences now produce a failed send outcome but still trigger sent events and respect configured inter-message delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->