### PR TITLE
feat: dispatch ON_EXCEPTION for agent loop provider/tool errors

### DIFF
--- a/core/agent/agent_executor.py
+++ b/core/agent/agent_executor.py
@@ -114,7 +114,7 @@ class AgentExecutor:
                             traceback=traceback.format_exc(),
                             stage="agent_loop",
                             source="provider",
-                            comp_id=llm_model.model.provider_name,
+                            comp_id=model.model.provider_name,
                             e=last_exc,
                         )
                         for h in event_handler_reg.get_handlers(EventType.ON_EXCEPTION):

--- a/core/agent/agent_executor.py
+++ b/core/agent/agent_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import traceback
 from dataclasses import dataclass
 from typing import AsyncIterator, Optional, TYPE_CHECKING, Literal
 
@@ -10,6 +11,7 @@ from core.llm_client import LLMClient
 from core.provider import LLMRequest, LLMResponse, LLMModelClient
 from core.agent.tool import ToolSet
 from core.agent.message import OpenAIMessage
+from core.chat.message_utils import KiraExceptionEvent
 from core.plugin.plugin_handlers import event_handler_reg, EventType
 
 if TYPE_CHECKING:
@@ -106,6 +108,20 @@ class AgentExecutor:
                         state = "error"
                         err = f"All models failed. Last error: {type(last_exc).__name__}: {last_exc}"
                         is_final = True
+                        exc_event = KiraExceptionEvent(
+                            name=type(last_exc).__name__,
+                            message=str(last_exc),
+                            traceback=traceback.format_exc(),
+                            stage="agent_loop",
+                            source="provider",
+                            comp_id=llm_model.model.provider_name,
+                            e=last_exc,
+                        )
+                        for h in event_handler_reg.get_handlers(EventType.ON_EXCEPTION):
+                            try:
+                                await h.handler(event, exc_event)
+                            except Exception:
+                                logger.error(traceback.format_exc())
 
             has_tool_calls = bool(llm_resp.tool_calls)
 
@@ -161,7 +177,25 @@ class AgentExecutor:
             assistant_content = llm_resp.text_response or ""
             reasoning = llm_resp.reasoning_content or ""
 
-            await self.llm_api.execute_tool(event, llm_resp, tool_set=self.tool_set)
+            try:
+                await self.llm_api.execute_tool(event, llm_resp, tool_set=self.tool_set)
+            except Exception as e:
+                logger.error(f"[{sid}] Tool execution failed: {e}")
+                exc_event = KiraExceptionEvent(
+                    name=type(e).__name__,
+                    message=str(e),
+                    traceback=traceback.format_exc(),
+                    stage="agent_loop",
+                    source="tool",
+                    comp_id=None,
+                    e=e,
+                )
+                for h in event_handler_reg.get_handlers(EventType.ON_EXCEPTION):
+                    try:
+                        await h.handler(event, exc_event)
+                    except Exception:
+                        logger.error(traceback.format_exc())
+                raise
             # An ON_TOOL_RESULT handler may stop the event mid multi-tool-call turn,
             # leaving execute_tool to produce only partial tool_results. Keep the
             # assistant message's tool_calls consistent with the tool_results actually


### PR DESCRIPTION
## Summary

在 `AgentExecutor` 中为 agent 循环内的异常新增 ON_EXCEPTION 事件分发，使插件能够感知并处理 provider 错误和 tool 执行错误。

## Type of change

- [x] feat: New feature

## Changes

- provider 错误（所有模型失败）：构造 `KiraExceptionEvent(source="provider")` 并分发给 ON_EXCEPTION 处理器
- tool 执行错误：构造 `KiraExceptionEvent(source="tool")` 并分发后 re-raise
- 新增 `import traceback` 和 `KiraExceptionEvent` 导入

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling so failures are now reported more consistently during agent runs and tool execution.
  * Added richer failure details to help surface what went wrong, including error type, message, and traceback information.
  * Ensured exception reporting continues even if one handler fails, reducing the chance of missed error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->