### PR TITLE
feat: add persona_select config field type

### DIFF
--- a/core/config/config_field.py
+++ b/core/config/config_field.py
@@ -16,6 +16,7 @@ class ConfigType(Enum):
     Textarea = "textarea"
     ModelSelect = "model_select"
     MultiSelect = "multi_select"
+    PersonaSelect = "persona_select"
     Section = "section"
 
 
@@ -165,6 +166,13 @@ class MultiSelectField(BaseConfigField):
         self.options = list(options)
 
 
+class PersonaSelectField(BaseConfigField):
+    type = ConfigType.PersonaSelect
+
+    def __init__(self, key: str, name: str, hint: str, default=None, locales: dict = None):
+        super().__init__(key, name, hint, default, locales)
+
+
 class SectionField(BaseConfigField):
     type = ConfigType.Section
 
@@ -227,6 +235,9 @@ def create_field_from_schema(key: str, schema: dict) -> BaseConfigField:
 
     if field_type == "multi_select":
         return MultiSelectField(key=key, name=name, hint=hint, options=options or [], default=default, locales=locales)
+
+    if field_type == "persona_select":
+        return PersonaSelectField(key=key, name=name, hint=hint, default=default, locales=locales)
 
     if field_type == "section":
         collapsed = schema.get("collapsed", False)

--- a/webui/frontend/src/components/common/ConfigForm.vue
+++ b/webui/frontend/src/components/common/ConfigForm.vue
@@ -39,6 +39,14 @@
                   @update:model-value="updateSectionField(entry.key, key as string, $event)"
                 />
 
+                <CustomSelect
+                  v-else-if="isPersonaSelectLike(field.type)"
+                  :model-value="sectionFieldValue(entry.key, key as string, field) ?? ''"
+                  :options="personaSelectOptions"
+                  :placeholder="t('config.select_persona')"
+                  @update:model-value="updateSectionField(entry.key, key as string, $event)"
+                />
+
                 <div v-else-if="isBoolLike(field.type)" class="flex items-center">
                   <input
                     :id="'config-switch-' + entry.key + '-' + key"
@@ -167,6 +175,14 @@
           @update:model-value="updateField(entry.key, $event)"
         />
 
+        <CustomSelect
+          v-else-if="isPersonaSelectLike(entry.field.type)"
+          :model-value="fieldValue(entry.key, entry.field) ?? ''"
+          :options="personaSelectOptions"
+          :placeholder="t('config.select_persona')"
+          @update:model-value="updateField(entry.key, $event)"
+        />
+
         <div v-else-if="isBoolLike(entry.field.type)" class="flex items-center">
           <input
             :id="'config-switch-' + entry.key"
@@ -275,6 +291,7 @@ import CollapsibleSection from '@/components/common/CollapsibleSection.vue'
 import MonacoEditor from '@/components/common/MonacoEditor.vue'
 import { IconEye, IconEyeOff } from '@/components/icons'
 import { getProviders, getModels } from '@/api/provider'
+import { getPersonas } from '@/api/persona'
 
 const props = defineProps<{
   modelValue: Record<string, any>
@@ -291,6 +308,7 @@ const { localize } = useLocalized()
 const drafts = reactive<Record<string, string>>({})
 const sensitiveVisible = reactive<Record<string, boolean>>({})
 const modelSelectOptions = reactive<Record<string, { value: string; label: string }[]>>({})
+const personaSelectOptions = reactive<{ value: string; label: string }[]>([])
 const sectionCollapsed = reactive<Record<string, boolean>>({})
 
 const effectiveSchema = computed<Record<string, any>>(() => {
@@ -395,6 +413,10 @@ function isModelSelectLike(type: string): boolean {
   return type === 'model_select'
 }
 
+function isPersonaSelectLike(type: string): boolean {
+  return type === 'persona_select'
+}
+
 function isMultiSelectLike(type: string): boolean {
   return type === 'multi_select'
 }
@@ -443,6 +465,24 @@ async function loadModelSelectOptions() {
     }
   } catch (e) {
     console.warn('Failed to load model options:', e)
+  }
+}
+
+async function loadPersonaSelectOptions() {
+  const schema = allDataFields.value
+  const hasPersonaSelect = Object.values(schema).some(({ field }) => field && isPersonaSelectLike(field.type))
+  if (!hasPersonaSelect || personaSelectOptions.length > 0) return
+
+  try {
+    const res = await getPersonas()
+    const personas = res.data || []
+    personaSelectOptions.length = 0
+    personaSelectOptions.push({ value: '', label: t('config.select_persona') })
+    for (const p of personas) {
+      personaSelectOptions.push({ value: p.id, label: p.name || p.id })
+    }
+  } catch (e) {
+    console.warn('Failed to load persona options:', e)
   }
 }
 
@@ -524,6 +564,7 @@ watch(() => effectiveSchema.value, () => {
   initDrafts()
   applyDefaults()
   loadModelSelectOptions()
+  loadPersonaSelectOptions()
   const schema = effectiveSchema.value
   for (const key in schema) {
     const field = schema[key]

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -802,6 +802,7 @@ export default {
     module_unavailable: 'Configuration module unavailable',
     load_error: 'Failed to load configuration',
     select_model: '— Select model —',
+    select_persona: 'Select Persona',
     json_invalid: 'Invalid JSON in field "{field}": {error}',
   },
   login: {

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -802,6 +802,7 @@ export default {
     module_unavailable: '配置模块不可用',
     load_error: '加载配置失败',
     select_model: '— 请选择模型 —',
+    select_persona: '选择人设',
     json_invalid: '字段"{field}"包含无效的 JSON：{error}',
   },
   login: {


### PR DESCRIPTION
## Summary

Adds a new `persona_select` config field type to ConfigForm. When a schema field uses `"type": "persona_select"`, the UI fetches all available personas from the API and renders a dropdown that saves the selected persona's unique ID as the config value.

## Type of change

- [x] feat: New feature

## Changes

- **Backend**: Add `PersonaSelect` to `ConfigType` enum and `PersonaSelectField` class in `config_field.py`; register `persona_select` in schema parser
- **Frontend**: Add `persona_select` rendering in `ConfigForm.vue` with `getPersonas()` API call, reusing `CustomSelect` component
- **i18n**: Add `config.select_persona` key in `en.ts` and `zh.ts`

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Persona” selection field in configuration forms.
  * Users can now choose from a loaded list of personas, including an empty/default option.

* **Bug Fixes**
  * Configuration schemas now recognize the new persona selection type correctly.

* **Documentation**
  * Added localized text for the new persona selector in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->