### PR TITLE
feat: enhance plugin page capability

### DIFF
--- a/core/plugin/__init__.py
+++ b/core/plugin/__init__.py
@@ -1,6 +1,6 @@
 from .plugin import BasePlugin
 from .plugin_context import PluginContext
-from .plugin_registry import PluginManager, PluginInfo, register_tool, on, register, PluginPage
+from .plugin_registry import PluginManager, PluginInfo, register_tool, on, register, PluginPage, PageMenu
 from .plugin_handlers import EventType, Priority
 
 from core.logging_manager import get_logger
@@ -14,6 +14,7 @@ __all__ = [
     'PluginManager',
     'PluginInfo',
     'PluginPage',
+    'PageMenu',
     "register_tool",
     "register",
     "on",

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -60,6 +60,33 @@ _module_to_plugin: Dict[str, str] = {}
 _plugin_schemas: Dict[str, List[BaseConfigField]] = {}
 
 
+class PageMenu:
+    """Sidebar menu configuration for a plugin page.
+
+    Args:
+        label: Display text — a plain string or a dict of locale→translation
+               (e.g. ``{"zh": "仪表盘", "en": "Dashboard"}``).
+        icon:  Element Plus icon component name (e.g. ``"Monitor"``).
+        order: Sort order in the sidebar (lower = higher, default 100).
+    """
+
+    def __init__(self, label: Union[str, Dict[str, str]], icon: Optional[str] = None,
+                 order: int = 100):
+        if not isinstance(label, (str, dict)):
+            raise TypeError(f"label must be a str or dict, got {type(label).__name__}")
+        if isinstance(label, dict):
+            for k, v in label.items():
+                if not isinstance(k, str) or not isinstance(v, str):
+                    raise TypeError(f"label dict keys and values must be strings, "
+                                    f"got {type(k).__name__}: {type(v).__name__}")
+        self.label: Union[str, Dict[str, str]] = label
+        self.icon: Optional[str] = icon
+        self.order: int = order
+
+    def dict(self) -> dict:
+        return {"label": self.label, "icon": self.icon, "order": self.order}
+
+
 class PluginPageSource(Enum):
     FOLDER = "folder"
     URL = "url"
@@ -81,7 +108,7 @@ class PluginPage:
     """
 
     def __init__(self, source: PluginPageSource, source_value: str,
-                 auth: bool = True, menu: Optional[dict] = None):
+                 auth: bool = True, menu: Optional[Union[dict, "PageMenu"]] = None):
         self.source = source
         self.source_value = source_value
         self.auth = auth
@@ -89,7 +116,7 @@ class PluginPage:
 
     @classmethod
     def from_folder(cls, path: str, auth: bool = True,
-                    menu: Optional[dict] = None) -> "PluginPage":
+                    menu: Optional[Union[dict, "PageMenu"]] = None) -> "PluginPage":
         """Serve static files from a directory relative to the plugin root.
 
         Only files *inside* the plugin directory are accessible — any path
@@ -104,7 +131,7 @@ class PluginPage:
 
     @classmethod
     def from_url(cls, url: str, auth: bool = True,
-                 menu: Optional[dict] = None) -> "PluginPage":
+                 menu: Optional[Union[dict, "PageMenu"]] = None) -> "PluginPage":
         """Redirect the iframe to an external URL.
 
         Args:
@@ -116,7 +143,7 @@ class PluginPage:
 
     @classmethod
     def from_html(cls, html: str, auth: bool = True,
-                  menu: Optional[dict] = None) -> "PluginPage":
+                  menu: Optional[Union[dict, "PageMenu"]] = None) -> "PluginPage":
         """Serve a static HTML string.
 
         Args:
@@ -169,9 +196,11 @@ class PluginComponents:
         self.hooks.append(eh)
 
     def register_page(self, route: str, func: Callable, auth: bool = True,
-                      menu: Optional[dict] = None,
+                      menu: Optional[Union[dict, "PageMenu"]] = None,
                       page_obj: Optional["PluginPage"] = None,
                       returns_plugin_page: bool = False):
