### PR TITLE
fix(webui): stream backup download instead of buffering in memory

### DIFF
--- a/webui/frontend/src/api/settings.ts
+++ b/webui/frontend/src/api/settings.ts
@@ -36,10 +36,6 @@ export function listBackups() {
   return apiClient.get<BackupItem[]>('/settings/backup/list')
 }
 
-export function downloadBackup(filename: string) {
-  return apiClient.get(`/settings/backup/download/${filename}`, { responseType: 'blob' })
-}
-
 export function deleteBackup(filename: string) {
   return apiClient.delete(`/settings/backup/${filename}`)
 }

--- a/webui/frontend/src/views/SettingsView.vue
+++ b/webui/frontend/src/views/SettingsView.vue
@@ -442,7 +442,6 @@ import {
   getStorageInfo,
   createBackup,
   listBackups,
-  downloadBackup,
   deleteBackup,
   restoreBackup,
   restoreFromBackup,
@@ -614,20 +613,14 @@ async function handleCreateBackup() {
   }
 }
 
-async function handleDownloadBackup(filename: string) {
-  try {
-    const { data } = await downloadBackup(filename)
-    const url = URL.createObjectURL(data as Blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = filename
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-  } catch {
-    // silent
-  }
+function handleDownloadBackup(filename: string) {
+  const a = document.createElement('a')
+  a.href = `/api/settings/backup/download/${encodeURIComponent(filename)}`
+  a.download = filename
+  a.style.display = 'none'
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
 }
 
 async function handleDeleteBackup(filename: string) {


### PR DESCRIPTION
## Summary

Replace Axios `responseType: 'blob'` download with direct browser `<a>` tag navigation, so the backup file streams to disk incrementally instead of being fully buffered in browser memory first. Fixes the issue where large backup downloads caused a noticeable delay before the save dialog appeared.

## Type of change

- [x] fix: Bug fix

## Changes

- `SettingsView.vue`: rewrite `handleDownloadBackup` to use a programmatic `<a>` click pointing at the download URL directly
- `settings.ts`: remove unused `downloadBackup` API function (no longer needed)
- No backend changes required — auth works via the existing `kira_token` cookie (`samesite=lax` sends it on top-level GET navigations)

## Screenshots / Logs

N/A — no visual change.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined backup download mechanism for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->