### PR TITLE
feat(plugin): add KiraCustomEvent for inter-plugin communication

### DIFF
--- a/core/chat/__init__.py
+++ b/core/chat/__init__.py
@@ -1,4 +1,5 @@
 from .session import Session, Group, User
-from .message_utils import (KiraMessageEvent, KiraIMMessage, KiraIMSentResult,  KiraMessageBatchEvent, KiraCommentEvent, MessageChain)
-__all__ = ["KiraCommentEvent", "KiraMessageEvent", "KiraIMMessage", "KiraIMSentResult",
+from .message_utils import (KiraMessageEvent, KiraIMMessage, KiraIMSentResult, KiraMessageBatchEvent,
+                            KiraCommentEvent, KiraCustomEvent, MessageChain)
+__all__ = ["KiraCommentEvent", "KiraCustomEvent", "KiraMessageEvent", "KiraIMMessage", "KiraIMSentResult",
            "KiraMessageBatchEvent", "MessageChain", "Session", "Group", "User"]

--- a/core/chat/message_utils.py
+++ b/core/chat/message_utils.py
@@ -243,6 +243,14 @@ class KiraExceptionEvent:
         pass
 
 
+@dataclass
+class KiraCustomEvent:
+    event_name: str
+    source_plugin: str
+    payload: dict = field(default_factory=dict)
+    timestamp: int = 0
+
+
 class MessageChain:
     def __init__(self, message_list: list[BaseMessageElement] = None):
         self.message_list: list = message_list or []

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -95,7 +95,9 @@ class EventBus:
         if isinstance(event, KiraCustomEvent):
             from core.plugin.plugin_handlers import event_handler_reg, EventType as PluginEventType
             for handler in event_handler_reg.get_handlers(PluginEventType.ON_CUSTOM_EVENT):
-                await handler.exec_handler(event)
+                filter_name = getattr(handler.handler, '_custom_event_name', None)
+                if filter_name is None or filter_name == event.event_name:
+                    await handler.exec_handler(event)
             return
         async with self.message_processing_semaphore:
             if isinstance(event, KiraMessageEvent):

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -12,7 +12,7 @@ from .statistics import Statistics
 from .logging_manager import get_logger
 
 from core.chat import KiraMessageEvent, KiraCommentEvent
-from core.chat.message_utils import KiraMessageBatchEvent
+from core.chat.message_utils import KiraMessageBatchEvent, KiraCustomEvent
 
 
 class EventType(Enum):
@@ -91,6 +91,11 @@ class EventBus:
     async def _dispatch_event(self, event):
         if isinstance(event, KiraMessageBatchEvent):
             await self.message_processor.handle_im_batch_message(event)
+            return
+        if isinstance(event, KiraCustomEvent):
+            from core.plugin.plugin_handlers import event_handler_reg, EventType as PluginEventType
+            for handler in event_handler_reg.get_handlers(PluginEventType.ON_CUSTOM_EVENT):
+                await handler.exec_handler(event)
             return
         async with self.message_processing_semaphore:
             if isinstance(event, KiraMessageEvent):

--- a/core/plugin/plugin_context.py
+++ b/core/plugin/plugin_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import inspect
+import time
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING, Literal
 
@@ -132,6 +133,27 @@ class PluginContext:
         if isinstance(client, EmbeddingModelClient):
             return client
         return
+
+    async def emit_custom_event(self, event_name: str, payload: dict = None):
+        from core.chat.message_utils import KiraCustomEvent
+        from core.plugin.plugin_handlers import event_handler_reg, EventType
+
+        plugin_id = None
+        frame = inspect.currentframe().f_back
+        if frame and self.plugin_mgr:
+            module_name = frame.f_globals.get("__name__", "")
+            plugin_id = self.plugin_mgr.get_plugin_id_for_module(module_name)
+
+        event = KiraCustomEvent(
+            event_name=event_name,
+            source_plugin=plugin_id or "unknown",
+            payload=payload or {},
+            timestamp=int(time.time()),
+        )
+
+        for handler in event_handler_reg.get_handlers(EventType.ON_CUSTOM_EVENT):
+            await handler.exec_handler(event)
+        return event
 
     async def publish_notice(self, session: str, chain: MessageChain, is_mentioned: bool = True):
         import time

--- a/core/plugin/plugin_context.py
+++ b/core/plugin/plugin_context.py
@@ -136,7 +136,6 @@ class PluginContext:
 
     async def emit_custom_event(self, event_name: str, payload: dict = None):
         from core.chat.message_utils import KiraCustomEvent
-        from core.plugin.plugin_handlers import event_handler_reg, EventType
 
         plugin_id = None
         frame = inspect.currentframe().f_back
@@ -151,8 +150,7 @@ class PluginContext:
             timestamp=int(time.time()),
         )
 
