### PR TITLE
fix(webui): SPA sticker page returns 404 on refresh

### DIFF
--- a/webui/frontend/src/components/layout/AppSidebar.vue
+++ b/webui/frontend/src/components/layout/AppSidebar.vue
@@ -123,7 +123,10 @@ const navItems = computed(() => {
 })
 
 function isActive(path: string): boolean {
-  return route.path === path
+  // Normalize trailing slashes so refresh (which Vue Router may canonicalise
+  // with a trailing slash) matches the nav item path written without one.
+  const norm = (p: string) => (p.length > 1 && p.endsWith('/') ? p.slice(0, -1) : p)
+  return norm(route.path) === norm(path)
 }
 </script>
 

--- a/webui/routes/auth.py
+++ b/webui/routes/auth.py
@@ -122,6 +122,7 @@ class AuthRoutes(Routes):
         The middleware only intercepts 404 responses for browser GET requests.
         """
         dist_dir = self.dist_dir
+        sticker_dir = self._get_sticker_dir()
 
         class SPAStaticFallbackMiddleware(BaseHTTPMiddleware):
             async def dispatch(self, request, call_next):
@@ -133,8 +134,15 @@ class AuthRoutes(Routes):
                 if "text/html" not in request.headers.get("accept", ""):
                     return response
                 full_path = request.url.path.lstrip("/")
-                if full_path.startswith(("api/", "sticker/", "assets/", "monacoeditorwork/", "page/")):
+                if full_path.startswith(("api/", "assets/", "monacoeditorwork/", "page/")):
                     return response
+                # sticker mount: only exclude if the requested file actually exists
+                # /sticker/xxx.gif → file exists → let mount handle it
+                # /sticker/ or /sticker → SPA route → serve index.html
+                if full_path.startswith("sticker/"):
+                    remaining = full_path[len("sticker/"):]
+                    if remaining and ".." not in remaining and (sticker_dir / remaining).exists():
+                        return response
                 # Serve single-segment root files from dist (favicon.ico, etc.)
                 if full_path and "/" not in full_path and ".." not in full_path:
                     candidate = dist_dir / full_path
@@ -160,6 +168,11 @@ class AuthRoutes(Routes):
 
         self.app.add_middleware(SPAStaticFallbackMiddleware)
 
+    @staticmethod
+    def _get_sticker_dir() -> Path:
+        from core.utils.path_utils import get_data_path
+        return get_data_path() / "sticker"
+
     async def serve_spa(self, request: Request = None, full_path: str = ""):
         """Serve the Vue SPA.
 
@@ -170,8 +183,13 @@ class AuthRoutes(Routes):
         the build command.
         """
         # Don't serve SPA for paths handled by dedicated mounts.
-        if full_path.startswith(("api/", "sticker/", "assets/", "monacoeditorwork/", "page/")):
+        if full_path.startswith(("api/", "assets/", "monacoeditorwork/", "page/")):
             raise HTTPException(status_code=404)
+        # sticker mount: only exclude if the requested file actually exists
+        if full_path.startswith("sticker/"):
+            remaining = full_path[len("sticker/"):]
+            if remaining and ".." not in remaining and (self._get_sticker_dir() / remaining).exists():
+                raise HTTPException(status_code=404)
         # Serve single-segment root files from dist (favicon.ico, etc.).
         # Restrict to one path segment to avoid traversal.
         if full_path and "/" not in full_path and ".." not in full_path:


### PR DESCRIPTION
## Summary

Fixes #105: WebUI sticker page (`/sticker`) returns `{"detail":"Not Found"}` when refreshed.

The root cause is a conflict between FastAPI's `StaticFiles` mount at `/sticker/` (which serves sticker image files) and the Vue SPA route `/sticker` (which should be handled by the SPA fallback middleware).

When the browser refreshes `/sticker`:
1. FastAPI's `StaticFiles` mount returns a 307 redirect to `/sticker/`
2. The SPA middleware catches the 404, but its naive prefix-match exclusion (`"sticker/"`) excludes `/sticker/` — treating it as a static file request instead of a SPA route
3. The 404 is returned as-is, never reaching `index.html`

The fix replaces the naive prefix-match exclusion with a file existence check. Only paths that correspond to an actual file under `data/sticker/` are excluded; the `/sticker/` SPA route (where no file exists) correctly falls through to serve `index.html`.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- `webui/routes/auth.py`: Replace naive `sticker/` prefix exclusion in SPA middleware with a precise file-existence check. Same fix applied to `serve_spa` route handler.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

Closes #105


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static file serving for stickers with more precise detection of available resources, enhancing consistency in file request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->