### PR TITLE
fix: resolve 19 correctness/robustness bugs from dev-branch review

### DIFF
--- a/core/adapter/src/bilibili/bilibili.py
+++ b/core/adapter/src/bilibili/bilibili.py
@@ -31,7 +31,7 @@ class BiliBiliAdapter(SocialMediaAdapter):
         self.listening_task = None
         self.bot_uid = self.config.get("bot_uid")
         self._credential = Credential(
-            sessdata=self.config.get("sessdata", ""),
+            sessdata=self.config.get("sessdata") or self.config.get("sesdata", ""),
             bili_jct=self.config.get("bili_jct", ""),
             buvid3=self.config.get("buvid3", ""),
             dedeuserid=self.config.get("dedeuserid", ""),
@@ -193,7 +193,7 @@ class BiliBiliAdapter(SocialMediaAdapter):
             commenter = cmt.get("user")
             commenter_id = cmt.get("uid")
             cmt_ts = int(cmt.get("ctime"))
-            if cmt_ts > self.last_process_ts and cmt.get("uid") != self.bot_uid:
+            if cmt_ts > self.last_process_ts and str(cmt.get("uid")) != str(self.bot_uid):
                 cmt_obj = KiraCommentEvent(
                     platform=self.info.platform,
                     adapter_name=self.info.name,
@@ -207,14 +207,14 @@ class BiliBiliAdapter(SocialMediaAdapter):
                 await self.event_bus.put(cmt_obj)
                 self.last_process_ts = int(cmt.get("ctime"))
                 await asyncio.sleep(self.config.get("message_process_interval"))
-            if cmt.get("uid") == self.bot_uid:
+            if str(cmt.get("uid")) == str(self.bot_uid):
                 for sub_cmt in cmt.get("sub_replies"):
                     sub_cmt_id = int(sub_cmt.get("comment_id"))
                     sub_cmt_content = sub_cmt.get("message")
                     sub_cmt_ts = int(sub_cmt.get("ctime"))
                     sub_commenter = sub_cmt.get("user")
                     sub_commenter_uid = sub_cmt.get("uid")
-                    if sub_cmt_ts > self.last_process_ts and sub_commenter_uid != self.bot_uid:
+                    if sub_cmt_ts > self.last_process_ts and str(sub_commenter_uid) != str(self.bot_uid):
                         cmt_obj = KiraCommentEvent(
                             platform=self.info.platform,
                             adapter_name=self.info.name,

--- a/core/adapter/src/bilibili/bilibili.py
+++ b/core/adapter/src/bilibili/bilibili.py
@@ -31,7 +31,7 @@ class BiliBiliAdapter(SocialMediaAdapter):
         self.listening_task = None
         self.bot_uid = self.config.get("bot_uid")
         self._credential = Credential(
-            sessdata=self.config.get("sessdata") or self.config.get("sesdata", ""),
+            sessdata=self.config.get("sessdata", ""),
             bili_jct=self.config.get("bili_jct", ""),
             buvid3=self.config.get("buvid3", ""),
             dedeuserid=self.config.get("dedeuserid", ""),

--- a/core/adapter/src/bilibili/schema.json
+++ b/core/adapter/src/bilibili/schema.json
@@ -35,11 +35,11 @@
       "zh": { "name": "消息处理间隔", "hint": "消息处理间隔，防止操作过快" }
     }
   },
-  "sesdata": {
-    "name": "sesdata",
+  "sessdata": {
+    "name": "sessdata",
     "type": "string",
     "default": "",
-    "hint": "sesdata（From Cookie）",
+    "hint": "sessdata（From Cookie）",
     "locales": {
       "zh": { "name": "SESSDATA", "hint": "SESSDATA（从 Cookie 获取）" }
     }

--- a/core/adapter/src/qq/napcat_client/client.py
+++ b/core/adapter/src/qq/napcat_client/client.py
@@ -363,10 +363,13 @@ class NapCatWebSocketClient:
             response = await asyncio.wait_for(future, timeout=timeout)
             return response
         except asyncio.TimeoutError:
-            await self.response_futures.pop(echo, None)
+            # Discard the pending Future entry; do not await it (awaiting a Future
+            # here would raise CancelledError and mask the intended TimeoutError).
+            self.response_futures.pop(echo, None)
             raise TimeoutError(f"请求 {action} 超时")
         except Exception:
-            await self.response_futures.pop(echo, None)
+            # Same as above: just drop the entry without awaiting it.
+            self.response_futures.pop(echo, None)
             raise
 
     async def get_login_info(self):

--- a/core/adapter/src/qq/qq.py
+++ b/core/adapter/src/qq/qq.py
@@ -118,6 +118,9 @@ class QQAdapter(IMAdapter):
     async def send_group_message(self, group_id, send_message_obj):
         try:
             message_chain = await self._process_outgoing_message(send_message_obj)
+            if not message_chain:
+                self.logger.warning("处理后的消息链为空，跳过群消息发送")
+                return KiraIMSentResult(None, ok=False, err="Empty message chain after processing")
             ele = message_chain[0]
             if isinstance(ele, Poke):
                 await self.bot.send_poke(user_id=ele.pid, group_id=group_id)
@@ -268,6 +271,11 @@ class QQAdapter(IMAdapter):
         msg_res = KiraIMSentResult(None)
         try:
             message_chain = await self._process_outgoing_message(send_message_obj)
+            if not message_chain:
+                self.logger.warning("处理后的消息链为空，跳过私聊消息发送")
+                msg_res.ok = False
+                msg_res.err = "Empty message chain after processing"
+                return msg_res
             ele = message_chain[0]
             if isinstance(ele, Poke):
                 await self.bot.send_poke(user_id=ele.pid)
@@ -439,10 +447,10 @@ class QQAdapter(IMAdapter):
                 emoji_desc = self.emoji_dict.get(emoji_id)
                 message_content.append(Emoji(emoji_id, emoji_desc))
             elif ele.get("type") == "image":
-                img_url = ele.get("data", "").get("url", "")
+                img_url = ele.get("data", {}).get("url", "")
 
-                summary = ele.get("data", "").get("summary", "")
-                sub_type = ele.get("data", "").get("sub_type", 0)
+                summary = ele.get("data", {}).get("summary", "")
+                sub_type = ele.get("data", {}).get("sub_type", 0)
 
                 if sub_type == 1 or summary == "[动画表情]":
                     from core.utils.common_utils import image_to_base64
@@ -461,7 +469,7 @@ class QQAdapter(IMAdapter):
                     import traceback
                     self.logger.error(traceback.format_exc())
             elif ele.get("type") == "json":
-                json_card_info = ele.get("data", "").get("data", "")
+                json_card_info = ele.get("data", {}).get("data", "")
                 card_data = extract_card_info(json_card_info)
                 message_content.append(Json(card_data))
             elif ele.get("type") == "file":

--- a/core/adapter/src/telegram/telegram.py
+++ b/core/adapter/src/telegram/telegram.py
@@ -265,11 +265,21 @@ class TelegramAdapter(IMAdapter):
         if message_text:
             try:
                 entities = getattr(tg_message, "entities", None) or getattr(tg_message, "caption_entities", None) or []
+                # Telegram entity offset/length are in UTF-16 code units, which
+                # diverge from Python str indices once the text contains non-BMP
+                # characters (e.g. emoji). Slice on the UTF-16-LE encoding so the
+                # mention text and the surrounding text segments stay aligned.
+                text_u16 = message_text.encode("utf-16-le")
+
+                def _u16_slice(start_units: int, len_units: int) -> str:
+                    return text_u16[start_units * 2: (start_units + len_units) * 2].decode("utf-16-le", "ignore")
+
+                total_units = len(text_u16) // 2
                 # Collect mention entities with their positions
                 mentions = []
                 for ent in entities:
                     if ent.type == "mention":
-                        username = message_text[ent.offset: ent.offset + ent.length].lstrip("@")
+                        username = _u16_slice(ent.offset, ent.length).lstrip("@")
                         # Resolve display name: bot self → full_name directly,
                         # others → use @username (avoid per-mention get_chat to prevent rate-limit issues)
                         display = username
@@ -285,18 +295,18 @@ class TelegramAdapter(IMAdapter):
                         mentions.append((ent.offset, ent.length, At(pid=str(user_obj.id), nickname=display)))
                 # Sort by position to interleave text and At in order
                 mentions.sort(key=lambda m: m[0])
-                # Build elements by splitting text around mention ranges
+                # Build elements by splitting text around mention ranges (UTF-16 units)
                 pos = 0
                 for offset, length, at_elem in mentions:
                     if offset > pos:
-                        plain = message_text[pos:offset]
+                        plain = _u16_slice(pos, offset - pos)
                         if plain:
                             elements.append(Text(plain))
                     elements.append(at_elem)
                     pos = offset + length
-                # Remaining text after last mention
-                if pos < len(message_text):
-                    trailing = message_text[pos:]
+                # Remaining text after the last mention
+                if pos < total_units:
+                    trailing = _u16_slice(pos, total_units - pos)
                     if trailing:
                         elements.append(Text(trailing))
             except Exception:

--- a/core/adapter/src/telegram/telegram.py
+++ b/core/adapter/src/telegram/telegram.py
@@ -171,10 +171,14 @@ class TelegramAdapter(IMAdapter):
             # 2) Check if bot is mentioned by username or text_mention
             if not is_mentioned:
                 try:
-                    if getattr(msg, "entities", None):
-                        for ent in msg.entities:
-                            if ent.type == "mention" and bot_username:
-                                mention_text = msg.text[ent.offset: ent.offset + ent.length]
+                    # Media messages carry their text in caption/caption_entities,
+                    # so fall back to those when plain text entities are absent.
+                    scan_text = msg.text if msg.text is not None else msg.caption
+                    scan_entities = getattr(msg, "entities", None) or getattr(msg, "caption_entities", None)
+                    if scan_entities:
+                        for ent in scan_entities:
+                            if ent.type == "mention" and bot_username and scan_text is not None:
+                                mention_text = scan_text[ent.offset: ent.offset + ent.length]
                                 if mention_text.lower() == f"@{bot_username.lower()}":
                                     is_mentioned = True
                                     break
@@ -249,14 +253,17 @@ class TelegramAdapter(IMAdapter):
             elements.append(Reply(str(tg_message.reply_to_message.id), replied_text))
 
         # Text + inline mentions
-        if tg_message.text:
+        # Media messages (photo/video/document) put their text in caption/caption_entities,
+        # so fall back to those when plain text is absent to avoid losing the caption.
+        message_text = tg_message.text if tg_message.text is not None else tg_message.caption
+        if message_text:
             try:
-                entities = getattr(tg_message, "entities", None) or []
+                entities = getattr(tg_message, "entities", None) or getattr(tg_message, "caption_entities", None) or []
                 # Collect mention entities with their positions
                 mentions = []
                 for ent in entities:
                     if ent.type == "mention":
-                        username = tg_message.text[ent.offset: ent.offset + ent.length].lstrip("@")
+                        username = message_text[ent.offset: ent.offset + ent.length].lstrip("@")
                         # Resolve display name: bot self → full_name directly,
                         # others → use @username (avoid per-mention get_chat to prevent rate-limit issues)
                         display = username
@@ -276,18 +283,18 @@ class TelegramAdapter(IMAdapter):
                 pos = 0
                 for offset, length, at_elem in mentions:
                     if offset > pos:
-                        plain = tg_message.text[pos:offset]
+                        plain = message_text[pos:offset]
                         if plain:
                             elements.append(Text(plain))
                     elements.append(at_elem)
                     pos = offset + length
                 # Remaining text after last mention
-                if pos < len(tg_message.text):
-                    trailing = tg_message.text[pos:]
+                if pos < len(message_text):
+                    trailing = message_text[pos:]
                     if trailing:
                         elements.append(Text(trailing))
             except Exception:
-                elements.append(Text(tg_message.text))
+                elements.append(Text(message_text))
 
         # Photo
         if tg_message.photo:

--- a/core/adapter/src/telegram/telegram.py
+++ b/core/adapter/src/telegram/telegram.py
@@ -171,14 +171,20 @@ class TelegramAdapter(IMAdapter):
             # 2) Check if bot is mentioned by username or text_mention
             if not is_mentioned:
                 try:
-                    # Media messages carry their text in caption/caption_entities,
-                    # so fall back to those when plain text entities are absent.
-                    scan_text = msg.text if msg.text is not None else msg.caption
-                    scan_entities = getattr(msg, "entities", None) or getattr(msg, "caption_entities", None)
+                    # Media messages carry their text in caption/caption_entities;
+                    # use parse_entity/parse_caption_entity so non-BMP characters
+                    # (whose UTF-16 offsets differ from Python str indices) are
+                    # handled correctly instead of slicing the string manually.
+                    using_caption = msg.text is None
+                    scan_entities = msg.caption_entities if using_caption else msg.entities
                     if scan_entities:
                         for ent in scan_entities:
-                            if ent.type == "mention" and bot_username and scan_text is not None:
-                                mention_text = scan_text[ent.offset: ent.offset + ent.length]
+                            if ent.type == "mention" and bot_username:
+                                mention_text = (
+                                    msg.parse_caption_entity(ent)
+                                    if using_caption
+                                    else msg.parse_entity(ent)
+                                )
                                 if mention_text.lower() == f"@{bot_username.lower()}":
                                     is_mentioned = True
                                     break

--- a/core/adapter/src/weixin_oc/weixin_oc.py
+++ b/core/adapter/src/weixin_oc/weixin_oc.py
@@ -752,19 +752,34 @@ class WeixinOCAdapter(IMAdapter):
     async def _save_account_state(self) -> None:
         """保存登录状态到配置文件"""
         try:
-            # 更新内存中的配置
+            # 更新内存中的配置。self.info.config 是共享配置树中本适配器
+            # config 子树的实时引用，原地修改即同步到全局内存配置。
             self.info.config["weixin_oc_token"] = self.token or ""
             self.info.config["weixin_oc_account_id"] = self.account_id or ""
             self.info.config["weixin_oc_sync_buf"] = self._sync_buf
             self.info.config["weixin_oc_base_url"] = self.base_url
-            
-            # 保存到配置文件
-            from core.config.config_loader import KiraConfig
-            kira_config = KiraConfig()
-            adapters = kira_config.get("adapters", {})
+
+            # Persist by updating only this adapter's config subtree on disk.
+            # Constructing a fresh KiraConfig() would reload defaults and rewrite
+            # the whole file, clobbering unsaved in-memory edits to other sections.
+            import json
+            import os
+            from core.config.config_loader import CONFIG_PATH
+
+            if not os.path.exists(CONFIG_PATH):
+                self.logger.warning(
+                    "weixin_oc(%s): config file not found, skip saving state",
+                    self.info.name,
+                )
+                return
+            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            adapters = data.get("adapters", {})
             if self.info.adapter_id in adapters:
                 adapters[self.info.adapter_id]["config"] = dict(self.info.config)
-                kira_config.save_config()
+                os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+                with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+                    f.write(json.dumps(data, indent=4, ensure_ascii=False))
                 self.logger.info("weixin_oc(%s): account state saved", self.info.name)
             else:
                 self.logger.warning("weixin_oc(%s): adapter not found in config", self.info.name)

--- a/core/adapter/src/weixin_oc/weixin_oc.py
+++ b/core/adapter/src/weixin_oc/weixin_oc.py
@@ -752,34 +752,19 @@ class WeixinOCAdapter(IMAdapter):
     async def _save_account_state(self) -> None:
         """保存登录状态到配置文件"""
         try:
-            # 更新内存中的配置。self.info.config 是共享配置树中本适配器
-            # config 子树的实时引用，原地修改即同步到全局内存配置。
+            # 更新内存中的配置
             self.info.config["weixin_oc_token"] = self.token or ""
             self.info.config["weixin_oc_account_id"] = self.account_id or ""
             self.info.config["weixin_oc_sync_buf"] = self._sync_buf
             self.info.config["weixin_oc_base_url"] = self.base_url
 
-            # Persist by updating only this adapter's config subtree on disk.
-            # Constructing a fresh KiraConfig() would reload defaults and rewrite
-            # the whole file, clobbering unsaved in-memory edits to other sections.
-            import json
-            import os
-            from core.config.config_loader import CONFIG_PATH
-
-            if not os.path.exists(CONFIG_PATH):
-                self.logger.warning(
-                    "weixin_oc(%s): config file not found, skip saving state",
-                    self.info.name,
-                )
-                return
-            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
-                data = json.load(f)
-            adapters = data.get("adapters", {})
+            # 保存到配置文件
+            from core.config.config_loader import KiraConfig
+            kira_config = KiraConfig()
+            adapters = kira_config.get("adapters", {})
             if self.info.adapter_id in adapters:
                 adapters[self.info.adapter_id]["config"] = dict(self.info.config)
-                os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
-                with open(CONFIG_PATH, "w", encoding="utf-8") as f:
-                    f.write(json.dumps(data, indent=4, ensure_ascii=False))
+                kira_config.save_config()
                 self.logger.info("weixin_oc(%s): account state saved", self.info.name)
             else:
                 self.logger.warning("weixin_oc(%s): adapter not found in config", self.info.name)

--- a/core/agent/agent_executor.py
+++ b/core/agent/agent_executor.py
@@ -162,10 +162,19 @@ class AgentExecutor:
             reasoning = llm_resp.reasoning_content or ""
 
             await self.llm_api.execute_tool(event, llm_resp, tool_set=self.tool_set)
+            # An ON_TOOL_RESULT handler may stop the event mid multi-tool-call turn,
+            # leaving execute_tool to produce only partial tool_results. Keep the
+            # assistant message's tool_calls consistent with the tool_results actually
+            # produced (matched by id), so history never contains an assistant message
+            # with unanswered tool_calls (which would 400 the next OpenAI request).
+            answered_ids = {r.get("tool_call_id") for r in llm_resp.tool_results}
+            answered_tool_calls = [
+                tc for tc in llm_resp.tool_calls if tc.get("id") in answered_ids
+            ]
             msg = OpenAIMessage(
                 role="assistant",
                 content=assistant_content,
-                tool_calls=llm_resp.tool_calls,
+                tool_calls=answered_tool_calls,
                 reasoning_content=reasoning
             )
             request.messages.append(msg)

--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -458,14 +458,8 @@ class MCPManager:
                     )
                 logger.info(f"Registered {len(tool_names)} MCP tools from {server.name}: {tool_names}")
 
-        # Launch registration concurrently, then await all so errors are not
-        # swallowed and tools are ready when init_mcp returns.
-        tasks = [asyncio.create_task(init_server(server)) for server in self.servers]
-        if tasks:
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            for server, result in zip(self.servers, results, strict=True):
-                if isinstance(result, Exception):
-                    logger.error(f"Failed to initialize MCP server {server.name}: {result}")
+        for server in self.servers:
+            asyncio.create_task(init_server(server))
 
     @staticmethod
     async def _make_mcp_func(server: MCPServer, tool_name: str):

--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -458,8 +458,14 @@ class MCPManager:
                     )
                 logger.info(f"Registered {len(tool_names)} MCP tools from {server.name}: {tool_names}")
 
-        for server in self.servers:
-            asyncio.create_task(init_server(server))
+        # Launch registration concurrently, then await all so errors are not
+        # swallowed and tools are ready when init_mcp returns.
+        tasks = [asyncio.create_task(init_server(server)) for server in self.servers]
+        if tasks:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for server, result in zip(self.servers, results):
+                if isinstance(result, Exception):
+                    logger.error(f"Failed to initialize MCP server {server.name}: {result}")
 
     @staticmethod
     async def _make_mcp_func(server: MCPServer, tool_name: str):

--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -463,7 +463,7 @@ class MCPManager:
         tasks = [asyncio.create_task(init_server(server)) for server in self.servers]
         if tasks:
             results = await asyncio.gather(*tasks, return_exceptions=True)
-            for server, result in zip(self.servers, results):
+            for server, result in zip(self.servers, results, strict=True):
                 if isinstance(result, Exception):
                     logger.error(f"Failed to initialize MCP server {server.name}: {result}")
 

--- a/core/chat/session_manager.py
+++ b/core/chat/session_manager.py
@@ -187,6 +187,6 @@ class SessionManager:
 
     def delete_session(self, session: str):
         with self.memory_lock:
-            self.chat_memory.pop(session)
+            self.chat_memory.pop(session, None)
             self._save_memory(self.chat_memory, self.chat_memory_path)
         logger.info(f"Memory deleted for {session}")

--- a/core/config/config_loader.py
+++ b/core/config/config_loader.py
@@ -50,7 +50,11 @@ class KiraConfig(dict):
 
         self.update(copy.deepcopy(self.default_config))
         self._deep_update(self, data)
-        self.save_config()
+        # Only persist when merging defaults actually changed the config (e.g.
+        # newly-added default keys). An unchanged config must not be rewritten
+        # on every boot.
+        if dict(self) != data:
+            self.save_config()
 
     def _deep_update(self, target: dict, source: dict):
         """Recursively update target dict with source dict"""

--- a/core/db/service.py
+++ b/core/db/service.py
@@ -387,20 +387,21 @@ class DatabaseService:
         rows = await self.db.fetch_all(stmt)
         return [{"hour_ts": r["hour_ts"], "platform": r["platform"], "count": r["count"]} for r in rows]
 
-    async def get_unreported_telemetry_message_ids_by_hour(self, since_ts: int) -> list[dict]:
-        """Return the primary-key id of every unreported message row tagged with its hour bucket.
+    async def get_unreported_telemetry_message_rows(self, since_ts: int) -> list[dict]:
+        """Return every unreported message row (id + hour bucket + platform) in one query.
 
-        Used to mark only the exact rows that were aggregated into a report, avoiding the
-        race where rows inserted into the still-filling hour after aggregation get marked
-        reported without ever being sent.
+        Deriving BOTH the per-platform counts and the id set to mark from this single
+        snapshot keeps them exactly consistent: no row can be counted without being
+        marked reported, or marked without being counted (which the previous two-query
+        approach allowed when a row was inserted between the two reads).
         """
         hour_bucket = cast(TelemetryMessage.timestamp / 3600, Integer) * 3600
         stmt = (
-            select(hour_bucket.label("hour_ts"), TelemetryMessage.id)
+            select(hour_bucket.label("hour_ts"), TelemetryMessage.platform, TelemetryMessage.id)
             .where(and_(TelemetryMessage.reported.is_(False), TelemetryMessage.timestamp >= since_ts))
         )
         rows = await self.db.fetch_all(stmt)
-        return [{"hour_ts": r["hour_ts"], "id": r["id"]} for r in rows]
+        return [{"hour_ts": r["hour_ts"], "platform": r["platform"], "id": r["id"]} for r in rows]
 
     async def get_unreported_telemetry_llm_usage_by_hour(self, since_ts: int) -> list[dict]:
         """Return per-(hour, model) rows for building aggregated hourly reports."""
@@ -430,20 +431,39 @@ class DatabaseService:
             for r in rows
         ]
 
-    async def get_unreported_telemetry_llm_usage_ids_by_hour(self, since_ts: int) -> list[dict]:
-        """Return the primary-key id of every unreported LLM-usage row tagged with its hour bucket.
+    async def get_unreported_telemetry_llm_usage_rows(self, since_ts: int) -> list[dict]:
+        """Return every unreported LLM-usage row (id + hour bucket + measures) in one query.
 
-        Used to mark only the exact rows that were aggregated into a report, avoiding the
-        race where rows inserted into the still-filling hour after aggregation get marked
-        reported without ever being sent.
+        Counts and the id set to mark are aggregated in Python from this single
+        snapshot (see get_unreported_telemetry_message_rows for the consistency
+        rationale).
         """
         hour_bucket = cast(TelemetryLLMUsage.timestamp / 3600, Integer) * 3600
         stmt = (
-            select(hour_bucket.label("hour_ts"), TelemetryLLMUsage.id)
+            select(
+                hour_bucket.label("hour_ts"),
+                TelemetryLLMUsage.id,
+                TelemetryLLMUsage.model,
+                TelemetryLLMUsage.success,
+                TelemetryLLMUsage.input_tokens,
+                TelemetryLLMUsage.output_tokens,
+                TelemetryLLMUsage.cached_tokens,
+                TelemetryLLMUsage.response_time_ms,
+            )
             .where(and_(TelemetryLLMUsage.reported.is_(False), TelemetryLLMUsage.timestamp >= since_ts))
         )
         rows = await self.db.fetch_all(stmt)
-        return [{"hour_ts": r["hour_ts"], "id": r["id"]} for r in rows]
+        return [
+            {
+                "hour_ts": r["hour_ts"], "id": r["id"], "model": r["model"],
+                "success": r["success"],
+                "input_tokens": r["input_tokens"] or 0,
+                "output_tokens": r["output_tokens"] or 0,
+                "cached_tokens": r["cached_tokens"] or 0,
+                "response_time_ms": r["response_time_ms"] or 0,
+            }
+            for r in rows
+        ]
 
     async def mark_telemetry_reported(self) -> None:
         async with self.db.transaction() as session:
@@ -467,11 +487,15 @@ class DatabaseService:
         if not ids:
             return
         async with self.db.transaction() as session:
-            await session.execute(
-                TelemetryMessage.__table__.update()
-                .where(TelemetryMessage.id.in_(ids))
-                .values(reported=True)
-            )
+            # Chunk so the bound-parameter count stays well under SQLite's
+            # SQLITE_MAX_VARIABLE_NUMBER (999 on older builds) no matter how many
+            # rows accumulated in an hour bucket.
+            for i in range(0, len(ids), 500):
+                await session.execute(
+                    TelemetryMessage.__table__.update()
+                    .where(TelemetryMessage.id.in_(ids[i:i + 500]))
+                    .values(reported=True)
+                )
 
     async def mark_telemetry_llm_by_ids(self, ids: list[str]) -> None:
         """Mark only the specific LLM-usage rows (by primary key) as reported.
@@ -482,11 +506,14 @@ class DatabaseService:
         if not ids:
             return
         async with self.db.transaction() as session:
-            await session.execute(
-                TelemetryLLMUsage.__table__.update()
-                .where(TelemetryLLMUsage.id.in_(ids))
-                .values(reported=True)
-            )
+            # Chunk to stay under SQLite's bound-parameter limit (see
+            # mark_telemetry_messages_by_ids).
+            for i in range(0, len(ids), 500):
+                await session.execute(
+                    TelemetryLLMUsage.__table__.update()
+                    .where(TelemetryLLMUsage.id.in_(ids[i:i + 500]))
+                    .values(reported=True)
+                )
 
     async def delete_telemetry_records_before(self, cutoff_ts: int) -> None:
         async with self.db.transaction() as session:

--- a/core/db/service.py
+++ b/core/db/service.py
@@ -387,6 +387,21 @@ class DatabaseService:
         rows = await self.db.fetch_all(stmt)
         return [{"hour_ts": r["hour_ts"], "platform": r["platform"], "count": r["count"]} for r in rows]
 
+    async def get_unreported_telemetry_message_ids_by_hour(self, since_ts: int) -> list[dict]:
+        """Return the primary-key id of every unreported message row tagged with its hour bucket.
+
+        Used to mark only the exact rows that were aggregated into a report, avoiding the
+        race where rows inserted into the still-filling hour after aggregation get marked
+        reported without ever being sent.
+        """
+        hour_bucket = cast(TelemetryMessage.timestamp / 3600, Integer) * 3600
+        stmt = (
+            select(hour_bucket.label("hour_ts"), TelemetryMessage.id)
+            .where(and_(TelemetryMessage.reported.is_(False), TelemetryMessage.timestamp >= since_ts))
+        )
+        rows = await self.db.fetch_all(stmt)
+        return [{"hour_ts": r["hour_ts"], "id": r["id"]} for r in rows]
+
     async def get_unreported_telemetry_llm_usage_by_hour(self, since_ts: int) -> list[dict]:
         """Return per-(hour, model) rows for building aggregated hourly reports."""
         hour_bucket = cast(TelemetryLLMUsage.timestamp / 3600, Integer) * 3600
@@ -415,6 +430,21 @@ class DatabaseService:
             for r in rows
         ]
 
+    async def get_unreported_telemetry_llm_usage_ids_by_hour(self, since_ts: int) -> list[dict]:
+        """Return the primary-key id of every unreported LLM-usage row tagged with its hour bucket.
+
+        Used to mark only the exact rows that were aggregated into a report, avoiding the
+        race where rows inserted into the still-filling hour after aggregation get marked
+        reported without ever being sent.
+        """
+        hour_bucket = cast(TelemetryLLMUsage.timestamp / 3600, Integer) * 3600
+        stmt = (
+            select(hour_bucket.label("hour_ts"), TelemetryLLMUsage.id)
+            .where(and_(TelemetryLLMUsage.reported.is_(False), TelemetryLLMUsage.timestamp >= since_ts))
+        )
+        rows = await self.db.fetch_all(stmt)
+        return [{"hour_ts": r["hour_ts"], "id": r["id"]} for r in rows]
+
     async def mark_telemetry_reported(self) -> None:
         async with self.db.transaction() as session:
             await session.execute(
@@ -428,31 +458,33 @@ class DatabaseService:
                 .values(reported=True)
             )
 
-    async def mark_telemetry_messages_by_hours(self, hour_ts_list: list[int]) -> None:
-        if not hour_ts_list:
+    async def mark_telemetry_messages_by_ids(self, ids: list[str]) -> None:
+        """Mark only the specific message rows (by primary key) as reported.
+
+        Marking exact ids — instead of an hour window — guarantees rows inserted into the
+        still-filling hour after aggregation are never marked reported without being sent.
+        """
+        if not ids:
             return
         async with self.db.transaction() as session:
-            conditions = [
-                and_(TelemetryMessage.timestamp >= h, TelemetryMessage.timestamp < h + 3600)
-                for h in hour_ts_list
-            ]
             await session.execute(
                 TelemetryMessage.__table__.update()
-                .where(and_(TelemetryMessage.reported.is_(False), or_(*conditions)))
+                .where(TelemetryMessage.id.in_(ids))
                 .values(reported=True)
             )
 
-    async def mark_telemetry_llm_by_hours(self, hour_ts_list: list[int]) -> None:
-        if not hour_ts_list:
+    async def mark_telemetry_llm_by_ids(self, ids: list[str]) -> None:
+        """Mark only the specific LLM-usage rows (by primary key) as reported.
+
+        Marking exact ids — instead of an hour window — guarantees rows inserted into the
+        still-filling hour after aggregation are never marked reported without being sent.
+        """
+        if not ids:
             return
         async with self.db.transaction() as session:
-            conditions = [
-                and_(TelemetryLLMUsage.timestamp >= h, TelemetryLLMUsage.timestamp < h + 3600)
-                for h in hour_ts_list
-            ]
             await session.execute(
                 TelemetryLLMUsage.__table__.update()
-                .where(and_(TelemetryLLMUsage.reported.is_(False), or_(*conditions)))
+                .where(TelemetryLLMUsage.id.in_(ids))
                 .values(reported=True)
             )
 

--- a/core/launcher.py
+++ b/core/launcher.py
@@ -67,8 +67,8 @@ class KiraLauncher:
         self.webui = KiraWebUI(lifecycle=self.lifecycle, disable_auth=self.disable_webui_auth)
 
         try:
-            host = webui_config.get("host", "0.0.0.0")
-            port = webui_config.get("port", 5267)
+            host = webui_config["host"]
+            port = webui_config["port"]
 
             if self.disable_webui_auth and host not in ("localhost", "127.0.0.1"):
                 self.logger.warning("Auth disabled — forcing host to 127.0.0.1 for security")

--- a/core/launcher.py
+++ b/core/launcher.py
@@ -67,8 +67,8 @@ class KiraLauncher:
         self.webui = KiraWebUI(lifecycle=self.lifecycle, disable_auth=self.disable_webui_auth)
 
         try:
-            host = webui_config["host"]
-            port = webui_config["port"]
+            host = webui_config.get("host", "0.0.0.0")
+            port = webui_config.get("port", 5267)
 
             if self.disable_webui_auth and host not in ("localhost", "127.0.0.1"):
                 self.logger.warning("Auth disabled — forcing host to 127.0.0.1 for security")

--- a/core/lifecycle.py
+++ b/core/lifecycle.py
@@ -268,8 +268,10 @@ class KiraLifecycle:
             await self.plugin_manager.terminate()
 
         # terminate all running adapters
-        await self.adapter_manager.stop_adapters()
-        await self.event_bus.stop()
+        if self.adapter_manager:
+            await self.adapter_manager.stop_adapters()
+        if self.event_bus:
+            await self.event_bus.stop()
 
         # dispose database manager
         if self.db_manager:

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -120,12 +120,18 @@ class ImageDescCache:
         return None
 
     async def set(self, md5: str, description: str):
+        # Never cache an empty/failed description: an empty string would otherwise be
+        # stored permanently as the caption for this md5 and served to every later hit.
+        if not description:
+            return
         existing = await self.db.get_image_desc_cache(md5)
         if existing:
+            # Preserve the accumulated hit count that cleanup relies on; resetting it to 1
+            # on every update would prevent frequently-seen entries from being retained.
             await self.db.update_image_desc_cache(
                 md5,
                 description=description,
-                count=1,
+                count=existing["count"],
                 last_seen=int(time.time()),
             )
         else:

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -315,12 +315,14 @@ class FilePlugin(BasePlugin):
         if os.name == 'nt':
             shell_command = f'chcp 65001 >nul && {shell_command}'
 
+        exec_timeout = 30  # seconds
+
         logger.info(f'Executing shell command: {shell_command} (cwd: {os.getcwd()})')
         try:
             result = subprocess.run(
                 shell_command, shell=True, capture_output=True,
                 stdin=subprocess.DEVNULL,
-                timeout=30, env=env, encoding='utf-8', errors='replace'
+                timeout=exec_timeout, env=env, encoding='utf-8', errors='replace'
             )
             output = (result.stdout or '') + (result.stderr or '')
             if result.returncode == 0:
@@ -328,6 +330,6 @@ class FilePlugin(BasePlugin):
             else:
                 return f'Shell command failed (exit {result.returncode}):\n{output}'
         except subprocess.TimeoutExpired:
-            return f'Shell command timed out after 120 seconds: {shell_command}'
+            return f'Shell command timed out after {exec_timeout} seconds: {shell_command}'
         except Exception as e:
             return f'Unexpected error while executing shell command: {e}'

--- a/core/plugin/builtin_plugins/kira-ai/tags.py
+++ b/core/plugin/builtin_plugins/kira-ai/tags.py
@@ -114,11 +114,12 @@ class VideoTag(BaseTag):
 
         try:
             video_obj = await video_client.generate_video(prompt=value)
-        except Exception as e:
+        except Exception:
             # generate_video may raise (timeout / failed status / no url). Drop
             # only this element instead of letting the exception abort the whole
-            # message turn, mirroring RecordTag's handling.
-            provider_logger.error(f"an error occurred while generating video: {e}")
+            # message turn, mirroring RecordTag's handling. exception() captures
+            # the full stack trace for debugging.
+            provider_logger.exception("an error occurred while generating video")
             return []
         if video_obj:
             provider_logger.info(f"Generated video from text {value}")

--- a/core/plugin/builtin_plugins/kira-ai/tags.py
+++ b/core/plugin/builtin_plugins/kira-ai/tags.py
@@ -112,7 +112,14 @@ class VideoTag(BaseTag):
         model_id = video_client.model.model_id
         provider_logger.info(f"Generating video using {model_id} ({provider_name})")
 
-        video_obj = await video_client.generate_video(prompt=value)
+        try:
+            video_obj = await video_client.generate_video(prompt=value)
+        except Exception as e:
+            # generate_video may raise (timeout / failed status / no url). Drop
+            # only this element instead of letting the exception abort the whole
+            # message turn, mirroring RecordTag's handling.
+            provider_logger.error(f"an error occurred while generating video: {e}")
+            return []
         if video_obj:
             provider_logger.info(f"Generated video from text {value}")
             return [video_obj]

--- a/core/plugin/builtin_plugins/memory/main.py
+++ b/core/plugin/builtin_plugins/memory/main.py
@@ -153,6 +153,8 @@ class MemoryPlugin(BasePlugin):
                 p.content += self.get_core_memory()
                 p.content += "\n"
                 p.content += MEM_RULE_PROMPT
-                break
+                # Do not break here: the 'tools' prompt comes after 'memory',
+                # so we must keep iterating to also inject the tools few-shot.
+                continue
             if p.name == "tools":
                 p.content += MEM_TOOL_FEW_SHOT

--- a/core/plugin/plugin_handlers.py
+++ b/core/plugin/plugin_handlers.py
@@ -34,7 +34,9 @@ class EventType(Enum):
     ...
 
 
-@dataclass
+# eq=False keeps identity-based equality/hash so that del_handler removes the
+# exact handler instance, not a different field-identical one.
+@dataclass(eq=False)
 class EventHandler:
     event_type: EventType
 

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -1339,10 +1339,20 @@ class PluginManager:
             if plugin_id in self.plugin_instances and plugin_id in _plugin_infos:
                 _plugin_infos[plugin_id].status = "ready"
 
-        # Phase 2: Recover plugins that failed with import errors
+        # Phase 2: Recover plugins that failed with import errors.
+        # Detect missing-dependency failures reliably: accept any error_type that
+        # is an ImportError subclass (covers ModuleNotFoundError and ImportError),
+        # and fall back to the error message when error_type was not stored.
+        def _is_missing_dep_failure(err_info: Dict[str, Any]) -> bool:
+            err_type = err_info.get("error_type")
+            if isinstance(err_type, type) and issubclass(err_type, ImportError):
+                return True
+            msg = str(err_info.get("error", "")).lower()
+            return "no module named" in msg or "modulenotfounderror" in msg
+
         import_failures = [
             pid for pid, err_info in _plugin_load_errors.items()
-            if err_info.get("error_type") is ModuleNotFoundError and pid in _plugin_module_paths
+            if _is_missing_dep_failure(err_info) and pid in _plugin_module_paths
         ]
         if import_failures:
             logger.info(f"Plugins with import errors, will attempt dependency install: {import_failures}")
@@ -1851,6 +1861,7 @@ class PluginManager:
                     _plugin_load_errors[plugin_id] = {
                         "manifest": _plugin_manifests.get(plugin_id, {}),
                         "error": f"Import error (after retry): {retry_e}",
+                        "error_type": type(retry_e),
                     }
                     if plugin_id in _plugin_infos:
                         _plugin_infos[plugin_id].error = f"Import error (after retry): {retry_e}"

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -1345,10 +1345,7 @@ class PluginManager:
         # and fall back to the error message when error_type was not stored.
         def _is_missing_dep_failure(err_info: Dict[str, Any]) -> bool:
             err_type = err_info.get("error_type")
-            if isinstance(err_type, type) and issubclass(err_type, ImportError):
-                return True
-            msg = str(err_info.get("error", "")).lower()
-            return "no module named" in msg or "modulenotfounderror" in msg
+            return isinstance(err_type, type) and issubclass(err_type, ImportError)
 
         import_failures = [
             pid for pid, err_info in _plugin_load_errors.items()

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -886,7 +886,7 @@ class PluginManager:
                         async def __call__(self, scope, receive, send):
                             if scope["type"] == "http":
                                 from starlette.requests import Request as StarletteRequest
-                                from webui.utils import _verify_jwt_token
+                                from webui.utils import verify_session_token
 
                                 request = StarletteRequest(scope)
                                 # Plugin-enabled check
@@ -914,7 +914,7 @@ class PluginManager:
                                         return
                                     # Validate token
                                     try:
-                                        _verify_jwt_token(token)
+                                        verify_session_token(token, request.app.state)
                                     except Exception:
                                         response = HTMLResponse(
                                             content='{"detail":"Invalid token"}',
@@ -1039,7 +1039,7 @@ class PluginManager:
                         async def __call__(self, scope, receive, send):
                             if scope["type"] == "http":
                                 from starlette.requests import Request as StarletteRequest
-                                from webui.utils import _verify_jwt_token
+                                from webui.utils import verify_session_token
 
                                 request = StarletteRequest(scope)
                                 if not mgr.is_plugin_enabled(plugin_id):
@@ -1064,7 +1064,7 @@ class PluginManager:
                                         await response(scope, receive, send)
                                         return
                                     try:
-                                        _verify_jwt_token(token)
+                                        verify_session_token(token, request.app.state)
                                     except Exception:
                                         response = HTMLResponse(
                                             content='{"detail":"Invalid token"}',

--- a/core/provider/provider_manager.py
+++ b/core/provider/provider_manager.py
@@ -196,8 +196,9 @@ class ProviderManager:
                 model_provider,
                 self.kira_config.get_config(f"providers.{model_provider}.name"),
                 self.kira_config.get_config(f"providers.{model_provider}.provider_config"),
-                # When the model ID has a dot, kira_config.get_config would return unexpected value
-                self.kira_config.get_config(f"providers.{model_provider}.model_config.{model_type}").get(model_id)
+                # When the model ID has a dot, kira_config.get_config would return unexpected value.
+                # Guard against a missing model_config section (get_config returns None).
+                (self.kira_config.get_config(f"providers.{model_provider}.model_config.{model_type}") or {}).get(model_id)
             )
             return model_info
 

--- a/core/provider/src/openai/model_clients.py
+++ b/core/provider/src/openai/model_clients.py
@@ -74,6 +74,8 @@ class OpenAIImageClient(ImageModelClient):
                 response_format="url",
                 extra_body={"watermark": False},
             )
+            if not images_response.data:
+                raise ValueError("Image generation API returned empty data")
             return Image(image=images_response.data[0].url)
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:
             logger.error(f"Image generation API error: {e}")
@@ -254,6 +256,8 @@ class OpenAIImageClient(ImageModelClient):
                 response_format="url",
                 extra_body={"watermark": False, "image": image_data_urls},
             )
+            if not images_response.data:
+                raise ValueError("Image-to-image generation API returned empty data")
             return Image(image=images_response.data[0].url)
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:
             logger.error(f"Image-to-image generation API error: {e}")

--- a/core/provider/src/volcengine/model_clients.py
+++ b/core/provider/src/volcengine/model_clients.py
@@ -82,6 +82,9 @@ class VolcengineVideoClient(VideoModelClient):
 
                 if status == "succeeded":
                     url = data.get("content", {}).get("video_url")
+                    if not url:
+                        logger.error(f"Video generation succeeded but returned no video_url: {data}")
+                        raise RuntimeError("Volcengine video generation succeeded but returned no video_url")
                     logger.info(f"火山方舟视频生成耗时：{time.time() - start_ts}")
                     return Video(file=url)
 
@@ -94,6 +97,7 @@ class VolcengineVideoClient(VideoModelClient):
                 await asyncio.sleep(2)
 
             logger.error(f"Timeout while generating video: {data}")
+            raise TimeoutError("Volcengine video generation timed out")
 
     async def _create_task(self, client: httpx.AsyncClient, text: str, ref: list[Image] = None, duration: int = 5) -> str:
         url = "https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks"

--- a/core/provider/src/volcengine/model_clients.py
+++ b/core/provider/src/volcengine/model_clients.py
@@ -1,4 +1,5 @@
 from openai import AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionError
+import asyncio
 import time
 import httpx
 from typing import Optional, Union
@@ -66,24 +67,33 @@ class VolcengineVideoClient(VideoModelClient):
         super().__init__(model)
 
     async def generate_video(self, prompt: str, ref: list[Image] = None, duration: int = 5, **kwargs) -> Video:
-        client = httpx.AsyncClient(timeout=5)
-        task_id = await self._create_task(client=client, text=prompt, ref=ref, duration=duration)
+        # Use a context-managed client so the connection is always closed.
+        async with httpx.AsyncClient(timeout=30) as client:
+            task_id = await self._create_task(client=client, text=prompt, ref=ref, duration=duration)
 
-        start_ts = time.time()
+            start_ts = time.time()
 
-        data = None
+            data = None
 
-        while time.time() - start_ts < 30:
-            data = await self._get_task(client=client, task_id=task_id)
+            while time.time() - start_ts < 30:
+                data = await self._get_task(client=client, task_id=task_id)
 
-            status = data.get("status")
+                status = data.get("status")
 
-            if status == "succeeded":
-                url = data.get("content", {}).get("video_url")
-                logger.info(f"火山方舟视频生成耗时：{time.time() - start_ts}")
-                return Video(file=url)
+                if status == "succeeded":
+                    url = data.get("content", {}).get("video_url")
+                    logger.info(f"火山方舟视频生成耗时：{time.time() - start_ts}")
+                    return Video(file=url)
 
-        logger.error(f"Timeout while generating video: {data}")
+                # Break out early on terminal failure statuses instead of busy-spinning.
+                if status in ("failed", "canceled", "expired"):
+                    logger.error(f"Video generation failed with status '{status}': {data}")
+                    raise RuntimeError(f"Volcengine video generation failed with status: {status}")
+
+                # Avoid busy-spinning: wait before polling the task status again.
+                await asyncio.sleep(2)
+
+            logger.error(f"Timeout while generating video: {data}")
 
     async def _create_task(self, client: httpx.AsyncClient, text: str, ref: list[Image] = None, duration: int = 5) -> str:
         url = "https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks"

--- a/core/sticker_manager.py
+++ b/core/sticker_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import inspect
+import uuid
 
 from typing import Optional, Union, Any, Callable
 from copy import deepcopy
@@ -157,13 +158,9 @@ class StickerManager:
             ext = ""
         if not ext:
             ext = ".png"
-            base_name = base_name + ext
-        filename = base_name
-        os.makedirs(self.sticker_folder, exist_ok=True)
-        file_path = os.path.join(self.sticker_folder, filename)
-        with open(file_path, "wb") as f:
-            f.write(file_bytes)
         final_desc = desc or ""
+        # Resolve the sticker id before building the stored filename so the id
+        # can be used to keep filenames unique.
         if sticker_id and str(sticker_id).strip():
             sid = str(sticker_id).strip()
             if sid in self._sticker_cache:
@@ -178,6 +175,14 @@ class StickerManager:
         else:
             self._sticker_index += 1
             sid = str(self._sticker_index)
+        # Prefix the stored filename with the unique sticker id so same-named
+        # uploads no longer overwrite each other (and deleting one no longer
+        # removes another's file).
+        filename = f"{sid}_{uuid.uuid4().hex}{ext}"
+        os.makedirs(self.sticker_folder, exist_ok=True)
+        file_path = os.path.join(self.sticker_folder, filename)
+        with open(file_path, "wb") as f:
+            f.write(file_bytes)
         await self.register_sticker(filename, final_desc, sid)
         return {
             "id": sid,

--- a/core/sticker_manager.py
+++ b/core/sticker_manager.py
@@ -153,10 +153,7 @@ class StickerManager:
         if not original_filename:
             raise ValueError("File name is required")
         base_name = os.path.basename(original_filename)
-        try:
-            _, ext = os.path.splitext(base_name)
-        except Exception:
-            ext = ""
+        name_only, ext = os.path.splitext(base_name)
         if not ext:
             ext = ".png"
         final_desc = desc or ""
@@ -176,15 +173,16 @@ class StickerManager:
         else:
             self._sticker_index += 1
             sid = str(self._sticker_index)
-        # Prefix the stored filename with the unique sticker id so same-named
-        # uploads no longer overwrite each other (and deleting one no longer
-        # removes another's file).
-        # Sanitize the id used in the on-disk filename so a crafted sticker id
-        # (e.g. containing "/", "\\" or "..") cannot escape the sticker folder.
-        safe_sid = re.sub(r"[^A-Za-z0-9_-]", "_", sid)
-        filename = f"{safe_sid}_{uuid.uuid4().hex}{ext}"
+        # Sanitize the name to prevent path traversal (e.g. "../secret")
+        safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", name_only)
+        if not safe_name or safe_name in (".", ".."):
+            safe_name = "file"
+        filename = f"{safe_name}{ext}"
         os.makedirs(self.sticker_folder, exist_ok=True)
         file_path = os.path.join(self.sticker_folder, filename)
+        if os.path.exists(file_path):
+            filename = f"{safe_name}_{uuid.uuid4().hex}{ext}"
+            file_path = os.path.join(self.sticker_folder, filename)
         with open(file_path, "wb") as f:
             f.write(file_bytes)
         await self.register_sticker(filename, final_desc, sid)

--- a/core/sticker_manager.py
+++ b/core/sticker_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import inspect
 import uuid
 
@@ -178,7 +179,10 @@ class StickerManager:
         # Prefix the stored filename with the unique sticker id so same-named
         # uploads no longer overwrite each other (and deleting one no longer
         # removes another's file).
-        filename = f"{sid}_{uuid.uuid4().hex}{ext}"
+        # Sanitize the id used in the on-disk filename so a crafted sticker id
+        # (e.g. containing "/", "\\" or "..") cannot escape the sticker folder.
+        safe_sid = re.sub(r"[^A-Za-z0-9_-]", "_", sid)
+        filename = f"{safe_sid}_{uuid.uuid4().hex}{ext}"
         os.makedirs(self.sticker_folder, exist_ok=True)
         file_path = os.path.join(self.sticker_folder, filename)
         with open(file_path, "wb") as f:

--- a/core/telemetry/client.py
+++ b/core/telemetry/client.py
@@ -454,22 +454,22 @@ class TelemetryClient:
             since_ts = int(time.time()) - 12 * 3600
             event_count = 0
 
-            # Message stats — combine all platforms per hour into one event
-            msg_rows = await self.db.get_unreported_telemetry_messages_by_hour(since_ts)
+            # Message stats — combine all platforms per hour into one event.
+            # Counts and the id set to mark are derived from a SINGLE per-row
+            # snapshot, so they cannot diverge (a row counted but never marked, or
+            # marked but never counted, as the prior two-query read allowed).
+            msg_rows = await self.db.get_unreported_telemetry_message_rows(since_ts)
             if msg_rows:
-                # Collect the exact row ids aggregated into each hour bucket so that on
-                # success we mark only those rows — never rows inserted into the still-filling
-                # current hour between this read and the deferred on-success mark.
-                msg_ids_by_hour: dict[int, list[str]] = {}
-                for id_row in await self.db.get_unreported_telemetry_message_ids_by_hour(since_ts):
-                    msg_ids_by_hour.setdefault(id_row["hour_ts"], []).append(id_row["id"])
-
                 by_hour: dict[int, dict[str, int]] = {}
+                msg_ids_by_hour: dict[int, list[str]] = {}
                 for row in msg_rows:
-                    hour = by_hour.setdefault(row["hour_ts"], {})
-                    hour[row["platform"]] = hour.get(row["platform"], 0) + row["count"]
+                    platforms = by_hour.setdefault(row["hour_ts"], {})
+                    platforms[row["platform"]] = platforms.get(row["platform"], 0) + 1
+                    msg_ids_by_hour.setdefault(row["hour_ts"], []).append(row["id"])
                 for hour_ts, platforms in by_hour.items():
                     ids = msg_ids_by_hour.get(hour_ts, [])
+                    if not ids:
+                        continue
                     self.send_event(TelemetryEventType.MESSAGE_STATS, {
                         "hour": datetime.fromtimestamp(hour_ts, tz=timezone.utc).isoformat(),
                         "total_messages": sum(platforms.values()),
@@ -478,37 +478,49 @@ class TelemetryClient:
                     }, on_success=lambda ids=ids: self.db.mark_telemetry_messages_by_ids(ids))
                     event_count += 1
 
-            # LLM usage stats — one event per hour, models nested
-            llm_rows = await self.db.get_unreported_telemetry_llm_usage_by_hour(since_ts)
+            # LLM usage stats — one event per hour, models nested. Same single-snapshot
+            # approach: aggregate measures and collect ids from the same rows.
+            llm_rows = await self.db.get_unreported_telemetry_llm_usage_rows(since_ts)
             if llm_rows:
-                # Collect the exact row ids aggregated into each hour bucket (see note above).
-                llm_ids_by_hour: dict[int, list[str]] = {}
-                for id_row in await self.db.get_unreported_telemetry_llm_usage_ids_by_hour(since_ts):
-                    llm_ids_by_hour.setdefault(id_row["hour_ts"], []).append(id_row["id"])
-
                 llm_by_hour: dict[int, list[dict]] = {}
+                llm_ids_by_hour: dict[int, list[str]] = {}
                 for row in llm_rows:
                     llm_by_hour.setdefault(row["hour_ts"], []).append(row)
+                    llm_ids_by_hour.setdefault(row["hour_ts"], []).append(row["id"])
                 for hour_ts, rows in llm_by_hour.items():
-                    total_calls = sum(r["call_count"] for r in rows)
-                    total_success = sum(r["success_count"] for r in rows)
-                    total_input = sum(r["total_input"] for r in rows)
-                    total_output = sum(r["total_output"] for r in rows)
-                    total_cached = sum(r["total_cached"] for r in rows)
-                    total_resp_ms = sum(r["total_response_ms"] for r in rows)
-                    models = {}
-                    for r in rows:
-                        avg_resp = int(r["total_response_ms"] / r["call_count"]) if r["call_count"] else 0
-                        models[r["model"]] = {
-                            "total_calls": r["call_count"],
-                            "success_calls": r["success_count"],
-                            "failed_calls": r["call_count"] - r["success_count"],
-                            "total_input_tokens": r["total_input"],
-                            "total_output_tokens": r["total_output"],
-                            "total_cached_tokens": r["total_cached"],
-                            "avg_response_time_ms": avg_resp,
-                        }
                     ids = llm_ids_by_hour.get(hour_ts, [])
+                    if not ids:
+                        continue
+                    # Aggregate per model from the raw rows.
+                    per_model: dict[str, dict[str, int]] = {}
+                    for r in rows:
+                        m = per_model.setdefault(r["model"], {
+                            "calls": 0, "success": 0, "input": 0, "output": 0, "cached": 0, "resp_ms": 0,
+                        })
+                        m["calls"] += 1
+                        m["success"] += 1 if r["success"] else 0
+                        m["input"] += r["input_tokens"]
+                        m["output"] += r["output_tokens"]
+                        m["cached"] += r["cached_tokens"]
+                        m["resp_ms"] += r["response_time_ms"]
+                    total_calls = sum(m["calls"] for m in per_model.values())
+                    total_success = sum(m["success"] for m in per_model.values())
+                    total_input = sum(m["input"] for m in per_model.values())
+                    total_output = sum(m["output"] for m in per_model.values())
+                    total_cached = sum(m["cached"] for m in per_model.values())
+                    total_resp_ms = sum(m["resp_ms"] for m in per_model.values())
+                    models = {
+                        model: {
+                            "total_calls": m["calls"],
+                            "success_calls": m["success"],
+                            "failed_calls": m["calls"] - m["success"],
+                            "total_input_tokens": m["input"],
+                            "total_output_tokens": m["output"],
+                            "total_cached_tokens": m["cached"],
+                            "avg_response_time_ms": int(m["resp_ms"] / m["calls"]) if m["calls"] else 0,
+                        }
+                        for model, m in per_model.items()
+                    }
                     self.send_event(TelemetryEventType.LLM_USAGE, {
                         "hour": datetime.fromtimestamp(hour_ts, tz=timezone.utc).isoformat(),
                         "total_calls": total_calls,

--- a/core/telemetry/client.py
+++ b/core/telemetry/client.py
@@ -457,23 +457,35 @@ class TelemetryClient:
             # Message stats — combine all platforms per hour into one event
             msg_rows = await self.db.get_unreported_telemetry_messages_by_hour(since_ts)
             if msg_rows:
+                # Collect the exact row ids aggregated into each hour bucket so that on
+                # success we mark only those rows — never rows inserted into the still-filling
+                # current hour between this read and the deferred on-success mark.
+                msg_ids_by_hour: dict[int, list[str]] = {}
+                for id_row in await self.db.get_unreported_telemetry_message_ids_by_hour(since_ts):
+                    msg_ids_by_hour.setdefault(id_row["hour_ts"], []).append(id_row["id"])
+
                 by_hour: dict[int, dict[str, int]] = {}
                 for row in msg_rows:
                     hour = by_hour.setdefault(row["hour_ts"], {})
                     hour[row["platform"]] = hour.get(row["platform"], 0) + row["count"]
                 for hour_ts, platforms in by_hour.items():
-                    h = hour_ts
+                    ids = msg_ids_by_hour.get(hour_ts, [])
                     self.send_event(TelemetryEventType.MESSAGE_STATS, {
                         "hour": datetime.fromtimestamp(hour_ts, tz=timezone.utc).isoformat(),
                         "total_messages": sum(platforms.values()),
                         "messages_by_platform": platforms,
                         "time_window_minutes": 60,
-                    }, on_success=lambda h=h: self.db.mark_telemetry_messages_by_hours([h]))
+                    }, on_success=lambda ids=ids: self.db.mark_telemetry_messages_by_ids(ids))
                     event_count += 1
 
             # LLM usage stats — one event per hour, models nested
             llm_rows = await self.db.get_unreported_telemetry_llm_usage_by_hour(since_ts)
             if llm_rows:
+                # Collect the exact row ids aggregated into each hour bucket (see note above).
+                llm_ids_by_hour: dict[int, list[str]] = {}
+                for id_row in await self.db.get_unreported_telemetry_llm_usage_ids_by_hour(since_ts):
+                    llm_ids_by_hour.setdefault(id_row["hour_ts"], []).append(id_row["id"])
+
                 llm_by_hour: dict[int, list[dict]] = {}
                 for row in llm_rows:
                     llm_by_hour.setdefault(row["hour_ts"], []).append(row)
@@ -496,7 +508,7 @@ class TelemetryClient:
                             "total_cached_tokens": r["total_cached"],
                             "avg_response_time_ms": avg_resp,
                         }
-                    h = hour_ts
+                    ids = llm_ids_by_hour.get(hour_ts, [])
                     self.send_event(TelemetryEventType.LLM_USAGE, {
                         "hour": datetime.fromtimestamp(hour_ts, tz=timezone.utc).isoformat(),
                         "total_calls": total_calls,
@@ -507,7 +519,7 @@ class TelemetryClient:
                         "total_cached_tokens": total_cached,
                         "avg_response_time_ms": int(total_resp_ms / total_calls) if total_calls else 0,
                         "models": models,
-                    }, on_success=lambda h=h: self.db.mark_telemetry_llm_by_hours([h]))
+                    }, on_success=lambda ids=ids: self.db.mark_telemetry_llm_by_ids(ids))
                     event_count += 1
 
             if event_count:

--- a/core/utils/github_api.py
+++ b/core/utils/github_api.py
@@ -343,39 +343,42 @@ async def pick_fastest_source(
     return a list of download URLs ranked by latency (best first).
     Returns empty list if all fail.
     """
-    candidates: list[tuple[str, str]] = [("direct", direct_url)]
+    # Carry the original base URL alongside each label so the fastest source
+    # can be mapped back to the exact base it was derived from. Substring
+    # matching on the bare host (e.g. "gh-proxy.org") is ambiguous because it
+    # also matches "hk.gh-proxy.org" / "cdn.gh-proxy.org" / etc.
+    candidates: list[tuple[str, str, Optional[str]]] = [("direct", direct_url, None)]
     for base in GH_PROXY_LIST:
         label = base.rstrip("/").split("//", 1)[-1]
-        candidates.append((label, f"{base.rstrip('/')}/{direct_url}"))
+        candidates.append((label, f"{base.rstrip('/')}/{direct_url}", base))
 
     logger.info(f"Speed-testing {len(candidates)} GitHub sources ...")
 
-    async def _probe(label: str, url: str) -> tuple[str, Optional[float]]:
+    async def _probe(label: str, url: str, base: Optional[str]) -> tuple[str, Optional[str], Optional[float]]:
         try:
             result = await test_url_speed(url, proxy=proxy, timeout=timeout)
-            return label, result["latency"]
+            return label, base, result["latency"]
         except Exception:
-            return label, None
+            return label, base, None
 
-    results = await asyncio.gather(*[_probe(label, url) for label, url in candidates])
+    results = await asyncio.gather(
+        *[_probe(label, url, base) for label, url, base in candidates]
+    )
 
-    for label, latency in sorted(results, key=lambda x: x[1] or 999):
+    for label, _base, latency in sorted(results, key=lambda x: x[2] or 999):
         if latency is not None:
             logger.info(f"  {label}: {latency:.3f}s")
         else:
             logger.warning(f"  {label}: FAILED")
 
     ranked: list[str] = []
-    for label, latency in sorted(results, key=lambda x: x[1] or 999):
+    for label, base, latency in sorted(results, key=lambda x: x[2] or 999):
         if latency is None:
             continue
         if label == "direct":
             ranked.append(direct_url)
         else:
-            proxy_base = next((b for b in GH_PROXY_LIST if label in b), None)
-            if proxy_base is None:
-                continue
-            ranked.append(f"{proxy_base.rstrip('/')}/{direct_url}")
+            ranked.append(f"{base.rstrip('/')}/{direct_url}")
 
     if ranked:
         logger.info(f"Ranked {len(ranked)} usable source(s)")

--- a/main.py
+++ b/main.py
@@ -210,7 +210,10 @@ def _run_supervisor(args: argparse.Namespace):
             print(f"[supervisor] Exceeded {MAX_RESTARTS} rapid restarts, exiting.")
             break
 
-        backoff = min(RESTART_BACKOFF_BASE * restart_count, 60)
+        # Exponential backoff capped at 60s. restart_count is already 1 on the
+        # first restart, so 2 ** (restart_count - 1) makes the first backoff
+        # equal to RESTART_BACKOFF_BASE.
+        backoff = min(RESTART_BACKOFF_BASE * (2 ** (restart_count - 1)), 60)
         print(f"[supervisor] Restart {restart_count}/{MAX_RESTARTS} in {backoff}s ...")
         time.sleep(backoff)
 

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -304,6 +304,62 @@ async def test_telemetry_llm_usage_aggregation(svc):
 
 
 @pytest.mark.anyio
+async def test_telemetry_message_rows_and_mark_by_ids(svc):
+    h10 = 10 * HOUR
+    await svc.add_telemetry_message(h10 + 100, "QQ")
+    await svc.add_telemetry_message(h10 + 200, "QQ")
+    await svc.add_telemetry_message(h10 + 300, "Telegram")
+
+    rows = await svc.get_unreported_telemetry_message_rows(since_ts=0)
+    assert len(rows) == 3
+    assert all(r["id"] for r in rows)
+    # Per-row data aggregates to the same counts as the SQL aggregate query.
+    counts: dict = {}
+    for r in rows:
+        counts[(r["hour_ts"], r["platform"])] = counts.get((r["hour_ts"], r["platform"]), 0) + 1
+    assert counts[(h10, "QQ")] == 2
+    assert counts[(h10, "Telegram")] == 1
+
+    # Marking exactly those ids clears them (and only them).
+    await svc.mark_telemetry_messages_by_ids([r["id"] for r in rows])
+    assert await svc.get_unreported_telemetry_message_rows(since_ts=0) == []
+
+
+@pytest.mark.anyio
+async def test_telemetry_llm_usage_rows_fields(svc):
+    h10 = 10 * HOUR
+    await svc.add_telemetry_llm_usage(h10 + 100, "gpt-4o", 1000, 500, 100, 800, True)
+    await svc.add_telemetry_llm_usage(h10 + 300, "deepseek", 500, 0, None, 5000, False)
+
+    rows = await svc.get_unreported_telemetry_llm_usage_rows(since_ts=0)
+    assert len(rows) == 2
+    by_model = {r["model"]: r for r in rows}
+    assert by_model["gpt-4o"]["input_tokens"] == 1000
+    assert by_model["gpt-4o"]["cached_tokens"] == 100
+    assert by_model["gpt-4o"]["success"] in (True, 1)
+    # None cached_tokens is normalized to 0.
+    assert by_model["deepseek"]["cached_tokens"] == 0
+    assert by_model["deepseek"]["success"] in (False, 0)
+    assert all(r["id"] for r in rows)
+
+    await svc.mark_telemetry_llm_by_ids([r["id"] for r in rows])
+    assert await svc.get_unreported_telemetry_llm_usage_rows(since_ts=0) == []
+
+
+@pytest.mark.anyio
+async def test_mark_telemetry_messages_by_ids_chunks_over_limit(svc):
+    # More than SQLite's ~999 bound-parameter limit, to exercise the chunked
+    # WHERE id IN (...) marking and ensure it doesn't raise "too many SQL variables".
+    h10 = 10 * HOUR
+    for i in range(1100):
+        await svc.add_telemetry_message(h10 + i, "QQ")
+    rows = await svc.get_unreported_telemetry_message_rows(since_ts=0)
+    assert len(rows) == 1100
+    await svc.mark_telemetry_messages_by_ids([r["id"] for r in rows])
+    assert await svc.get_unreported_telemetry_message_rows(since_ts=0) == []
+
+
+@pytest.mark.anyio
 async def test_delete_telemetry_records_before(svc):
     h10 = 10 * HOUR
     h20 = 20 * HOUR

--- a/webui/routes/auth.py
+++ b/webui/routes/auth.py
@@ -10,7 +10,7 @@ from starlette.responses import JSONResponse, Response
 from core.config.default import VERSION
 from webui.models import LoginResponse, TokenLoginRequest, VersionResponse
 from webui.routes.base import RouteDefinition, Routes
-from webui.utils import _create_jwt_token, _verify_jwt_token
+from webui.utils import _access_token_fingerprint, _create_jwt_token, _verify_jwt_token
 
 
 async def require_auth(
@@ -50,6 +50,16 @@ async def require_auth(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token issued under a different auth mode, please re-login",
+        )
+
+    # tv claim binds the JWT to a fingerprint of the access token in effect at
+    # issue time. Rotating the access token changes the fingerprint, so every
+    # previously issued JWT (including any missing the claim) is rejected here.
+    current_token = getattr(request.app.state, "access_token", "")
+    if payload.get("tv") != _access_token_fingerprint(current_token):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session invalidated by an access-token change, please re-login",
         )
     return payload.get("sub", "admin")
 
@@ -246,6 +256,9 @@ class AuthRoutes(Routes):
             data={
                 "sub": "admin",
                 "auth_mode": "disabled" if self.disable_auth else "enabled",
+                # Bind the session to the current access token; rotating the
+                # token changes this fingerprint and invalidates old JWTs.
+                "tv": _access_token_fingerprint(current_token),
             },
             expires_delta=timedelta(days=5),
         )

--- a/webui/routes/auth.py
+++ b/webui/routes/auth.py
@@ -10,7 +10,7 @@ from starlette.responses import JSONResponse, Response
 from core.config.default import VERSION
 from webui.models import LoginResponse, TokenLoginRequest, VersionResponse
 from webui.routes.base import RouteDefinition, Routes
-from webui.utils import _access_token_fingerprint, _create_jwt_token, _verify_jwt_token
+from webui.utils import _access_token_fingerprint, _create_jwt_token, verify_session_token
 
 
 async def require_auth(
@@ -42,25 +42,9 @@ async def require_auth(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing or invalid authorization header",
         )
-    payload = _verify_jwt_token(token)
-
-    current_mode = "disabled" if getattr(request.app.state, "disable_auth", False) else "enabled"
-    token_mode = payload.get("auth_mode", "enabled")
-    if token_mode != current_mode:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token issued under a different auth mode, please re-login",
-        )
-
-    # tv claim binds the JWT to a fingerprint of the access token in effect at
-    # issue time. Rotating the access token changes the fingerprint, so every
-    # previously issued JWT (including any missing the claim) is rejected here.
-    current_token = getattr(request.app.state, "access_token", "")
-    if payload.get("tv") != _access_token_fingerprint(current_token):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Session invalidated by an access-token change, please re-login",
-        )
+    # Signature/expiry + auth_mode + access-token (tv) binding, via the shared
+    # helper so plugin page/static auth enforces the exact same claims.
+    payload = verify_session_token(token, request.app.state)
     return payload.get("sub", "admin")
 
 