+        if isinstance(menu, dict):
+            menu = PageMenu(**menu)
         self.pages.append({
             "route": route,
             "func": func,
@@ -299,12 +328,12 @@ class RegisterDeco:
         return decorator
 
     @staticmethod
-    def page(route: str, auth: bool = True, menu: Optional[dict] = None):
+    def page(route: str, auth: bool = True, menu: Optional[Union[dict, "PageMenu"]] = None):
         """Register a plugin page endpoint.
 
         Accepts a ``PluginPage`` object or a function that returns one::
 
-            @register.page("/dashboard", menu={"label": "Dashboard", "icon": "Monitor"})
+            @register.page("/dashboard", menu=PageMenu(label={"zh": "仪表盘", "en": "Dashboard"}, icon="Monitor"))
             def dashboard(self):
                 return PluginPage.from_folder("./web")
 
@@ -312,7 +341,8 @@ class RegisterDeco:
             route: URL path relative to plugin prefix, e.g. ``"/dashboard"``.
                    Final route: ``/page/plugin/{plugin_id}{route}``
             auth:  Require JWT auth (default ``True``).
-            menu:  Optional sidebar menu config dict.
+            menu:  Optional sidebar menu config — a ``PageMenu`` object or a dict
+                   with keys ``label`` (str or locale dict), ``icon``, ``order``.
         """
         def decorator(obj):
             plugin_id = get_obj_plugin_id(obj)

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -74,11 +74,16 @@ class PageMenu:
                  order: int = 100):
         if not isinstance(label, (str, dict)):
             raise TypeError(f"label must be a str or dict, got {type(label).__name__}")
+        if isinstance(label, str):
+            if not label.strip():
+                raise ValueError("label string must not be empty or whitespace")
         if isinstance(label, dict):
             for k, v in label.items():
                 if not isinstance(k, str) or not isinstance(v, str):
                     raise TypeError(f"label dict keys and values must be strings, "
                                     f"got {type(k).__name__}: {type(v).__name__}")
+                if not v.strip():
+                    raise ValueError(f"label dict value for '{k}' must not be empty or whitespace")
         self.label: Union[str, Dict[str, str]] = label
         self.icon: Optional[str] = icon
         self.order: int = order
@@ -103,19 +108,18 @@ class PluginPage:
     - ``PluginPage.from_url("https://example.com")`` — redirect to an external URL.
     - ``PluginPage.from_html("<h1>Hello</h1>")`` — serve inline HTML.
 
-    The *auth* and *menu* parameters can also be passed to ``@register.page()``
-    as decorator-level overrides.
+    The *menu* parameter can also be passed to ``@register.page()``
+    as a decorator-level override.
     """
 
     def __init__(self, source: PluginPageSource, source_value: str,
-                 auth: bool = True, menu: Optional[Union[dict, "PageMenu"]] = None):
+                 menu: Optional[Union[dict, "PageMenu"]] = None):
         self.source = source
         self.source_value = source_value
-        self.auth = auth
         self.menu = menu
 
     @classmethod
-    def from_folder(cls, path: str, auth: bool = True,
+    def from_folder(cls, path: str,
                     menu: Optional[Union[dict, "PageMenu"]] = None) -> "PluginPage":
         """Serve static files from a directory relative to the plugin root.
 
@@ -124,34 +128,31 @@ class PluginPage:
 
         Args:
             path: Directory path relative to the plugin root, e.g. ``"./web"``.
-            auth: Require JWT auth (default ``True``).
-            menu: Optional sidebar menu config dict.
+            menu: Optional sidebar menu config — a ``PageMenu`` object or a dict.
         """
-        return cls(PluginPageSource.FOLDER, path, auth, menu)
+        return cls(PluginPageSource.FOLDER, path, menu)
 
     @classmethod
-    def from_url(cls, url: str, auth: bool = True,
+    def from_url(cls, url: str,
                  menu: Optional[Union[dict, "PageMenu"]] = None) -> "PluginPage":
         """Redirect the iframe to an external URL.
 
         Args:
             url: Full URL to redirect to, e.g. ``"https://example.com"``.
-            auth: Require JWT auth (default ``True``).
-            menu: Optional sidebar menu config dict.
+            menu: Optional sidebar menu config — a ``PageMenu`` object or a dict.
         """
-        return cls(PluginPageSource.URL, url, auth, menu)
+        return cls(PluginPageSource.URL, url, menu)
 
     @classmethod
-    def from_html(cls, html: str, auth: bool = True,
+    def from_html(cls, html: str,
                   menu: Optional[Union[dict, "PageMenu"]] = None) -> "PluginPage":
         """Serve a static HTML string.
 
         Args:
             html: Raw HTML content.
-            auth: Require JWT auth (default ``True``).
-            menu: Optional sidebar menu config dict.
+            menu: Optional sidebar menu config — a ``PageMenu`` object or a dict.
         """
-        return cls(PluginPageSource.HTML, html, auth, menu)
+        return cls(PluginPageSource.HTML, html, menu)
 
 
 @dataclass
@@ -349,10 +350,9 @@ class RegisterDeco:
             comp = _ensure_components(plugin_id)
 
             if isinstance(obj, PluginPage):
-                obj.auth = auth
                 if menu is not None:
                     obj.menu = menu
-                comp.register_page(route, None, obj.auth, obj.menu, page_obj=obj)
+                comp.register_page(route, None, auth, obj.menu, page_obj=obj)
                 return obj
 
             # Function that returns PluginPage — defer call to init time
@@ -1013,8 +1013,6 @@ class PluginManager:
                     continue
 
                 # Merge decorator-level overrides
-                if page["auth"] is not None:
-                    page_obj.auth = page["auth"]
                 if page.get("menu") is not None:
                     page_obj.menu = page["menu"]
 

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -302,19 +302,11 @@ class RegisterDeco:
     def page(route: str, auth: bool = True, menu: Optional[dict] = None):
         """Register a plugin page endpoint.
 
-        Accepts either a ``PluginPage`` object or a callable that returns one.
-
-        **Object-based** (recommended — required for ``from_folder``)::
+        Accepts a ``PluginPage`` object or a function that returns one::
 
             @register.page("/dashboard", menu={"label": "Dashboard", "icon": "Monitor"})
-            def dashboard():
+            def dashboard(self):
                 return PluginPage.from_folder("./web")
-
-        **Function-based** (legacy, still supported)::
-
-            @register.page("/legacy")
-            async def legacy_page(self):
-                return HTMLResponse("<h1>Hello</h1>")
 
         Args:
             route: URL path relative to plugin prefix, e.g. ``"/dashboard"``.
@@ -333,22 +325,9 @@ class RegisterDeco:
                 comp.register_page(route, None, obj.auth, obj.menu, page_obj=obj)
                 return obj
 
-            # Check if the function's return annotation indicates PluginPage.
-            # For class methods, we can't call them at decoration time (no
-            # instance yet), so we mark it and defer to _register_plugin_pages_for
-            # where the instance is available.
-            import typing
-            returns_plugin_page = False
-            try:
-                hints = typing.get_type_hints(obj)
-                rt = hints.get("return")
-                if rt is PluginPage or (isinstance(rt, str) and rt == "PluginPage"):
-                    returns_plugin_page = True
-            except Exception:
-                pass
-
-            comp.register_page(route, obj, auth, menu,
-                               returns_plugin_page=returns_plugin_page)
+            # Function that returns PluginPage — defer call to init time
+            # where the plugin instance is available.
+            comp.register_page(route, obj, auth, menu, returns_plugin_page=True)
             comp.page_funcs[obj.__name__] = obj
             return obj
         return decorator
@@ -1126,64 +1105,6 @@ class PluginManager:
                     registered.append(f"{full_path} (html)")
 
                 continue
-
-            # ── Legacy function-based pages ────────────────────────────────
-            func = page["func"]
-            func_name = func.__name__
-
-            # Resolve annotations eagerly using the plugin module's own globals
-            try:
-                resolved_hints = typing.get_type_hints(func, globalns=func.__globals__)
-            except Exception:
-                resolved_hints = {}
-
-            params = [
-                p.replace(annotation=resolved_hints.get(name, p.annotation))
-                for name, p in inspect.signature(func).parameters.items()
-                if name != "self"
-            ]
-
-            # Capture loop variables via default args to avoid closure issues
-            async def dynamic_page_endpoint(
-                _pid=plugin_id, _fname=func_name, _mgr=mgr, **kwargs
-            ):
-                inst = _mgr.plugin_instances.get(_pid)
-                if inst is None:
-                    raise HTTPException(status_code=503, detail="Plugin not available")
-                raw = getattr(inst, _fname)(**kwargs)
-                import asyncio
-                if asyncio.iscoroutine(raw) or asyncio.isfuture(raw):
-                    result = await raw
-                else:
-                    result = raw
-                # Support legacy functions that return a PluginPage at request time
-                if isinstance(result, PluginPage):
-                    if result.source == PluginPageSource.URL:
-                        return RedirectResponse(url=result.source_value)
-                    elif result.source == PluginPageSource.HTML:
-                        return HTMLResponse(content=result.source_value)
-                    else:
-                        raise HTTPException(
-                            status_code=500,
-                            detail="PluginPage.from_folder() must be used with "
-                                   "@register.page(), not returned from a function",
-                        )
-                return result
-
-            dynamic_page_endpoint.__signature__ = inspect.Signature(params)
-
-            dependencies = []
-            if page["auth"]:
-                dependencies.append(Depends(require_auth))
-
-            self._web_app.add_api_route(
-                path=full_path,
-                endpoint=dynamic_page_endpoint,
-                methods=["GET"],
-                dependencies=dependencies,
-                tags=[f"plugin:{plugin_id}"],
-            )
-            registered.append(full_path)
 
         if registered:
             logger.info(f"Registered {len(registered)} page routes from {plugin_id}: {registered}")

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -84,6 +84,10 @@ class PageMenu:
                                     f"got {type(k).__name__}: {type(v).__name__}")
                 if not v.strip():
                     raise ValueError(f"label dict value for '{k}' must not be empty or whitespace")
