### PR TITLE
feat(sticker): add VLM concurrency control for default-sticker

### DIFF
--- a/core/plugin/builtin_plugins/sticker/main.py
+++ b/core/plugin/builtin_plugins/sticker/main.py
@@ -1,7 +1,6 @@
 import os
 import asyncio
 
-from pathlib import Path
 from typing import Optional, Type
 
 from core.logging_manager import get_logger
@@ -13,6 +12,8 @@ from core.utils.path_utils import get_data_path
 from core.chat.message_elements import BaseMessageElement, Sticker
 
 message_logger = get_logger("message", "cyan")
+
+STICKER_EXTENSIONS = (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp")
 
 
 def build_sticker_tag(sticker_dict: dict) -> Type[BaseTag]:
@@ -41,6 +42,7 @@ def build_sticker_tag(sticker_dict: dict) -> Type[BaseTag]:
                 return [sticker_obj]
             except Exception as e:
                 message_logger.error(f"error while parsing sticker: {str(e)}")
+                return []
 
     return StickerTag
 
@@ -57,6 +59,8 @@ class DefaultStickerPlugin(BasePlugin):
         self.scan_interval = 120
         self.recognition_model = None
         self.recognition_prompt = self.DEFAULT_RECOGNITION_PROMPT
+        self.vlm_concurrency = 3
+        self._vlm_sem: Optional[asyncio.Semaphore] = None
         self.sticker_mgr = self.ctx.sticker_manager
         self._scan_task: Optional[asyncio.Task] = None
     
@@ -64,15 +68,23 @@ class DefaultStickerPlugin(BasePlugin):
         self.scan_interval = self.plugin_cfg.get("scan_interval", 120)
         self.recognition_model = self.plugin_cfg.get("recognition_model", None)
         self.recognition_prompt = self.plugin_cfg.get("recognition_prompt", "").strip() or self.DEFAULT_RECOGNITION_PROMPT
+        self.vlm_concurrency = max(self.plugin_cfg.get("vlm_concurrency", 3), 1)
+        self._vlm_sem = asyncio.Semaphore(self.vlm_concurrency)
         self.sticker_mgr.on_sticker_registered(self.on_sticker_registered)
 
         self._scan_task = asyncio.create_task(self._scan_loop())
+        logger.info(f"Default Sticker initialized (vlm_concurrency={self.vlm_concurrency})")
     
     async def terminate(self):
         self.sticker_mgr.off_sticker_registered(self.on_sticker_registered)
 
         if self._scan_task:
             self._scan_task.cancel()
+            try:
+                await self._scan_task
+            except asyncio.CancelledError:
+                pass
+            self._scan_task = None
 
     async def on_sticker_registered(self, sticker_id: str, sticker_info: dict):
         path = sticker_info.get("path")
@@ -80,12 +92,13 @@ class DefaultStickerPlugin(BasePlugin):
 
         if desc:
             return
-        try:
-            sticker_desc = await self.get_sticker_description(path)
-            await self.sticker_mgr.update_sticker_desc(sticker_id, sticker_desc)
-            logger.info(f"Sticker {sticker_id} description updated by VLM: {sticker_desc}")
-        except Exception as e:
-            logger.error(f"Failed to get description for sticker {sticker_id} by VLM: {e}")
+        async with self._vlm_sem:
+            try:
+                sticker_desc = await self.get_sticker_description(path)
+                await self.sticker_mgr.update_sticker_desc(sticker_id, sticker_desc)
+                logger.info(f"Sticker {sticker_id} description updated by VLM: {sticker_desc}")
+            except Exception as e:
+                logger.error(f"Failed to get description for sticker {sticker_id} by VLM: {e}")
 
     async def get_sticker_description(self, sticker_file):
         sticker_path = os.path.join(self.sticker_mgr.sticker_folder, sticker_file)
@@ -105,22 +118,50 @@ class DefaultStickerPlugin(BasePlugin):
 
         return sticker_desc
 
+    async def _scan_once(self):
+        logger.info("Scanning unregistered stickers")
+        sticker_files = [
+            f for f in os.listdir(self.sticker_mgr.sticker_folder)
+            if f.lower().endswith(STICKER_EXTENSIONS)
+        ]
+        pending = [
+            f for f in sticker_files
+            if f not in self.sticker_mgr.sticker_paths
+        ]
+
+        if pending:
+            logger.info(f"Found {len(pending)} unregistered stickers, describing (vlm_concurrency={self.vlm_concurrency})...")
+
+            async def _describe_one(file: str) -> tuple[str, str]:
+                async with self._vlm_sem:
+                    desc = await self.get_sticker_description(file)
+                    return file, desc
+
+            results = await asyncio.gather(
+                *[_describe_one(f) for f in pending],
+                return_exceptions=True,
+            )
+
+            for item in results:
+                if isinstance(item, Exception):
+                    logger.error(f"VLM description failed during scan: {item}")
+                    continue
+                file, desc = item
+                if desc:
+                    await self.sticker_mgr.register_sticker(file, desc)
+                    logger.info(f"Registered sticker: {desc[:60]}")
+        else:
+            logger.info("All stickers are already registered")
+
     async def _scan_loop(self):
         try:
             while True:
-                logger.info("Scanning unregistered stickers")
-                sticker_files = os.listdir(self.sticker_mgr.sticker_folder)
-                is_found = False
-                for sticker_file in sticker_files:
-                    if sticker_file not in self.sticker_mgr.sticker_paths:
-                        is_found = True
-                        logger.info(f"found sticker {sticker_file}")
-                        sticker_description = await self.get_sticker_description(sticker_file)
-                        logger.info(f"Registered sticker: {sticker_description}")
-                        await self.sticker_mgr.register_sticker(sticker_file, sticker_description)
-
-                if not is_found:
-                    logger.info("All stickers are already registered")
+                try:
+                    await self._scan_once()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.error(f"Scan iteration failed, will retry next interval: {e}")
 
                 delay_minutes = self.scan_interval
                 if delay_minutes < 10:

--- a/core/plugin/builtin_plugins/sticker/schema.json
+++ b/core/plugin/builtin_plugins/sticker/schema.json
@@ -5,7 +5,7 @@
     "default": 120,
     "hint": "Interval of scanning unregistered stickers (Unit: minutes)",
     "locales": {
-      "zh": { "name": "扫描间隔", "hint": "扫描未注册贴纸的间隔（单位：分钟）" }
+      "zh": { "name": "扫描间隔", "hint": "扫描未注册表情包的间隔（单位：分钟）" }
     }
   },
   "recognition_model": {
@@ -33,7 +33,7 @@
     "default": 3,
     "hint": "Maximum concurrent VLM calls for sticker description",
     "locales": {
-      "zh": { "name": "VLM 并发数", "hint": "贴纸 VLM 描述的最大并发数（最小 1）" }
+      "zh": { "name": "VLM 并发数", "hint": "表情包 VLM 描述的最大并发数（最小 1）" }
     }
   }
 }