--- a/webui/routes/config.py
+++ b/webui/routes/config.py
@@ -72,20 +72,32 @@ class ConfigRoutes(Routes):
         if not self.lifecycle or not getattr(self.lifecycle, "kira_config", None):
             raise HTTPException(status_code=500, detail="Configuration not available")
         config = self.lifecycle.kira_config
+        # Replace-on-send semantics are intentional: each section sent by the
+        # client fully replaces the stored section so the WebUI can delete items
+        # (e.g. remove an adapter) by omitting them. To avoid type-confusion
+        # corruption, validate that every section *present* in the payload is an
+        # object/dict and reject with HTTP 400 otherwise; sections the client did
+        # not send are left untouched (present-only assignment).
+        for section in ("bot_config", "models", "logging", "adapters", "network"):
+            if section in payload and not isinstance(payload[section], dict):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid configuration: '{section}' must be an object",
+                )
         bot_config = payload.get("bot_config")
         models = payload.get("models")
         logging_config = payload.get("logging")
         adapters_config = payload.get("adapters")
         network_config = payload.get("network")
         updated = False
-        if isinstance(bot_config, dict):
+        if "bot_config" in payload:
             config["bot_config"] = bot_config
             updated = True
-        if isinstance(models, dict):
+        if "models" in payload:
             config["models"] = models
             updated = True
         logging_changed = False
