### PR TITLE
fix: wrap get_default_vlm() calls to prevent crash when default_vlm not set

### DIFF
--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -243,10 +243,14 @@ class MessageProcessor:
                     if cached_desc:
                         img_desc = cached_desc
                     else:
-                        vlm_model = self.provider_mgr.get_default_vlm()
-                        img_desc = await desc_img(client=vlm_model, image=ele)
-                        if md5:
-                            await self.image_desc_cache.set(md5, img_desc)
+                        try:
+                            vlm_model = self.provider_mgr.get_default_vlm()
+                            img_desc = await desc_img(client=vlm_model, image=ele)
+                            if md5:
+                                await self.image_desc_cache.set(md5, img_desc)
+                        except Exception as e:
+                            logger.error(f"Failed to get default VLM model for image description: {e}")
+                            img_desc = ""
                     ele.caption = img_desc
                 else:
                     try:
@@ -280,10 +284,14 @@ class MessageProcessor:
                     if cached_desc:
                         sticker_desc = cached_desc
                     else:
-                        vlm_model = self.provider_mgr.get_default_vlm()
-                        sticker_desc = await desc_img(client=vlm_model, image=ele)
-                        if md5:
-                            await self.image_desc_cache.set(md5, sticker_desc)
+                        try:
+                            vlm_model = self.provider_mgr.get_default_vlm()
+                            sticker_desc = await desc_img(client=vlm_model, image=ele)
+                            if md5:
+                                await self.image_desc_cache.set(md5, sticker_desc)
+                        except Exception as e:
+                            logger.error(f"Failed to get default VLM model for sticker description: {e}")
+                            sticker_desc = ""
                     ele.caption = sticker_desc
                 else:
                     try:

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -246,11 +246,15 @@ class MessageProcessor:
                         try:
                             vlm_model = self.provider_mgr.get_default_vlm()
                             img_desc = await desc_img(client=vlm_model, image=ele)
-                            if md5:
-                                await self.image_desc_cache.set(md5, img_desc)
                         except Exception as e:
                             logger.error(f"Failed to get default VLM model for image description: {e}")
                             img_desc = ""
+
+                        if md5 and img_desc:
+                            try:
+                                await self.image_desc_cache.set(md5, img_desc)
+                            except Exception as e:
+                                logger.warning(f"Failed to cache image desc: {e}")
                     ele.caption = img_desc
                 else:
                     try:
@@ -287,11 +291,15 @@ class MessageProcessor:
                         try:
                             vlm_model = self.provider_mgr.get_default_vlm()
                             sticker_desc = await desc_img(client=vlm_model, image=ele)
-                            if md5:
-                                await self.image_desc_cache.set(md5, sticker_desc)
                         except Exception as e:
                             logger.error(f"Failed to get default VLM model for sticker description: {e}")
                             sticker_desc = ""
+
+                        if md5 and sticker_desc:
+                            try:
+                                await self.image_desc_cache.set(md5, sticker_desc)
+                            except Exception as e:
+                                logger.warning(f"Failed to cache sticker desc: {e}")
                     ele.caption = sticker_desc
                 else:
                     try:


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Fixes unhandled `ValueError` crash when `default_vlm` is not configured. The `message_format_to_text()` method in `core/message_manager.py` calls `get_default_vlm()` without try/except protection in two places — Image and Sticker processing — causing the entire message handling flow to crash on any message containing images/stickers when no default VLM is set.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Wrapped `get_default_vlm()` call in Image processing path with try/except, logging error and falling back to empty string `""`
- Applied same defensive pattern to Sticker processing path
- Follows the existing pattern already used in `sticker/main.py:99`

## Screenshots / Logs

N/A — the fix prevents a crash; after the fix, affected messages will log:
```
Failed to get default VLM model for image description: <error>
Failed to get default VLM model for sticker description: <error>
```
and continue processing without VLM description.

## Checklist

- [ ] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for image and sticker caption generation. The system now gracefully handles processing failures by logging errors and using fallback descriptions instead of interrupting the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->