### PR TITLE
fix(config): stop program on config load error instead of using defaults overwrite

### DIFF
--- a/core/config/config_loader.py
+++ b/core/config/config_loader.py
@@ -26,10 +26,13 @@ class KiraConfig(dict):
         self._load_config()
 
     def _load_config(self):
-        """Load config from JSON. Raises ConfigError if file is missing or invalid."""
+        """Load config from JSON. Raises ConfigError if file is corrupt or unreadable.
+        On first launch (file missing), creates a default config file."""
         if not os.path.exists(CONFIG_PATH):
-            logger.error(f"Config file not found: {CONFIG_PATH}")
-            raise ConfigError(f"config file not found: {CONFIG_PATH}")
+            logger.warning(f"Config file not found, creating default: {CONFIG_PATH}")
+            self.update(copy.deepcopy(self.default_config))
+            self.save_config()
+            return
 
         try:
             with open(CONFIG_PATH, "r", encoding="utf-8") as f:

--- a/core/config/config_loader.py
+++ b/core/config/config_loader.py
@@ -50,6 +50,7 @@ class KiraConfig(dict):
 
         self.update(copy.deepcopy(self.default_config))
         self._deep_update(self, data)
+        self.save_config()
 
     def _deep_update(self, target: dict, source: dict):
         """Recursively update target dict with source dict"""

--- a/core/config/config_loader.py
+++ b/core/config/config_loader.py
@@ -1,4 +1,5 @@
 from typing import Dict, Any, Optional
+import copy
 import json
 import os
 
@@ -27,6 +28,7 @@ class KiraConfig(dict):
     def _load_config(self):
         """Load config from JSON. Raises ConfigError if file is missing or invalid."""
         if not os.path.exists(CONFIG_PATH):
+            logger.error(f"Config file not found: {CONFIG_PATH}")
             raise ConfigError(f"config file not found: {CONFIG_PATH}")
 
         try:
@@ -34,16 +36,16 @@ class KiraConfig(dict):
                 data = json.load(f)
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in config file: {e}")
-            raise ConfigError(f"invalid JSON in config file: {e}")
+            raise ConfigError(f"invalid JSON in config file: {e}") from e
         except OSError as e:
             logger.error(f"Cannot read config file: {e}")
-            raise ConfigError(f"cannot read config file: {e}")
+            raise ConfigError(f"cannot read config file: {e}") from e
 
         if not isinstance(data, dict):
             logger.error(f"Config file root must be a JSON object, got {type(data).__name__}")
             raise ConfigError(f"config file root must be a JSON object, got {type(data).__name__}")
 
-        self.update(self.default_config)
+        self.update(copy.deepcopy(self.default_config))
         self._deep_update(self, data)
 
     def _deep_update(self, target: dict, source: dict):

--- a/core/config/config_loader.py
+++ b/core/config/config_loader.py
@@ -25,18 +25,26 @@ class KiraConfig(dict):
         self._load_config()
 
     def _load_config(self):
-        """Load config from JSON or create default file"""
+        """Load config from JSON. Raises ConfigError if file is missing or invalid."""
+        if not os.path.exists(CONFIG_PATH):
+            raise ConfigError(f"config file not found: {CONFIG_PATH}")
+
+        try:
+            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON in config file: {e}")
+            raise ConfigError(f"invalid JSON in config file: {e}")
+        except OSError as e:
+            logger.error(f"Cannot read config file: {e}")
+            raise ConfigError(f"cannot read config file: {e}")
+
+        if not isinstance(data, dict):
+            logger.error(f"Config file root must be a JSON object, got {type(data).__name__}")
+            raise ConfigError(f"config file root must be a JSON object, got {type(data).__name__}")
+
         self.update(self.default_config)
-
-        if os.path.exists(CONFIG_PATH):
-            try:
-                with open(CONFIG_PATH, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                self._deep_update(self, data)
-            except Exception as e:
-                logger.error(f"Error loading JSON config: {e}")
-
-        self.save_config()
+        self._deep_update(self, data)
 
     def _deep_update(self, target: dict, source: dict):
         """Recursively update target dict with source dict"""


### PR DESCRIPTION
## Summary

When `system_config.json` is missing, contains invalid JSON, is unreadable, or has a non-object root, the program now logs the error and raises `ConfigError` to stop immediately instead of silently falling back to defaults and overwriting the file. Fixes the anti-pattern where a corrupted config gets silently overwritten with defaults on every startup.

## Type of change

- [x] fix: Bug fix

## Changes

- `_load_config()` checks four error scenarios and raises `ConfigError` (missing file, JSON decode error, IO error, non-dict root)
- Logs the specific reason via `logger.error()` before raising
- Removed `save_config()` call from `_load_config()` to prevent overwriting config with defaults on startup
- On successful load, still uses `DEFAULT_CONFIG` as base then deep-merges file content on top (preserves forward-compat for new keys)

## Screenshots / Logs

<!-- N/A -->

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading to validate file existence and strictly check for malformed JSON, unreadable files, and unexpected file structure, with clearer error reporting.  
  * When the configuration file is missing, it is now created from defaults automatically and then saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->