-        if isinstance(logging_config, dict):
+        if "logging" in payload:
             old_logging = deepcopy(config.get("logging", {}))
             logging_changed = logging_config != old_logging
             if logging_changed:
@@ -100,10 +112,10 @@ class ConfigRoutes(Routes):
                     logger.info("Logging configuration applied")
                 except Exception as e:
                     logger.error(f"Failed to apply logging config, not saving: {e}")
-        if isinstance(adapters_config, dict):
+        if "adapters" in payload:
             config["adapters"] = adapters_config
             updated = True
-        if isinstance(network_config, dict):
+        if "network" in payload:
             config["network"] = network_config
             updated = True
         if updated:

--- a/webui/routes/sessions.py
+++ b/webui/routes/sessions.py
@@ -70,11 +70,11 @@ class SessionsRoutes(Routes):
         if not self.lifecycle or not self.lifecycle.session_manager:
             raise HTTPException(status_code=404, detail="Memory manager not available")
 
-        memory = self.lifecycle.session_manager.read_memory(session_id)
-
         parts = session_id.split(":")
         if len(parts) < 3:
             raise HTTPException(status_code=400, detail="Invalid session id format")
+
+        memory = self.lifecycle.session_manager.read_memory(session_id)
 
         adapter_name, session_type, session_key = parts[0], parts[1], ":".join(parts[2:])
         session_meta = self.lifecycle.session_manager.chat_memory.get(session_id, {})

--- a/webui/routes/stickers.py
+++ b/webui/routes/stickers.py
@@ -1,4 +1,5 @@
 import json
+import re
 import uuid
 from typing import List, Optional
 
@@ -152,7 +153,10 @@ class StickersRoutes(Routes):
             ext = ".png"
         # Prefix the stored filename with the unique sticker id so same-named
         # uploads no longer overwrite each other.
-        filename = f"{sid}_{uuid.uuid4().hex}{ext}"
+        # Sanitize the id used in the on-disk filename to prevent path traversal
+        # via a crafted sticker id (e.g. one containing "/", "\\" or "..").
+        safe_sid = re.sub(r"[^A-Za-z0-9_-]", "_", sid)
+        filename = f"{safe_sid}_{uuid.uuid4().hex}{ext}"
         file_path = sticker_folder / filename
         try:
             with open(file_path, "wb") as f:

--- a/webui/routes/stickers.py
+++ b/webui/routes/stickers.py
@@ -145,19 +145,19 @@ class StickersRoutes(Routes):
             raise HTTPException(status_code=500, detail="Failed to prepare sticker folder")
         from pathlib import Path as _Path
         base_name = _Path(file.filename).name
-        try:
-            ext = _Path(base_name).suffix
-        except Exception:
-            ext = ""
+        name_only = _Path(base_name).stem
+        ext = _Path(base_name).suffix
         if not ext:
             ext = ".png"
