### PR TITLE
fix: point CLAUDE.md symlink to AGENTS.md with a relative path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-D:/MyProject/Python/KiraAI_OpenSource/AGENTS.md
+AGENTS.md


### PR DESCRIPTION
## What

`CLAUDE.md` was already a symlink, but its target was hard-coded to an absolute Windows path (`D:/MyProject/Python/KiraAI_OpenSource/AGENTS.md`). That made it a **dangling link** on macOS, CI, and any machine other than that one Windows box — `cat CLAUDE.md` returned "No such file".

This changes the symlink to a **relative target** (`AGENTS.md`), so it resolves to the sibling file on every platform.

## Why

Claude Code reads `CLAUDE.md` for repo guidance. With the broken link it read nothing; now both `CLAUDE.md` and `AGENTS.md` resolve to the same content with a single source of truth.

## Note for Windows users

Git stores this as a symlink (mode `120000`). On Windows, if `core.symlinks` is off or the user lacks privilege to create symlinks, git checks `CLAUDE.md` out as a plain text file whose content is the literal string `AGENTS.md`. If that happens, enable Developer Mode / `git config core.symlinks true` and re-checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation file organization for improved maintenance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->