### PR TITLE
refactor: extract change-token form into a global ChangeTokenModal

### DIFF
--- a/webui/frontend/src/components/common/ChangeTokenModal.vue
+++ b/webui/frontend/src/components/common/ChangeTokenModal.vue
@@ -1,0 +1,125 @@
+<template>
+  <Modal v-model="visible" content-class="max-w-md">
+    <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full flex flex-col" style="max-height: 90vh;">
+      <div class="flex justify-between items-center px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+        <div>
+          <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">{{ $t('settings.token_title') }}</h3>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ $t('settings.token_desc') }}</p>
+        </div>
+        <button type="button" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" @click="visible = false">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+        </button>
+      </div>
+      <div class="px-6 py-4 flex-1 overflow-y-auto space-y-4">
+        <div>
+          <label for="modal-token-old" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ $t('settings.token_old') }}</label>
+          <input
+            id="modal-token-old"
+            v-model="oldToken"
+            type="password"
+            :placeholder="$t('settings.token_old_placeholder')"
+            class="w-full px-3 py-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200"
+          />
+        </div>
+        <div>
+          <label for="modal-token-new" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ $t('settings.token_new') }}</label>
+          <input
+            id="modal-token-new"
+            v-model="newToken"
+            type="password"
+            :placeholder="$t('settings.token_new_placeholder')"
+            class="w-full px-3 py-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200"
+          />
+        </div>
+        <div>
+          <label for="modal-token-confirm" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ $t('settings.token_confirm') }}</label>
+          <input
+            id="modal-token-confirm"
+            v-model="confirmToken"
+            type="password"
+            :placeholder="$t('settings.token_confirm_placeholder')"
+            class="w-full px-3 py-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200"
+          />
+        </div>
+      </div>
+      <div class="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex justify-end space-x-3">
+        <button type="button" class="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors" @click="visible = false">{{ $t('settings.backup_confirm_cancel') }}</button>
+        <button type="button" class="px-4 py-2 bg-blue-600 dark:bg-blue-700 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" :disabled="tokenChanging" @click="tokenConfirmRef?.open()">{{ tokenChanging ? $t('settings.token_changing') : $t('settings.token_submit') }}</button>
+      </div>
+    </div>
+
+    <!-- Confirm Modal -->
+    <ConfirmModal
+      ref="tokenConfirmRef"
+      variant="danger"
+      :title="$t('settings.token_submit')"
+      :message="$t('settings.token_confirm_dialog')"
+      :cancel-text="$t('settings.backup_confirm_cancel')"
+      :confirm-text="$t('settings.backup_confirm_ok')"
+      @confirm="handleChangeToken"
+    />
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import { notify } from '@/composables/useNotification'
+import { useChangeTokenModal } from '@/composables/useChangeTokenModal'
+import { changeAccessToken } from '@/api/settings'
+import Modal from './Modal.vue'
+import ConfirmModal from './ConfirmModal.vue'
+
+const { t } = useI18n()
+const router = useRouter()
+const { visible } = useChangeTokenModal()
+
+const oldToken = ref('')
+const newToken = ref('')
+const confirmToken = ref('')
+const tokenChanging = ref(false)
+const tokenConfirmRef = ref<InstanceType<typeof ConfirmModal>>()
+
+// Clear inputs when modal opens
+watch(visible, (val) => {
+  if (val) {
+    oldToken.value = ''
+    newToken.value = ''
+    confirmToken.value = ''
+  }
+})
+
+async function handleChangeToken() {
+  if (!oldToken.value) {
+    notify(t('settings.token_old_required'), 'error')
+    return
+  }
+  if (!newToken.value || newToken.value.length < 6) {
+    notify(t('settings.token_new_too_short'), 'error')
+    return
+  }
+  if (newToken.value !== confirmToken.value) {
+    notify(t('settings.token_mismatch'), 'error')
+    return
+  }
+  tokenChanging.value = true
+  try {
+    await changeAccessToken(oldToken.value, newToken.value)
+    notify(t('settings.token_changed_logout'), 'success')
+    visible.value = false
+    localStorage.removeItem('jwt_token')
+    router.push('/login')
+    return
+  } catch (err: any) {
+    const detail = err?.response?.data?.detail
+    if (detail === 'Old token is incorrect') {
+      notify(t('settings.token_old_wrong'), 'error')
+    } else {
+      notify(t('settings.token_change_failed'), 'error')
+    }
+  } finally {
+    tokenChanging.value = false
+  }
+}
+</script>

--- a/webui/frontend/src/composables/useChangeTokenModal.ts
+++ b/webui/frontend/src/composables/useChangeTokenModal.ts
@@ -1,0 +1,11 @@
+import { ref } from 'vue'
+
+const visible = ref(false)
+
+export function openChangeTokenModal() {
+  visible.value = true
+}
+
+export function useChangeTokenModal() {
+  return { visible, open: openChangeTokenModal }
+}

--- a/webui/frontend/src/views/MainLayout.vue
+++ b/webui/frontend/src/views/MainLayout.vue
@@ -22,6 +22,7 @@
         </PageContainer>
       </main>
     </div>
+    <ChangeTokenModal />
   </div>
 </template>
 
@@ -33,6 +34,7 @@ import { usePluginMenuStore } from '@/stores/pluginMenu'
 import AppSidebar from '@/components/layout/AppSidebar.vue'
 import AppHeader from '@/components/layout/AppHeader.vue'
 import PageContainer from '@/components/layout/PageContainer.vue'
+import ChangeTokenModal from '@/components/common/ChangeTokenModal.vue'
 
 const route = useRoute()
 const router = useRouter()