-        # Prefix the stored filename with the unique sticker id so same-named
-        # uploads no longer overwrite each other.
-        # Sanitize the id used in the on-disk filename to prevent path traversal
-        # via a crafted sticker id (e.g. one containing "/", "\\" or "..").
-        safe_sid = re.sub(r"[^A-Za-z0-9_-]", "_", sid)
-        filename = f"{safe_sid}_{uuid.uuid4().hex}{ext}"
+        # Sanitize the name to prevent path traversal (e.g. "../secret")
+        safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", name_only)
+        if not safe_name or safe_name in (".", ".."):
+            safe_name = "file"
+        filename = f"{safe_name}{ext}"
         file_path = sticker_folder / filename
+        if file_path.exists():
+            filename = f"{safe_name}_{uuid.uuid4().hex}{ext}"
+            file_path = sticker_folder / filename
         try:
             with open(file_path, "wb") as f:
                 f.write(file_bytes)

--- a/webui/routes/stickers.py
+++ b/webui/routes/stickers.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from typing import List, Optional
 
 from fastapi import Depends, File, Form, HTTPException, UploadFile, status
@@ -149,8 +150,9 @@ class StickersRoutes(Routes):
             ext = ""
         if not ext:
             ext = ".png"
-            base_name = f"{base_name}{ext}"
-        filename = base_name
+        # Prefix the stored filename with the unique sticker id so same-named
+        # uploads no longer overwrite each other.
+        filename = f"{sid}_{uuid.uuid4().hex}{ext}"
         file_path = sticker_folder / filename
         try:
             with open(file_path, "wb") as f:

--- a/webui/utils.py
+++ b/webui/utils.py
@@ -163,6 +163,30 @@ def _verify_jwt_token(token: str) -> Dict:
         )
 
 
+def verify_session_token(token: str, app_state) -> Dict:
+    """Verify a session JWT end to end: signature/expiry, auth_mode, and the
+    access-token (tv) binding.
+
+    Shared by require_auth and the plugin page/static auth checks so every
+    auth-required path enforces the same claims — in particular, rotating the
+    access token invalidates old sessions everywhere, not just on API routes.
+    Raises HTTPException(401) on any failure and returns the decoded payload.
+    """
+    payload = _verify_jwt_token(token)
+    current_mode = "disabled" if getattr(app_state, "disable_auth", False) else "enabled"
+    if payload.get("auth_mode", "enabled") != current_mode:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token issued under a different auth mode, please re-login",
+        )
+    if payload.get("tv") != _access_token_fingerprint(getattr(app_state, "access_token", "")):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session invalidated by an access-token change, please re-login",
+        )
+    return payload
+
+
 def _generate_id() -> str:
     """Generate a short unique identifier."""
     return uuid.uuid4().hex[:12]

--- a/webui/utils.py
+++ b/webui/utils.py
@@ -1,6 +1,7 @@
 """
 Shared utility functions for the WebUI.
 """
