### PR TITLE
feat: add @register.ws decorator for plugin WebSocket endpoints

### DIFF
--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -607,6 +607,10 @@ class PluginManager:
         Also registers routes for any plugins that were already initialized before this call.
         """
         self._web_app = app
+        # Store reference so WS endpoints can access the manager without
+        # capturing it in closures (which breaks FastAPI's deepcopy during
+        # dependency resolution for WebSocket routes).
+        app.state.plugin_manager = self
         for plugin_id in list(self.plugin_instances.keys()):
             self._register_plugin_apis_for(plugin_id)
             self._register_plugin_ws_for(plugin_id)
@@ -906,7 +910,13 @@ class PluginManager:
             logger.info(f"Registered {len(registered)} API routes from {plugin_id}: {registered}")
 
     def _register_plugin_ws_for(self, plugin_id: str) -> None:
-        """Register plugin WebSocket routes on the FastAPI app."""
+        """Register plugin WebSocket routes on the FastAPI app.
+
+        Note: unlike HTTP endpoints, WS endpoints cannot use Depends with
+        closures that capture non-picklable objects (e.g. PluginManager),
+        because FastAPI deepcopies dependencies during WS dependency resolution.
+        Instead, the manager is accessed via ``ws.app.state.plugin_manager``.
+        """
         if self._web_app is None:
             return
         comp = _plugin_components.get(plugin_id)
@@ -919,32 +929,27 @@ class PluginManager:
         from webui.routes.auth import require_ws_auth
 
         _plugin_ws_registered.add(plugin_id)
-        mgr = self
-
-        def _make_plugin_check(pid: str):
-            async def check():
-                if not mgr.is_plugin_enabled(pid):
-                    from fastapi import WebSocketException
-                    raise WebSocketException(code=1011, reason="Plugin disabled")
-            return check
 
         registered: List[str] = []
 
         for route in comp.ws_routes:
             func = route["func"]
             func_name = func.__name__
+            pid = plugin_id
             full_path = f"/ws/plugin/{plugin_id}/{route['path'].lstrip('/')}"
 
-            async def dynamic_endpoint(
-                ws: WebSocket, _pid=plugin_id, _fname=func_name, _mgr=mgr
-            ):
-                inst = _mgr.plugin_instances.get(_pid)
+            async def dynamic_endpoint(ws: WebSocket, _pid=pid, _fname=func_name):
+                mgr = ws.app.state.plugin_manager
+                if not mgr.is_plugin_enabled(_pid):
+                    await ws.close(code=1011, reason="Plugin disabled")
+                    return
+                inst = mgr.plugin_instances.get(_pid)
                 if inst is None:
                     await ws.close(code=1011, reason="Plugin not available")
                     return
                 await getattr(inst, _fname)(ws)
 
-            dependencies = [Depends(_make_plugin_check(plugin_id))]
+            dependencies = []
             if route["auth"]:
                 dependencies.append(Depends(require_ws_auth))
 

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -162,13 +162,15 @@ class PluginComponents:
     page_funcs: Dict[str, Callable] = field(default_factory=dict)
     api_routes: List[dict] = field(default_factory=list)
     api_route_funcs: Dict[str, Callable] = field(default_factory=dict)
+    ws_routes: List[dict] = field(default_factory=list)
+    ws_route_funcs: Dict[str, Callable] = field(default_factory=dict)
     static_dirs: List[dict] = field(default_factory=list)
     widgets: List[dict] = field(default_factory=list)
     widget_funcs: Dict[str, Callable] = field(default_factory=dict)
 
     def has_any(self) -> bool:
         return bool(self.tools or self.tags or self.hooks or self.pages
-                    or self.api_routes or self.static_dirs or self.widgets)
+                    or self.api_routes or self.ws_routes or self.static_dirs or self.widgets)
 
     def register_tool(self, name: str, description: str, params: dict, func: Callable):
         self.tools[name] = {
@@ -228,6 +230,14 @@ class PluginComponents:
         })
         self.api_route_funcs[func.__name__] = func
 
+    def register_ws(self, path: str, func: Callable, auth: bool = True):
+        self.ws_routes.append({
+            "path": path,
+            "func": func,
+            "auth": auth,
+        })
+        self.ws_route_funcs[func.__name__] = func
+
     def register_widget(self, widget_id: str, label: Union[str, Dict[str, str]],
                         icon: str,
                         color: Literal["blue", "green", "purple", "yellow", "red", "gray"],
@@ -256,6 +266,9 @@ _plugin_load_errors: Dict[str, Dict[str, Any]] = {}
 
 """plugin_ids whose API routes have already been added to FastAPI."""
 _plugin_api_registered: set[str] = set()
+
+"""plugin_ids whose WS routes have already been added to FastAPI."""
+_plugin_ws_registered: set[str] = set()
 
 """Discovered plugin metadata: {plugin_id: PluginInfo}"""
 _plugin_infos: Dict[str, PluginInfo] = {}
@@ -401,6 +414,21 @@ class RegisterDeco:
         def decorator(func: Callable):
             plugin_id = get_obj_plugin_id(func)
             _ensure_components(plugin_id).register_api(method, path, func, auth, **kwargs)
+            return func
+        return decorator
+
+    @staticmethod
+    def ws(path: str, auth: bool = True):
+        """Register a plugin WebSocket endpoint.
+
+        path: Path relative to the plugin prefix, e.g. "/stream"
+              Final route: /ws/plugin/{plugin_id}{path}
+        auth: Require JWT auth during the WS handshake (default True).
+              When enabled, ``ws.state.user`` is set before the endpoint runs.
+        """
+        def decorator(func: Callable):
+            plugin_id = get_obj_plugin_id(func)
+            _ensure_components(plugin_id).register_ws(path, func, auth)
             return func
         return decorator
 
@@ -581,6 +609,7 @@ class PluginManager:
         self._web_app = app
         for plugin_id in list(self.plugin_instances.keys()):
             self._register_plugin_apis_for(plugin_id)
+            self._register_plugin_ws_for(plugin_id)
             self._register_plugin_pages_for(plugin_id)
             self._register_plugin_static_for(plugin_id)
 
@@ -875,6 +904,59 @@ class PluginManager:
 
         if registered:
             logger.info(f"Registered {len(registered)} API routes from {plugin_id}: {registered}")
+
+    def _register_plugin_ws_for(self, plugin_id: str) -> None:
+        """Register plugin WebSocket routes on the FastAPI app."""
+        if self._web_app is None:
+            return
+        comp = _plugin_components.get(plugin_id)
+        if not comp or not comp.ws_routes:
+            return
+        if plugin_id in _plugin_ws_registered:
+            return
+
+        from fastapi import Depends, WebSocket
+        from webui.routes.auth import require_ws_auth
+
+        _plugin_ws_registered.add(plugin_id)
+        mgr = self
+
+        def _make_plugin_check(pid: str):
+            async def check():
+                if not mgr.is_plugin_enabled(pid):
+                    from fastapi import WebSocketException
+                    raise WebSocketException(code=1011, reason="Plugin disabled")
+            return check
+
+        registered: List[str] = []
+
+        for route in comp.ws_routes:
+            func = route["func"]
+            func_name = func.__name__
+            full_path = f"/ws/plugin/{plugin_id}/{route['path'].lstrip('/')}"
+
+            async def dynamic_endpoint(
+                ws: WebSocket, _pid=plugin_id, _fname=func_name, _mgr=mgr
+            ):
+                inst = _mgr.plugin_instances.get(_pid)
+                if inst is None:
+                    await ws.close(code=1011, reason="Plugin not available")
+                    return
+                await getattr(inst, _fname)(ws)
+
+            dependencies = [Depends(_make_plugin_check(plugin_id))]
+            if route["auth"]:
+                dependencies.append(Depends(require_ws_auth))
+
+            self._web_app.add_api_websocket_route(
+                path=full_path,
+                endpoint=dynamic_endpoint,
+                dependencies=dependencies,
+            )
+            registered.append(full_path)
+
+        if registered:
+            logger.info(f"Registered {len(registered)} WS routes from {plugin_id}: {registered}")
 
     def _register_plugin_pages_for(self, plugin_id: str) -> None:
         """Register plugin page routes for URL access."""
@@ -1315,6 +1397,7 @@ class PluginManager:
         """
         # Reset tracking sets so init_plugin can re-register
         _plugin_api_registered.discard(plugin_id)
