### PR TITLE
fix: plugin static mount path from /page/ to /static/

### DIFF
--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -205,8 +205,8 @@ class RegisterDeco:
     def static(path: str, directory: str, html: bool = False):
         """Register a static file directory.
 
-        path:      URL path prefix relative to plugin, e.g., "/static"
-                   Final URL: /page/plugin/{plugin_id}{path}
+        path:      URL path prefix relative to plugin, e.g., "/assets"
+                   Final URL: /static/plugin/{plugin_id}{path}
         directory: Local directory path relative to plugin root
         html:      Try to serve index.html for directory requests
         """
@@ -770,7 +770,7 @@ class PluginManager:
 
         for static in comp.static_dirs:
             path_prefix = static["path"].lstrip('/')
-            full_path = f"/page/plugin/{plugin_id}/{path_prefix}"
+            full_path = f"/static/plugin/{plugin_id}/{path_prefix}"
             dir_path = plugin_root / static["directory"]
 
             if not dir_path.exists() or not dir_path.is_dir():


### PR DESCRIPTION
## Summary

Fixes a bug where plugin static files were mounted under `/page/plugin/{id}/` instead of `/static/plugin/{id}/`, colliding with page routes and causing uninstall cleanup to fail silently.

## Type of change

- [x] fix: Bug fix

## Changes

- `_register_plugin_static_for()`: changed mount prefix from `/page/plugin/` to `/static/plugin/`
- `@register.static()` docstring: updated to reflect the correct final URL
- `_remove_plugin_routes()` already used `/static/plugin/` — no change needed there, confirming this was a bug

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect URL routing for plugin static assets, ensuring they are now properly served from the correct path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->