+import hashlib
 import json
 import os
 import secrets
@@ -121,6 +122,16 @@ def _update_access_token(new_token: str) -> None:
     config = _load_webui_config()
     config["access_token"] = new_token
     _save_webui_config(config)
+
+
+def _access_token_fingerprint(token: str) -> str:
+    """Derive a short, stable fingerprint of the current access token.
+
+    Embedding this in the JWT lets require_auth invalidate every existing
+    session the moment the access token is rotated — without any per-request
+    file I/O, since it is computed purely from the in-memory token value.
+    """
+    return hashlib.sha256(token.encode()).hexdigest()[:16]
 
 
 def _create_jwt_token(data: Dict, expires_delta: Optional[timedelta] = None) -> str:


### PR DESCRIPTION
> **⚠️ Base branch is `dev`** (per the PR template).

## Summary

Fixes the remaining (non-security) bugs from a full review of the current `dev` tree — crashes, adapter correctness, session/agent pipeline issues, telemetry/cache accuracy, and assorted robustness cleanups. Each fix was implemented in isolation and independently verified; the full test suite passes (`169 passed`).

Fixes #113, Fixes #114, Fixes #115, Fixes #116, Fixes #117, Fixes #118, Fixes #119, Fixes #120, Fixes #121, Fixes #122, Fixes #123, Fixes #124, Fixes #125, Fixes #126, Fixes #127, Fixes #128, Fixes #129, Fixes #130, Fixes #132

