### PR TITLE
fix(webui): enforce auth on /api/live-log SSE endpoint

### DIFF
--- a/webui/routes/logs.py
+++ b/webui/routes/logs.py
@@ -1,14 +1,12 @@
 import asyncio
 import json
-from typing import Optional
 
-from fastapi import Depends, Header, HTTPException
+from fastapi import Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
 from core.logging_manager import get_logger, log_cache_manager
 from webui.routes.auth import require_auth
 from webui.routes.base import RouteDefinition, Routes
-from webui.utils import _verify_jwt_token
 
 logger = get_logger("webui", "blue")
 
@@ -21,6 +19,7 @@ class LogsRoutes(Routes):
                 methods=["GET"],
                 endpoint=self.live_log,
                 tags=["logs"],
+                dependencies=[Depends(require_auth)],
             ),
             RouteDefinition(
                 path="/api/log-history",
@@ -38,23 +37,8 @@ class LogsRoutes(Routes):
             ),
         ]
 
-    async def live_log(
-        self,
-        authorization: Optional[str] = Header(None),
-        token: Optional[str] = None,
-    ):
+    async def live_log(self):
         """SSE endpoint for real-time log streaming."""
-        jwt_token = None
-        if authorization and authorization.startswith("Bearer "):
-            jwt_token = authorization.split(" ", 1)[1]
-        elif token:
-            jwt_token = token
-
-        if jwt_token:
-            try:
-                _verify_jwt_token(jwt_token)
-            except HTTPException:
-                raise
 
         async def event_generator():
             que = log_cache_manager.add_queue()


### PR DESCRIPTION
## Summary

The `/api/live-log` SSE endpoint was accessible without authentication. It lacked the `require_auth` dependency and only verified a JWT when one was optionally provided, meaning requests with no credentials received the full live log stream. This is a confidentiality issue since application logs can contain sensitive material (API keys, request payloads, user identifiers, etc.).

Fixes #112

## Type of change

- [x] fix: Bug fix

## Changes

- Added `dependencies=[Depends(require_auth)]` to the `/api/live-log` route definition, matching the other log routes (`/api/log-history`, `/api/log-config`)
- Removed the manual optional JWT verification from the `live_log` handler — `require_auth` now enforces auth before the handler runs
- Cleaned up now-unused imports (`Optional`, `Header`, `_verify_jwt_token`)

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Live log endpoint now enforces authentication at the route level, ensuring only authorized users can access logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->