### PR TITLE
fix: remove redundant None in lifecycle hook exec_handler

### DIFF
--- a/core/lifecycle.py
+++ b/core/lifecycle.py
@@ -224,7 +224,7 @@ class KiraLifecycle:
         # Fire ON_LOADED lifecycle event (all plugins are initialized)
         loaded_handlers = event_handler_reg.get_handlers(EventType.ON_LOADED)
         for handler in loaded_handlers:
-            await handler.exec_handler(None)
+            await handler.exec_handler()
 
         # ====== init temp folder monitor ======
         temp_folder = get_data_path() / "temp"
@@ -254,7 +254,7 @@ class KiraLifecycle:
         # Fire ON_SHUTDOWN lifecycle event (before any teardown)
         shutdown_handlers = event_handler_reg.get_handlers(EventType.ON_SHUTDOWN)
         for handler in shutdown_handlers:
-            await handler.exec_handler(None)
+            await handler.exec_handler()
 
         # shutdown telemetry client
         if self.telemetry_client:

--- a/core/plugin/plugin_handlers.py
+++ b/core/plugin/plugin_handlers.py
@@ -51,6 +51,7 @@ class EventHandler:
         return self.priority > other.priority
 
     async def exec_handler(self, *args, **kwargs):
+        event = args[0] if args else None
         try:
             await self.handler(*args, **kwargs)
         except Exception as e:

--- a/core/plugin/plugin_handlers.py
+++ b/core/plugin/plugin_handlers.py
@@ -50,9 +50,9 @@ class EventHandler:
     def __gt__(self, other):
         return self.priority > other.priority
 
-    async def exec_handler(self, event, *args, **kwargs):
+    async def exec_handler(self, *args, **kwargs):
         try:
-            await self.handler(event, *args, **kwargs)
+            await self.handler(*args, **kwargs)
         except Exception as e:
             import traceback as tb
             logger.error(tb.format_exc())


### PR DESCRIPTION
## Summary

`exec_handler()` always passed `event` as a named first positional argument, forcing lifecycle hooks (`ON_LOADED` / `ON_SHUTDOWN`) to accept a useless `None`. Refactor to use `*args, **kwargs` so event is just another positional arg that lifecycle callers can omit.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [x] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- `EventHandler.exec_handler()`: `(self, event, *args, **kwargs)` → `(self, *args, **kwargs)`
- `KiraLifecycle`: remove `None` from `exec_handler()` calls for `ON_LOADED` / `ON_SHUTDOWN`
- Plugin lifecycle handlers now accept only `self`, no `_event` placeholder

All existing message hook call sites are unchanged — event is still passed as the first positional arg.

## Screenshots / Logs

**Before:**
```python
# lifecycle.py
await handler.exec_handler(None)

# plugin
@on.loaded()
async def on_loaded(self, _event):  # _event always None
    ...
```

**After:**
```python
# lifecycle.py
await handler.exec_handler()

# plugin
@on.loaded()
async def on_loaded(self):  # clean
    ...
```

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified plugin lifecycle handler invocation and unified handler call patterns to streamline event handling and exception flows; internal handler signatures were adjusted without changing public exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->