(Security issues #111 / #112 / #131 are handled separately in #133.)

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

Organized as one commit per area (each commit lists the issues it closes):

- **Crashes & startup (#113 #114 #115)** — guard `get_default_model_info` when a provider has no `model_config.<type>`; read `host`/`port` from `webui.json` with defaults instead of an uncaught `KeyError`; drop the erroneous `await` on `response_futures.pop` in NapCat so timeouts surface as `TimeoutError`.
- **Bilibili (#132 #117)** — load `SESSDATA` correctly (rename schema key to `sessdata`, with back-compat fallback to the old `sesdata`); normalize `uid` types so the bot stops replying to its own comments.
- **WebUI JWT (#116)** — embed a `tv` claim (fingerprint of the access token) in issued JWTs and reject mismatches in `require_auth`, so rotating the access token invalidates all existing sessions.
- **Agent tool-calls (#118)** — when a turn is stopped mid tool-calling, trim the assistant message's `tool_calls` to those with a matching tool result, so replayed history no longer 400s the next request.
- **Session / memory (#119 #120)** — idempotent `delete_session` (`pop(…, None)`); memory plugin no longer `break`s before injecting `MEM_TOOL_FEW_SHOT`.
- **Telemetry & image cache (#121 #126)** — mark only the exact aggregated telemetry rows by id (fixes the current-hour undercount race); stop caching empty/failed image descriptions and preserve hit count on update.
- **WebUI config (#122)** — validate that each provided config section is an object (HTTP 400 otherwise) and only assign sections present in the payload; replace-on-send (deletion) semantics intentionally preserved.
- **Lifecycle / MCP / Volcengine (#123 #125 #124)** — `stop()` None-guards for early shutdown; `init_mcp` gathers/awaits per-server tasks and logs failures; Volcengine video polling sleeps between polls, breaks on terminal status, and closes the httpx client.
- **Telegram / stickers (#127 #128)** — fall back to `caption`/`caption_entities` when `text` is absent; store stickers under a unique filename so same-named uploads don't collide.
- **Input guards (#129)** — guard empty outgoing message chains, use a dict default for element `data`, and guard empty image-generation responses.
- **Assorted cleanups (#130)** — exact-base gh-proxy source resolution; session-id validated before read; handler removal by identity; `weixin_oc` reuses the shared config instead of reloading from disk; reliable missing-dependency detection in the plugin loader; correct shell-timeout message; genuinely exponential restart backoff; config rewritten only when it actually changed.

## Screenshots / Logs

```
$ python3 -m pytest tests/ -q
169 passed
```

## Checklist

- [x] I have tested these changes locally — full suite passes (`169 passed`); every changed file `py_compile`s; each fix group was independently adversarially verified for correctness and no regression.
- [x] I have updated documentation if needed — no docs affected.
- [x] New dependencies have been added to `requirements.txt` (if applicable) — no new dependencies.
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer — N/A (bug fixes; tracked in the linked issues).
- [x] This PR does not introduce breaking changes — config update keeps its replace-on-send semantics; the JWT change logs out existing sessions once on deploy (expected for the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `@bot` mention detection for Telegram captions and improved mention parsing accuracy
  * Fixed QQ message sending timeout cleanup
  * Fixed WebUI startup with missing host/port config and improved session ID format validation
  * Fixed sticker uploads overwriting files with identical names
  * Fixed session deletion errors when the session key is missing
* **New Features**
  * Added automatic JWT session invalidation when the server access token changes
* **Improvements**
  * Improved telemetry accuracy using row-level reporting
  * Improved video generation reliability and polling behavior
  * Improved restart backoff to exponential growth
<!-- end of auto-generated comment: release notes by coderabbit.ai -->