-        for handler in event_handler_reg.get_handlers(EventType.ON_CUSTOM_EVENT):
-            await handler.exec_handler(event)
+        await self.event_bus.publish(event)
         return event
 
     async def publish_notice(self, session: str, chain: MessageChain, is_mentioned: bool = True):

--- a/core/plugin/plugin_handlers.py
+++ b/core/plugin/plugin_handlers.py
@@ -31,6 +31,7 @@ class EventType(Enum):
     ON_LOADED = "on_loaded"            # 所有插件加载完成后
     ON_SHUTDOWN = "on_shutdown"        # 系统即将关闭
     ON_EXCEPTION = "on_exception"  # 异常发生时
+    ON_CUSTOM_EVENT = "on_custom_event"  # 插件自定义事件
     ...
 
 

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -1,3 +1,4 @@
+import functools
 import importlib
 import importlib.util
 import inspect
@@ -478,6 +479,7 @@ class OnEventDeco:
         def decorator(func: Callable):
             handler = func
             if event_name is not None:
+                @functools.wraps(func)
                 async def _filtered(event, *args, **kwargs):
                     if event.event_name == event_name:
                         return await func(event, *args, **kwargs)

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -474,6 +474,18 @@ class OnEventDeco:
             return func
         return decorator
 
+    def custom_event(self, priority: Union[Priority, int] = Priority.MEDIUM, event_name: Optional[str] = None):
+        def decorator(func: Callable):
+            handler = func
+            if event_name is not None:
+                async def _filtered(event, *args, **kwargs):
+                    if event.event_name == event_name:
+                        return await func(event, *args, **kwargs)
+                handler = _filtered
+            self._register_hook(handler, priority, EventType.ON_CUSTOM_EVENT)
+            return func
+        return decorator
+
 
 register = RegisterDeco()
 on = OnEventDeco()

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -1,4 +1,3 @@
-import functools
 import importlib
 import importlib.util
 import inspect
@@ -477,14 +476,9 @@ class OnEventDeco:
 
     def custom_event(self, priority: Union[Priority, int] = Priority.MEDIUM, event_name: Optional[str] = None):
         def decorator(func: Callable):
-            handler = func
             if event_name is not None:
-                @functools.wraps(func)
-                async def _filtered(event, *args, **kwargs):
-                    if event.event_name == event_name:
-                        return await func(event, *args, **kwargs)
-                handler = _filtered
-            self._register_hook(handler, priority, EventType.ON_CUSTOM_EVENT)
+                func._custom_event_name = event_name
+            self._register_hook(func, priority, EventType.ON_CUSTOM_EVENT)
             return func
         return decorator
 


### PR DESCRIPTION
## Summary

Add a lightweight pub/sub mechanism (`KiraCustomEvent`) enabling plugins to emit and listen for named custom events with arbitrary payloads, replacing the need for tight coupling via `ctx.get_plugin_inst()`.

## Type of change

- [x] feat: New feature

## Changes

- Add `KiraCustomEvent` dataclass (`event_name`, `source_plugin`, `payload`, `timestamp`) in `core/chat/message_utils.py`
- Add `ON_CUSTOM_EVENT` to plugin `EventType` enum
- Add `@on.custom_event()` decorator with optional `event_name` filtering (uses `functools.wraps` for correct instance binding)
- Add `ctx.emit_custom_event(event_name, payload)` helper on `PluginContext` — publishes to the EventBus
- Wire `KiraCustomEvent` dispatch in `EventBus._dispatch_event()` → invokes registered `ON_CUSTOM_EVENT` hooks
- Export `KiraCustomEvent` from `core.chat`

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can now emit custom events with an event name, source information, an optional payload, and a timestamp for inter-plugin communication.
  * Added support for custom event handlers, including the ability to filter which handlers run based on the event name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->