--- a/core/plugin/builtin_plugins/sticker/schema.json
+++ b/core/plugin/builtin_plugins/sticker/schema.json
@@ -26,5 +26,14 @@
     "locales": {
       "zh": { "name": "表情包识别提示词", "hint": "引导模型识别表情包表情和情绪的提示词，留空使用默认提示词" }
     }
+  },
+  "vlm_concurrency": {
+    "name": "VLM Concurrency",
+    "type": "integer",
+    "default": 3,
+    "hint": "Maximum concurrent VLM calls for sticker description",
+    "locales": {
+      "zh": { "name": "VLM 并发数", "hint": "贴纸 VLM 描述的最大并发数（最小 1）" }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Implements the proposal in #102: adds configurable VLM concurrency control to the built-in `default-sticker` plugin.

Sticker description via VLM is now rate-limited by an `asyncio.Semaphore` (config `vlm_concurrency`, default 3) shared between the periodic scan loop and the registration callback. This prevents VLM API overload when many stickers are registered at once — e.g. when an external plugin batch-registers stickers, which previously fired unbounded concurrent VLM calls via the fire-and-forget `on_sticker_registered` callback.

Several robustness issues found in the same code path are fixed alongside.

> **Note on the architecture choice:** this implements the *plugin-level Semaphore* option from #102. The concurrency gap originates in `StickerManager.register_sticker` (fire-and-forget `create_task`); an alternative is to add a callback queue in `StickerManager` itself. Happy to revise per your preference — see #102 for the discussion.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

**Main feature**
- Add `vlm_concurrency` config (default 3, min 1) to `schema.json`.
- Add a shared `asyncio.Semaphore` guarding all VLM description calls, used by both the scan loop and the `on_sticker_registered` callback.

**Follow-up robustness fixes (same code path)**
- Scan loop no longer dies on a single VLM failure: extracted `_scan_once`, `gather(return_exceptions=True)`, and a per-iteration `try/except` so one bad sticker can't kill the periodic scan permanently.
- `StickerTag.handle` returns `[]` instead of implicit `None` on error, honoring the `-> list[BaseMessageElement]` contract.
- `terminate` now awaits the cancelled scan task before returning, avoiding a lingering background task across plugin reloads.
- Filter `os.listdir` by image extensions so non-image files (`.DS_Store`, subdirectories) are not fed to the VLM.
- Remove unused `from pathlib import Path` import.

## Screenshots / Logs

On startup the plugin now logs the active concurrency:
```
Default Sticker initialized (vlm_concurrency=3)
```

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

Closes #102


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting to control how many sticker descriptions are processed concurrently.

* **Improvements**
  * Sticker parsing failures now fail gracefully without disrupting the flow.
  * Sticker description and registration are more resilient—errors are logged and processing continues.
  * The periodic sticker scan now runs with safer retry behavior when unexpected errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->