### PR TITLE
fix: prevent crash when STT model is not configured

### DIFF
--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -334,7 +334,11 @@ class MessageProcessor:
                         forward_contents += f"\n{forward_content}\n"
                     message_str += f"[Forward {forward_contents.strip()}]"
             elif isinstance(ele, Record):
-                record_text = await self.llm_api.speech_to_text(record=ele)
+                try:
+                    record_text = await self.llm_api.speech_to_text(record=ele)
+                except Exception as e:
+                    logger.error(f"Failed to get STT model for speech recognition: {e}")
+                    record_text = "[Speech recognition unavailable]"
                 ele.transcript = record_text
                 message_str += f"[Record {record_text}]"
             elif isinstance(ele, Notice):
@@ -512,11 +516,11 @@ class MessageProcessor:
             try:
                 default_llm = self.provider_mgr.get_default_llm()
                 if not default_llm:
-                    llm_logger.error(f"Default LLM model not set, please set it in Configuration")
+                    llm_logger.error(f"Default LLM model not configured, please configure it in Configuration")
                     return
                 model_group = [default_llm]
             except Exception as _:
-                llm_logger.error(f"Default LLM model not set, please set it in Configuration")
+                llm_logger.error(f"Default LLM model not configured, please configure it in Configuration")
                 return
 
         # Filter tools by scope
@@ -674,7 +678,7 @@ class MessageProcessor:
 
         client = self.provider_mgr.get_default_llm()
         if not client:
-            llm_logger.error(f"Default LLM model not set, please set it in Configuration")
+            llm_logger.error(f"Default LLM model not configured, please configure it in Configuration")
             return
 
         llm_req = LLMRequest(messages=[OpenAIMessage(role="user", content=cmt_prompt)])

--- a/core/provider/provider_manager.py
+++ b/core/provider/provider_manager.py
@@ -124,7 +124,11 @@ class ProviderManager:
         return model_client
 
     def get_default_stt(self) -> STTModelClient:
-        model_info = self.get_default_model_info("default_stt")
+        try:
+            model_info = self.get_default_model_info("default_stt")
+        except ValueError:
+            logger.error("default_stt not configured, please configure it in Configuration")
+            raise
         model_client = self.get_model_client(model_info.provider_id, model_info.model_id)
         if not isinstance(model_client, STTModelClient):
             raise TypeError(


### PR DESCRIPTION
## Summary

Fix a bug where an unconfigured STT model causes the entire message processing pipeline to crash. When a voice message (Record) is received but `default_stt` is not set, `get_default_stt()` raises an unhandled `ValueError` that propagates up and aborts the whole batch — including any text messages in the same batch.

## Type of change

- [x] fix: Bug fix

## Changes

- Wrap `speech_to_text` call in `message_format_to_text` with try-except, degrading gracefully to `[Speech recognition unavailable]` when STT is unavailable
- Add error logging inside `get_default_stt` for clearer diagnostics when STT is not configured
- Harmonize LLM-related error messages in `message_manager.py` ("not set" → "not configured")

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Speech-to-text transcription now gracefully handles failures with a fallback message instead of crashing.
  * Improved error handling and logging for default speech-to-text configuration issues.

* **Improvements**
  * Updated error messages for default LLM model configuration to be clearer and more consistent across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->