+        _plugin_ws_registered.discard(plugin_id)
         if hasattr(self, '_plugin_pages_registered'):
             self._plugin_pages_registered.discard(plugin_id)
         if hasattr(self, '_plugin_static_registered'):
@@ -1326,6 +1409,7 @@ class PluginManager:
         tag_prefix = f"plugin:{plugin_id}"
         page_prefix = f"/page/plugin/{plugin_id}/"
         static_prefix = f"/static/plugin/{plugin_id}/"
+        ws_prefix = f"/ws/plugin/{plugin_id}/"
 
         routes = self._web_app.routes
         filtered_routes = []
@@ -1336,9 +1420,11 @@ class PluginManager:
             # API / page routes registered via add_api_route
             if hasattr(route, 'tags') and tag_prefix in (route.tags or []):
                 should_remove = True
-            # Page catch-all routes or static mounts
+            # Page catch-all routes, static mounts, or WS routes
             elif hasattr(route, 'path') and (
-                route.path.startswith(page_prefix) or route.path.startswith(static_prefix)
+                route.path.startswith(page_prefix)
+                or route.path.startswith(static_prefix)
+                or route.path.startswith(ws_prefix)
             ):
                 should_remove = True
 
@@ -1378,6 +1464,10 @@ class PluginManager:
         # clean up widget registration
         comp.widgets.clear()
         comp.widget_funcs.clear()
+
+        # clean up WS route registration
+        comp.ws_routes.clear()
+        comp.ws_route_funcs.clear()
 
         # clean up FastAPI routes (API routes, page routes, static mounts)
         self._remove_plugin_routes(plugin_id)