--- a/webui/frontend/src/views/SettingsView.vue
+++ b/webui/frontend/src/views/SettingsView.vue
@@ -198,46 +198,13 @@
       <div v-if="authEnabled">
         <h4 class="text-base font-semibold text-gray-800 dark:text-gray-100 mb-4">{{ $t('settings.token_title') }}</h4>
         <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ $t('settings.token_desc') }}</p>
-        <div class="max-w-md space-y-3">
-          <div>
-            <label for="token-old" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('settings.token_old') }}</label>
-            <input
-              id="token-old"
-              v-model="oldToken"
-              type="password"
-              :placeholder="$t('settings.token_old_placeholder')"
-              class="w-full px-3 py-2 rounded-lg text-gray-800 dark:text-gray-200"
-            />
-          </div>
-          <div>
-            <label for="token-new" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('settings.token_new') }}</label>
-            <input
-              id="token-new"
-              v-model="newToken"
-              type="password"
-              :placeholder="$t('settings.token_new_placeholder')"
-              class="w-full px-3 py-2 rounded-lg text-gray-800 dark:text-gray-200"
-            />
-          </div>
-          <div>
-            <label for="token-confirm" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ $t('settings.token_confirm') }}</label>
-            <input
-              id="token-confirm"
-              v-model="confirmToken"
-              type="password"
-              :placeholder="$t('settings.token_confirm_placeholder')"
-              class="w-full px-3 py-2 rounded-lg text-gray-800 dark:text-gray-200"
-            />
-          </div>
-          <button
-            type="button"
-            class="px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            :disabled="tokenChanging"
-            @click="tokenConfirmRef?.open()"
-          >
-            {{ tokenChanging ? $t('settings.token_changing') : $t('settings.token_submit') }}
-          </button>
-        </div>
+        <button
+          type="button"
+          class="px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          @click="openChangeTokenModal()"
+        >
+          {{ $t('settings.token_submit') }}
+        </button>
       </div>
     </div>
 
@@ -376,17 +343,6 @@
       @confirm="executeListAction"
     />
 
-    <!-- Token Change Confirm Modal -->
-    <ConfirmModal
-      ref="tokenConfirmRef"
-      variant="danger"
-      :title="$t('settings.token_submit')"
-      :message="$t('settings.token_confirm_dialog')"
-      :cancel-text="$t('settings.backup_confirm_cancel')"
-      :confirm-text="$t('settings.backup_confirm_ok')"
-      @confirm="handleChangeToken"
-    />
-
     <!-- Restore Modal -->
     <Modal v-model="restoreModalVisible" content-class="max-w-lg">
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl">
@@ -432,6 +388,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { notify } from '@/composables/useNotification'
+import { openChangeTokenModal } from '@/composables/useChangeTokenModal'
 import apiClient from '@/api/client'
 import { getAuthConfig } from '@/api/auth'
 import MonacoEditor from '@/components/common/MonacoEditor.vue'
@@ -445,7 +402,6 @@ import {
   deleteBackup,
   restoreBackup,
   restoreFromBackup,
-  changeAccessToken,
   type StorageInfoResponse,
   type BackupItem,
 } from '@/api/settings'
@@ -531,13 +487,6 @@ const listAction = ref<{ type: 'delete' | 'restore'; filename: string }>({ type:
 
 const restarting = ref(false)
 
-// ── Change Access Token ────────────────────────────────────────────────
-
-const oldToken = ref('')
-const newToken = ref('')
-const confirmToken = ref('')
-const tokenChanging = ref(false)
-const tokenConfirmRef = ref<InstanceType<typeof ConfirmModal>>()
 
 async function triggerRestart() {
   try {
@@ -556,38 +505,6 @@ async function handleRestart() {
     notify(t('header.restart_timeout'), 'warning', 600000)
   } finally {
     restarting.value = false
-  }
-}
-
-async function handleChangeToken() {
-  if (!oldToken.value) {
-    notify(t('settings.token_old_required'), 'error')
-    return
-  }
-  if (!newToken.value || newToken.value.length < 6) {
-    notify(t('settings.token_new_too_short'), 'error')
-    return
-  }
-  if (newToken.value !== confirmToken.value) {
-    notify(t('settings.token_mismatch'), 'error')
-    return
-  }
-  tokenChanging.value = true
-  try {
-    await changeAccessToken(oldToken.value, newToken.value)
-    notify(t('settings.token_changed_logout'), 'success')
-    localStorage.removeItem('jwt_token')
-    router.push('/login')
-    return
-  } catch (err: any) {
-    const detail = err?.response?.data?.detail
-    if (detail === 'Old token is incorrect') {
-      notify(t('settings.token_old_wrong'), 'error')
-    } else {
-      notify(t('settings.token_change_failed'), 'error')
-    }
-  } finally {
-    tokenChanging.value = false
   }
 }
 


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Extract the inline access-token change form from SettingsView into a standalone `ChangeTokenModal` component backed by a `useChangeTokenModal` composable. The modal is rendered once in MainLayout so every page can trigger it via `openChangeTokenModal()`.

## Type of change

- [x] refactor: Code refactor (no functional change)

## Changes

- Create `useChangeTokenModal` composable — module-level reactive state + `openChangeTokenModal()` export
- Create `ChangeTokenModal.vue` — self-contained modal with token form, validation, ConfirmModal, and API call
- Add `ChangeTokenModal` to `MainLayout.vue` for global availability
- Replace inline token form in `SettingsView.vue` with a button calling `openChangeTokenModal()`
- Remove all token-related state and logic from `SettingsView.vue`

## Screenshots / Logs

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated modal for changing the access token, with clear validation, success/error feedback, and automatic sign-out after a successful update.
  * Replaced the inline token-change form in Settings with a single action that opens the new modal.

* **Bug Fixes**
  * Improved token-change flow by resetting fields when the modal opens and disabling submission while the request is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->