### PR TITLE
feat: add confirmation dialog before switching persona

### DIFF
--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -266,6 +266,8 @@ export default {
     form_incomplete: 'Please fill in persona name',
     set_active: 'Switch',
     active: 'Active',
+    set_active_confirm_title: 'Switch Persona',
+    set_active_confirm_message: 'Switching persona may cause existing memory and conversations to become inconsistent. Please make sure you have handled relevant data before proceeding.',
     set_active_success: 'Persona switched successfully',
     set_active_failed: 'Failed to switch persona',
   },

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -266,6 +266,8 @@ export default {
     form_incomplete: '请填写人设名称',
     set_active: '切换',
     active: '已激活',
+    set_active_confirm_title: '切换人设',
+    set_active_confirm_message: '切换人设可能导致已有的记忆、对话等内容出现不匹配，请确保自行处理完成后再切换。',
     set_active_success: '人设切换成功',
     set_active_failed: '切换人设失败',
   },

--- a/webui/frontend/src/views/PersonaView.vue
+++ b/webui/frontend/src/views/PersonaView.vue
@@ -145,6 +145,16 @@
       :confirm-text="t('common.delete')"
       @confirm="onConfirmDelete"
     />
+
+    <ConfirmModal
+      ref="switchConfirmModalRef"
+      variant="info"
+      :title="t('persona.set_active_confirm_title')"
+      :message="t('persona.set_active_confirm_message')"
+      :cancel-text="t('persona.modal_cancel')"
+      :confirm-text="t('persona.set_active')"
+      @confirm="onConfirmSwitch"
+    />
   </div>
 </template>
 
@@ -165,6 +175,7 @@ import type { PersonaResponse } from '@/types'
 const { t } = useI18n()
 
 const confirmModalRef = ref<InstanceType<typeof ConfirmModal>>()
+const switchConfirmModalRef = ref<InstanceType<typeof ConfirmModal>>()
 
 const personas = ref<PersonaResponse[]>([])
 const dialogVisible = ref(false)
@@ -175,6 +186,7 @@ const saving = ref(false)
 const confirmTitle = ref('')
 const confirmMessage = ref('')
 let deleteTargetId: string | null = null
+let switchTargetId: string | null = null
 
 const formatOptions = computed(() => [
   { value: 'text', label: t('persona.format_text') },
@@ -287,8 +299,16 @@ async function onConfirmDelete() {
 }
 
 async function handleSetActive(personaId: string) {
+  switchTargetId = personaId
+  switchConfirmModalRef.value?.open()
+}
+
+async function onConfirmSwitch() {
+  if (!switchTargetId) return
+  const id = switchTargetId
+  switchTargetId = null
   try {
-    await setActivePersona(personaId)
+    await setActivePersona(id)
     notify(t('persona.set_active_success'), 'success')
     await loadPersonas()
   } catch (error: any) {


### PR DESCRIPTION
## Summary

Add a confirmation dialog before switching persona to warn users about potential memory and conversation inconsistency.

## Type of change

- [x] feat: New feature

## Changes

- Add `ConfirmModal` (info variant) in `PersonaView.vue` that opens when the "Switch" button is clicked
- Add `onConfirmSwitch` handler to perform actual switch only after user confirms
- Add i18n keys `set_active_confirm_title` and `set_active_confirm_message` in both `en.ts` and `zh.ts`

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes