### PR TITLE
fix(plugin): error overflow in PluginCard & wrong import type triggering dep install

### DIFF
--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -932,7 +932,7 @@ class PluginManager:
         # Phase 2: Recover plugins that failed with import errors
         import_failures = [
             pid for pid, err_info in _plugin_load_errors.items()
-            if "Import error" in err_info.get("error", "") and pid in _plugin_module_paths
+            if err_info.get("error_type") is ModuleNotFoundError and pid in _plugin_module_paths
         ]
         if import_failures:
             logger.info(f"Plugins with import errors, will attempt dependency install: {import_failures}")
@@ -1452,6 +1452,7 @@ class PluginManager:
                 _plugin_load_errors[plugin_id] = {
                     "manifest": _plugin_manifests.get(plugin_id, {}),
                     "error": f"Import error: {e}",
+                    "error_type": type(e),
                 }
                 if plugin_id in _plugin_infos:
                     _plugin_infos[plugin_id].error = f"Import error: {e}"

--- a/webui/frontend/src/components/common/PluginCard.vue
+++ b/webui/frontend/src/components/common/PluginCard.vue
@@ -24,9 +24,9 @@
           <span class="inline-block h-2 w-2 rounded-full bg-gray-400"></span>
           <span class="text-gray-500 dark:text-gray-400">{{ $t('plugin.status_pending') }}</span>
         </div>
-        <div v-if="error" class="mt-2 flex items-start gap-1.5 rounded-md bg-red-50 dark:bg-red-900/20 px-2 py-1.5 text-xs text-red-600 dark:text-red-400">
+        <div v-if="error" class="mt-2 min-w-0 flex items-start gap-1.5 rounded-md bg-red-50 dark:bg-red-900/20 px-2 py-1.5 text-xs text-red-600 dark:text-red-400 overflow-hidden">
           <IconInfo class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
-          <span>{{ error }}</span>
+          <span class="min-w-0 break-all line-clamp-6">{{ error }}</span>
         </div>
       </div>
       <div class="flex items-start space-x-2">


### PR DESCRIPTION
## Summary

Fixes two plugin-related bugs:
1. PluginCard error messages with long text (URLs, tracebacks) expand the card beyond its grid column width
2. Non-module `ImportError` (e.g. `cannot import name 'MessageChain'`) incorrectly triggers dependency installation, only `ModuleNotFoundError` should

## Type of change

- [x] fix: Bug fix

## Changes

- **PluginCard.vue**: Add `min-w-0`, `break-all`, `line-clamp-6`, `overflow-hidden` to the error block so long error messages wrap within the card and are capped at 6 lines
- **plugin_registry.py**: Store `error_type` (exception class) in `_plugin_load_errors` and use `is ModuleNotFoundError` check in Phase 2 recovery instead of the fragile `"Import error" in error_string` substring match

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin loading recovery to more accurately identify failed plugins eligible for dependency-install retry.

* **Improvements**
  * Enhanced plugin error message display with better text wrapping and overflow handling for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->