+        if icon is not None and not isinstance(icon, str):
+            raise TypeError(f"icon must be a string if provided, got {type(icon).__name__}")
+        if not isinstance(order, int) or isinstance(order, bool):
+            raise TypeError(f"order must be an integer, got {type(order).__name__}")
         self.label: Union[str, Dict[str, str]] = label
         self.icon: Optional[str] = icon
         self.order: int = order
@@ -108,19 +112,15 @@ class PluginPage:
     - ``PluginPage.from_url("https://example.com")`` — redirect to an external URL.
     - ``PluginPage.from_html("<h1>Hello</h1>")`` — serve inline HTML.
 
-    The *menu* parameter can also be passed to ``@register.page()``
-    as a decorator-level override.
+    Use ``@register.page()`` decorator parameters to control *auth* and *menu*.
     """
 
-    def __init__(self, source: PluginPageSource, source_value: str,
-                 menu: Optional[Union[dict, "PageMenu"]] = None):
+    def __init__(self, source: PluginPageSource, source_value: str):
         self.source = source
         self.source_value = source_value
-        self.menu = menu
 
     @classmethod
-    def from_folder(cls, path: str,
-                    menu: Optional[Union[dict, "PageMenu"]] = None) -> "PluginPage":
+    def from_folder(cls, path: str) -> "PluginPage":
         """Serve static files from a directory relative to the plugin root.
 
         Only files *inside* the plugin directory are accessible — any path
@@ -128,31 +128,26 @@ class PluginPage:
 
         Args:
             path: Directory path relative to the plugin root, e.g. ``"./web"``.
-            menu: Optional sidebar menu config — a ``PageMenu`` object or a dict.
         """
-        return cls(PluginPageSource.FOLDER, path, menu)
+        return cls(PluginPageSource.FOLDER, path)
 
     @classmethod
-    def from_url(cls, url: str,
-                 menu: Optional[Union[dict, "PageMenu"]] = None) -> "PluginPage":
+    def from_url(cls, url: str) -> "PluginPage":
         """Redirect the iframe to an external URL.
 
         Args:
             url: Full URL to redirect to, e.g. ``"https://example.com"``.
-            menu: Optional sidebar menu config — a ``PageMenu`` object or a dict.
         """
-        return cls(PluginPageSource.URL, url, menu)
+        return cls(PluginPageSource.URL, url)
 
     @classmethod
-    def from_html(cls, html: str,
-                  menu: Optional[Union[dict, "PageMenu"]] = None) -> "PluginPage":
+    def from_html(cls, html: str) -> "PluginPage":
         """Serve a static HTML string.
 
         Args:
             html: Raw HTML content.
-            menu: Optional sidebar menu config — a ``PageMenu`` object or a dict.
         """
-        return cls(PluginPageSource.HTML, html, menu)
+        return cls(PluginPageSource.HTML, html)
 
 
 @dataclass
@@ -350,9 +345,7 @@ class RegisterDeco:
             comp = _ensure_components(plugin_id)
 
             if isinstance(obj, PluginPage):
-                if menu is not None:
-                    obj.menu = menu
-                comp.register_page(route, None, auth, obj.menu, page_obj=obj)
+                comp.register_page(route, None, auth, menu, page_obj=obj)
                 return obj
 
             # Function that returns PluginPage — defer call to init time
@@ -1012,9 +1005,7 @@ class PluginManager:
                     logger.error(f"Plugin {plugin_id}: {func.__name__}() did not return PluginPage")
                     continue
 
-                # Merge decorator-level overrides
-                if page.get("menu") is not None:
-                    page_obj.menu = page["menu"]
+                # Merge decorator-level overrides (menu already handled by register_page)
 
                 # Handle the PluginPage (same logic as object-based above)
                 if page_obj.source == PluginPageSource.FOLDER:

--- a/webui/app.py
+++ b/webui/app.py
@@ -10,6 +10,8 @@ from typing import Optional
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
 import uvicorn
 
 from core.lifecycle import KiraLifecycle
@@ -84,6 +86,59 @@ class KiraWebUI:
             allow_methods=["*"],
             allow_headers=["*"],
         )
+
+        # Inject plugin-bridge.js into HTML responses served under /page/plugin/
+        _BRIDGE_TAG = '<script src="/plugin-bridge.js"></script>'
+        _BRIDGE_MARKER = '/plugin-bridge.js'
+
+        class PluginBridgeInjectionMiddleware(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                response = await call_next(request)
+                path = request.url.path
+                if not path.startswith('/page/plugin/') or request.method != 'GET':
+                    return response
+                ct = response.headers.get('content-type', '')
+                if 'text/html' not in ct:
+                    return response
+                body = b''
+                async for chunk in response.body_iterator:
+                    body += chunk if isinstance(chunk, bytes) else chunk.encode()
+                try:
+                    html = body.decode('utf-8')
+                except UnicodeDecodeError:
+                    return Response(content=body, status_code=response.status_code,
+                                   headers=dict(response.headers))
+                if _BRIDGE_MARKER in html:
+                    return Response(content=html.encode('utf-8'), status_code=response.status_code,
+                                   headers={k: v for k, v in response.headers.items()
+                                            if k.lower() != 'content-length'},
+                                   media_type='text/html')
+                if '</head>' in html:
+                    html = html.replace('</head>', _BRIDGE_TAG + '</head>', 1)
+                elif '<body' in html:
+                    idx = html.index('<body')
+                    end = html.index('>', idx) + 1
+                    html = html[:end] + _BRIDGE_TAG + html[end:]
+                else:
+                    html = _BRIDGE_TAG + html
+                # Strip content-length + caching headers — body changed,
+                # and stale cached copies would miss the bridge injection.
+                strip = {'content-length', 'etag', 'last-modified'}
+                hdrs = {k: v for k, v in response.headers.items()
+                        if k.lower() not in strip}
+                hdrs['cache-control'] = 'no-store'
+                return Response(content=html.encode('utf-8'), status_code=response.status_code,
+                               headers=hdrs, media_type='text/html')
+
+        self.app.add_middleware(PluginBridgeInjectionMiddleware)
+
+        # Serve the plugin bridge SDK directly so it works before frontend is built
+        bridge_js_path = self.webui_dir / 'frontend' / 'public' / 'plugin-bridge.js'
+        if bridge_js_path.exists():
+            from fastapi.responses import FileResponse as _FileResponse
+            @self.app.get('/plugin-bridge.js', include_in_schema=False)
+            async def serve_bridge_js():
+                return _FileResponse(bridge_js_path, media_type='application/javascript')
 
         # Mount user sticker library
         if self.sticker_dir.exists():

--- a/webui/frontend/public/plugin-bridge.js
+++ b/webui/frontend/public/plugin-bridge.js
@@ -1,0 +1,184 @@
+/**
+ * PluginPageContext Bridge SDK
+ *
+ * Injected automatically into plugin page iframes. Establishes a
+ * postMessage channel with the parent WebUI so plugin pages can receive
+ * context (theme, locale, plugin identity) and call plugin APIs.
+ *
+ * Usage in plugin HTML:
+ *   <script src="/plugin-bridge.js"></script>
+ *   <script>
+ *     window.PluginPageContext.ready().then(ctx => {
+ *       console.log(ctx.pluginId, ctx.isDark);
+ *     });
+ *   </script>
+ */
+;(function () {
+  'use strict'
+
+  var CHANNEL = 'kira-plugin-page'
+  var context = null
+  var readyPromise = null
+  var readyResolve = null
+  var contextHandlers = []
+  var themeHandlers = []
+  var idCounter = 0
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  function sendToParent(msg) {
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage(Object.assign({ channel: CHANNEL }, msg), '*')
+    }
+  }
+
+  function applyContext(next) {
+    var prevTheme = context ? context.isDark : null
+    context = next
+    // Set data-theme on <html> so plugin pages can use [data-theme="dark"] CSS
+    if (typeof next.isDark === 'boolean') {
+      document.documentElement.setAttribute('data-theme', next.isDark ? 'dark' : 'light')
+    }
+    // Notify all context listeners
+    for (var i = 0; i < contextHandlers.length; i++) {
+      try { contextHandlers[i](context) } catch (_) {}
+    }
+    // Notify theme listeners only if theme actually changed
+    if (prevTheme !== null && prevTheme !== next.isDark) {
+      for (var j = 0; j < themeHandlers.length; j++) {
+        try { themeHandlers[j](next.isDark) } catch (_) {}
+      }
+    }
+  }
+
+  // ── Message listener ────────────────────────────────────────────────────
+
+  window.addEventListener('message', function (e) {
+    var data = e.data
+    if (!data || data.channel !== CHANNEL) return
+
+    if (data.kind === 'context') {
+      applyContext(data.context)
+      if (readyResolve) {
+        readyResolve(context)
+        readyResolve = null
+      }
+    }
+  })
+
+  // ── Public API ──────────────────────────────────────────────────────────
+
+  /**
+   * Returns a Promise that resolves with the context object once the
+   * parent has sent the initial context. Calling ready() after context
+   * is already available resolves immediately.
+   */
+  function ready() {
+    if (context) return Promise.resolve(context)
+    if (!readyPromise) {
+      readyPromise = new Promise(function (resolve) {
+        readyResolve = resolve
+      })
+    }
+    return readyPromise
+  }
+
+  /** Synchronous access to the current context (null if not yet received). */
+  function getContext() {
+    return context
+  }
+
+  /**
+   * Subscribe to any context change (theme, locale, etc.).
+   * Returns an unsubscribe function.
+   */
+  function onContext(handler) {
+    contextHandlers.push(handler)
+    return function () {
+      var idx = contextHandlers.indexOf(handler)
+      if (idx !== -1) contextHandlers.splice(idx, 1)
+    }
+  }
+
+  /**
+   * Subscribe to theme changes only.
+   * handler(isDark: boolean) — called when dark mode toggles.
+   * Returns an unsubscribe function.
+   */
+  function onThemeChange(handler) {
+    themeHandlers.push(handler)
+    return function () {
+      var idx = themeHandlers.indexOf(handler)
+      if (idx !== -1) themeHandlers.splice(idx, 1)
+    }
+  }
+
+  // ── API helpers (same-origin fetch, cookie auth automatic) ──────────────
+
+  function buildPluginApiUrl(endpoint) {
+    var pluginId = context ? context.pluginId : ''
+    var normalized = endpoint.replace(/^\/+/, '')
+    return '/api/plugin/' + encodeURIComponent(pluginId) + '/' + normalized
+  }
+
+  function apiGet(endpoint, params) {
+    var url = buildPluginApiUrl(endpoint)
+    if (params) {
+      var qs = new URLSearchParams(params).toString()
+      if (qs) url += '?' + qs
+    }
+    return fetch(url, { credentials: 'same-origin' }).then(function (r) {
+      return r.json()
+    })
+  }
+
+  function apiPost(endpoint, body) {
+    return fetch(buildPluginApiUrl(endpoint), {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body || {}),
+    }).then(function (r) {
+      return r.json()
+    })
+  }
+
+  function apiUpload(endpoint, file, fieldName) {
+    var fd = new FormData()
+    fd.append(fieldName || 'file', file)
+    return fetch(buildPluginApiUrl(endpoint), {
+      method: 'POST',
+      credentials: 'same-origin',
+      body: fd,
+    }).then(function (r) {
+      return r.json()
+    })
+  }
+
+  function apiDelete(endpoint) {
+    return fetch(buildPluginApiUrl(endpoint), {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    }).then(function (r) {
+      return r.json()
+    })
+  }
+
+  // ── Expose global ───────────────────────────────────────────────────────
+
+  window.PluginPageContext = {
+    ready: ready,
+    getContext: getContext,
+    onContext: onContext,
+    onThemeChange: onThemeChange,
+    api: {
+      get: apiGet,
+      post: apiPost,
+      upload: apiUpload,
+      delete: apiDelete,
+    },
+  }
+
+  // Signal the parent that the bridge is loaded
+  sendToParent({ kind: 'ready' })
+})()

--- a/webui/frontend/src/components/layout/AppSidebar.vue
+++ b/webui/frontend/src/components/layout/AppSidebar.vue
@@ -36,8 +36,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted } from 'vue'
+import { computed, ref, watch, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { usePluginMenuStore } from '@/stores/pluginMenu'
 import { getVersion } from '@/api/overview'
@@ -68,6 +69,12 @@ const appVersion = ref('-')
 const route = useRoute()
 const appStore = useAppStore()
 const pluginMenuStore = usePluginMenuStore()
+const { locale } = useI18n()
+
+// Re-resolve plugin page labels when UI language changes
+watch(locale, (newLocale) => {
+  pluginMenuStore.reResolveLabels(newLocale)
+})
 
 onMounted(async () => {
   try {

--- a/webui/frontend/src/stores/pluginMenu.ts
+++ b/webui/frontend/src/stores/pluginMenu.ts
@@ -27,7 +27,7 @@ export function resolveLabel(label: string | Record<string, string>, locale: str
     const first = Object.values(label)[0]
     if (first) return first
   }
-  return String(label)
+  return ''
 }
 
 export const usePluginMenuStore = defineStore('pluginMenu', () => {

--- a/webui/frontend/src/stores/pluginMenu.ts
+++ b/webui/frontend/src/stores/pluginMenu.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { getPlugins } from '@/api/plugin'
 import router from '@/router'
 
@@ -8,20 +9,38 @@ export interface PluginMenuItem {
   pluginName: string
   route: string       // Vue Router path, e.g. /plugin-page/my-plugin/dashboard
   pageRoute: string   // The page route segment passed to PluginPageView
-  label: string
+  rawLabel: string | Record<string, string>  // Raw label from API (for i18n re-resolution)
+  label: string       // Resolved display text (re-computed on locale change)
   icon: string | null
   order: number
+}
+
+/**
+ * Resolve a label that may be a plain string or a locale dict.
+ * Falls back: requested locale → "en" → first available value → raw key.
+ */
+export function resolveLabel(label: string | Record<string, string>, locale: string): string {
+  if (typeof label === 'string') return label
+  if (typeof label === 'object' && label !== null) {
+    if (label[locale]) return label[locale]
+    if (label['en']) return label['en']
+    const first = Object.values(label)[0]
+    if (first) return first
+  }
+  return String(label)
 }
 
 export const usePluginMenuStore = defineStore('pluginMenu', () => {
   const menus = ref<PluginMenuItem[]>([])
   const loaded = ref(false)
+  const { locale } = useI18n()
 
   async function fetchAndRegisterMenus() {
     try {
       const { data } = await getPlugins()
       const newMenus: PluginMenuItem[] = []
       const seenRoutes = new Set<string>()
+      const currentLocale = locale.value
 
       for (const plugin of data) {
         if (!plugin.enabled || !plugin.menus?.length) continue
@@ -41,7 +60,8 @@ export const usePluginMenuStore = defineStore('pluginMenu', () => {
             pluginName: plugin.name,
             route: internalRoute,
             pageRoute,
-            label: menu.label,
+            rawLabel: menu.label,
+            label: resolveLabel(menu.label, currentLocale),
             icon: menu.icon,
             order: menu.order ?? 100,
           })
@@ -79,5 +99,13 @@ export const usePluginMenuStore = defineStore('pluginMenu', () => {
     }
   }
 
-  return { menus, loaded, fetchAndRegisterMenus }
+  /** Re-resolve all labels for a new locale (no API call). */
+  function reResolveLabels(newLocale: string) {
+    menus.value = menus.value.map(m => ({
+      ...m,
+      label: resolveLabel(m.rawLabel, newLocale),
+    }))
+  }
+
+  return { menus, loaded, fetchAndRegisterMenus, reResolveLabels }
 })

--- a/webui/frontend/src/types/models.ts
+++ b/webui/frontend/src/types/models.ts
@@ -102,7 +102,7 @@ export interface StickerUpdateRequest {
 
 export interface PageMenu {
   route: string
-  label: string
+  label: string | Record<string, string>
   icon: string | null
   order: number
 }

--- a/webui/frontend/src/views/PluginPageView.vue
+++ b/webui/frontend/src/views/PluginPageView.vue
@@ -61,7 +61,13 @@ function onMessage(e: MessageEvent) {
   }
 }
 
-onMounted(() => window.addEventListener('message', onMessage))
+onMounted(() => {
+  window.addEventListener('message', onMessage)
+  // Send context immediately in case the iframe's bridge already fired "ready"
+  // before we attached the listener. Harmless if iframe hasn't loaded yet —
+  // it will request context via its own "ready" message when it does.
+  sendContext()
+})
 onUnmounted(() => window.removeEventListener('message', onMessage))
 
 // Re-send context when theme or locale changes

--- a/webui/frontend/src/views/PluginPageView.vue
+++ b/webui/frontend/src/views/PluginPageView.vue
@@ -2,6 +2,7 @@
   <div class="plugin-page-wrapper">
     <iframe
       v-if="pageUrl"
+      ref="iframeRef"
       :src="pageUrl"
       class="plugin-page-iframe"
       sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
@@ -13,18 +14,59 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAppStore } from '@/stores/app'
+
+const CHANNEL = 'kira-plugin-page'
 
 const props = defineProps<{
   pluginId: string
   pageRoute: string
 }>()
 
+const iframeRef = ref<HTMLIFrameElement | null>(null)
+const appStore = useAppStore()
+const { locale } = useI18n()
+
 const pageUrl = computed(() => {
   if (!props.pluginId || !props.pageRoute) return ''
-  // Auth is handled via kira_token cookie — iframe sends it automatically (same-origin)
   return `/page/plugin/${encodeURIComponent(props.pluginId)}/${props.pageRoute}`
 })
+
+function buildContext() {
+  return {
+    channel: CHANNEL,
+    kind: 'context' as const,
+    context: {
+      pluginId: props.pluginId,
+      pageRoute: props.pageRoute,
+      isDark: appStore.isDark,
+      locale: locale.value,
+    },
+  }
+}
+
+function sendContext() {
+  const iframe = iframeRef.value
+  if (!iframe?.contentWindow) return
+  iframe.contentWindow.postMessage(buildContext(), '*')
+}
+
+function onMessage(e: MessageEvent) {
+  const data = e.data
+  if (!data || data.channel !== CHANNEL) return
+  if (data.kind === 'ready') {
+    sendContext()
+  }
+}
+
+onMounted(() => window.addEventListener('message', onMessage))
+onUnmounted(() => window.removeEventListener('message', onMessage))
+
+// Re-send context when theme or locale changes
+watch(() => appStore.isDark, sendContext)
+watch(locale, sendContext)
 </script>
 
 <style scoped>

--- a/webui/models.py
+++ b/webui/models.py
@@ -131,13 +131,15 @@ class PageMenu(BaseModel):
     def validate_label(cls, v):
         if isinstance(v, str):
             if not v.strip():
-                raise ValueError("label string must not be empty")
+                raise ValueError("label string must not be empty or whitespace")
             return v
         if isinstance(v, dict):
             for key, val in v.items():
                 if not isinstance(key, str) or not isinstance(val, str):
                     raise ValueError(f"label dict keys and values must be strings, "
                                      f"got {type(key).__name__}: {type(val).__name__}")
+                if not val.strip():
+                    raise ValueError(f"label dict value for '{key}' must not be empty or whitespace")
             return v
         raise ValueError(f"label must be a str or dict, got {type(v).__name__}")
 

--- a/webui/models.py
+++ b/webui/models.py
@@ -1,9 +1,9 @@
 """
 Pydantic models shared across WebUI routes.
 """
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class LoginRequest(BaseModel):
@@ -122,9 +122,24 @@ class StickerUpdateRequest(BaseModel):
 class PageMenu(BaseModel):
     """Menu entry for a plugin page, shown in sidebar."""
     route: str
-    label: str
+    label: Union[str, Dict[str, str]]
     icon: Optional[str] = None
     order: int = 100
+
+    @field_validator('label')
+    @classmethod
+    def validate_label(cls, v):
+        if isinstance(v, str):
+            if not v.strip():
+                raise ValueError("label string must not be empty")
+            return v
+        if isinstance(v, dict):
+            for key, val in v.items():
+                if not isinstance(key, str) or not isinstance(val, str):
+                    raise ValueError(f"label dict keys and values must be strings, "
+                                     f"got {type(key).__name__}: {type(val).__name__}")
+            return v
+        raise ValueError(f"label must be a str or dict, got {type(v).__name__}")
 
 
 class PluginItem(BaseModel):

--- a/webui/routes/plugins.py
+++ b/webui/routes/plugins.py
@@ -145,9 +145,9 @@ class PluginsRoutes(Routes):
                             continue
                         menus.append(PageMenu(
                             route=f"/page/plugin/{pid}/{page['route'].lstrip('/')}",
-                            label=menu_cfg.get("label", pid),
-                            icon=menu_cfg.get("icon"),
-                            order=menu_cfg.get("order", 100),
+                            label=menu_cfg.label,
+                            icon=menu_cfg.icon,
+                            order=menu_cfg.order,
                         ))
                     menus.sort(key=lambda m: m.order)
                 items.append(


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Enhance the plugin page registration system with a flexible `PluginPage` object that supports multiple content sources (`from_folder`, `from_url`, `from_html`), replacing the previous function-only pattern. Adds path traversal protection for folder-based pages and integrated auth gating for mounted static file apps.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [x] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Introduced `PluginPage` object with `from_folder()`, `from_url()`, `from_html()` factory methods
- `from_folder` serves static files from a plugin directory with path traversal protection
- `from_url` redirects the iframe to an external URL
- `from_html` serves inline HTML (replaces the old `HTMLResponse` pattern)
- `get_obj_plugin_id` now walks the call stack as fallback for non-function objects (e.g. `PluginPage` instances)
- Added `PluginPageStaticFiles` with integrated auth + plugin-enabled gating for mounted folder pages
- Removed legacy function-based page handler (`async def` returning `HTMLResponse` directly)
- `@register.page()` always defers function calls to init time — no type annotation required
- Updated `schema_test` plugin with `from_html` and `from_folder` test pages

## Screenshots / Logs

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified plugin page registration: you can now pass either a `PluginPage` or a callable returning one; menu types were expanded for locale-aware labels.
* **New Features**
  * Added an iframe plugin-page context/theme bridge using `postMessage`, with automatic script injection and direct serving of the bridge SDK.
  * Plugin menu labels now re-localize instantly when the UI language changes.
* **Refactor**
  * Standardized plugin page route registration to rely on deferred providers for callable registrations.
* **Bug Fixes**
  * Prevented modified plugin-page HTML responses from being cached by updating response headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->