@@ -1541,6 +1631,7 @@ class PluginManager:
             self._register_plugin_hooks_for(plugin_id)
             self._register_plugin_tags_for(plugin_id)
             self._register_plugin_apis_for(plugin_id)
+            self._register_plugin_ws_for(plugin_id)
             self._register_plugin_pages_for(plugin_id)
             self._register_plugin_static_for(plugin_id)
             self._register_plugin_widgets_for(plugin_id)

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -1470,10 +1470,6 @@ class PluginManager:
         comp.widgets.clear()
         comp.widget_funcs.clear()
 
-        # clean up WS route registration
-        comp.ws_routes.clear()
-        comp.ws_route_funcs.clear()
-
         # clean up FastAPI routes (API routes, page routes, static mounts)
         self._remove_plugin_routes(plugin_id)
 

--- a/webui/routes/auth.py
+++ b/webui/routes/auth.py
@@ -73,7 +73,7 @@ async def require_ws_auth(
     try:
         payload = verify_session_token(token, ws.app.state)
     except HTTPException:
-        raise WebSocketException(code=4003, reason="Invalid token")
+        raise WebSocketException(code=4003, reason="Invalid token") from None
     user = payload.get("sub", "admin")
     ws.state.user = user
     return user

--- a/webui/routes/auth.py
+++ b/webui/routes/auth.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Optional
 
-from fastapi import Depends, Header, HTTPException, Request, status
+from fastapi import Depends, Header, HTTPException, Request, WebSocket, WebSocketException, status
 from fastapi.responses import FileResponse, HTMLResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse, Response
@@ -46,6 +46,37 @@ async def require_auth(
     # helper so plugin page/static auth enforces the exact same claims.
     payload = verify_session_token(token, request.app.state)
     return payload.get("sub", "admin")
+
+
+async def require_ws_auth(
+    ws: WebSocket,
+) -> str:
+    """WebSocket auth dependency — validates token during the WS handshake.
+
+    Token source (checked in order):
+      1. ``?token=…`` query parameter  (most common for browser WS clients)
+      2. ``Authorization: Bearer …`` header
+
+    On failure the connection is accepted then immediately closed with
+    code 4003 so the client sees a meaningful close code instead of a
+    raw HTTP 403/401 that the browser cannot inspect.
+    """
+    token = ws.query_params.get("token")
+    if not token:
+        auth_header = ws.headers.get("authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header.split(" ", 1)[1]
+
+    if not token:
+        raise WebSocketException(code=4003, reason="Missing token")
+
+    try:
+        payload = verify_session_token(token, ws.app.state)
+    except HTTPException:
+        raise WebSocketException(code=4003, reason="Invalid token")
+    user = payload.get("sub", "admin")
+    ws.state.user = user
+    return user
 
 
 class AuthRoutes(Routes):


### PR DESCRIPTION
## Summary

Adds `@register.ws` decorator to the plugin registry, allowing plugins to register WebSocket endpoints alongside existing REST APIs, pages, and widgets. Also adds a framework-level `require_ws_auth` dependency for JWT authentication during the WS handshake.

## Type of change

- [x] feat: New feature
- [x] fix: Bug fix

## Changes

- **`PluginComponents`**: Added `ws_routes`, `ws_route_funcs` fields and `register_ws()` method; updated `has_any()`
- **`RegisterDeco`**: Added `ws(path, auth=True)` static decorator method
- **`PluginManager._register_plugin_ws_for()`**: New method that mounts WS routes on FastAPI via `add_api_websocket_route()`
- **Lifecycle wiring**: `_register_plugin_ws_for` called in `set_web_app()` and `init_plugin()`; cleanup added to `_remove_plugin_routes()` and `_cleanup_plugin_registration()`
- **`webui/routes/auth.py`**: Added `require_ws_auth(ws)` dependency — extracts token from `?token=` query param or `Authorization: Bearer` header, reuses `verify_session_token` for JWT validation, closes with code 4003 on failure
- **`app.state.plugin_manager`**: Stored in `set_web_app()` so WS endpoints can access the manager without capturing it in closures (fixes FastAPI deepcopy failure during WS dependency resolution)
- **`schema_test` plugin**: Added a `@register.ws("/echo", auth=False)` test endpoint

## Screenshots / Logs

WS endpoint registered successfully:
```
Registered 1 WS routes from schema_test: ['/ws/plugin/schema_test/echo']
```

Postman echo test:
```
→ hello
← echo: hello
```

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable) — none added
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plugin-driven WebSocket route support, enabling real-time functionality per plugin.
  * Added WebSocket authentication during connection setup, accepting session tokens from the `token` query parameter or `Authorization: Bearer ...` header.
* **Bug Fixes**
  * Plugin WebSocket connections now reliably close when a plugin is disabled or unavailable.
  * WebSocket routes are now registered and cleaned up consistently as plugins are initialized or removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->