### PR TITLE
feat: add top progress bar for route loading

### DIFF
--- a/webui/frontend/src/assets/main.css
+++ b/webui/frontend/src/assets/main.css
@@ -677,7 +677,7 @@ textarea:focus:hover,
   width: 0;
   height: 2px;
   z-index: 9999;
-  background: linear-gradient(90deg, #3b82f6, #60a5fa);
+  background: #60a5fa;
   border-radius: 0 2px 2px 0;
   /* transition only set on .loading and .completing — idle snaps instantly */
 }
@@ -693,7 +693,7 @@ textarea:focus:hover,
 }
 
 .dark .route-loading-bar {
-  background: linear-gradient(90deg, #4395f9, #88befc);
+  background: #3b82f6;
 }
 
 /* ==================== Loading Spinner ==================== */

--- a/webui/frontend/src/assets/main.css
+++ b/webui/frontend/src/assets/main.css
@@ -669,6 +669,33 @@ textarea:focus:hover,
   overflow: hidden;
 }
 
+/* ==================== Route Loading Bar ==================== */
+.route-loading-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 2px;
+  z-index: 9999;
+  background: linear-gradient(90deg, #3b82f6, #60a5fa);
+  border-radius: 0 2px 2px 0;
+  /* transition only set on .loading and .completing — idle snaps instantly */
+}
+
+.route-loading-bar.loading {
+  width: 70%;
+  transition: width 30s cubic-bezier(0.08, 0.07, 0, 1);
+}
+
+.route-loading-bar.completing {
+  width: 100%;
+  transition: width 0.3s ease;
+}
+
+.dark .route-loading-bar {
+  background: linear-gradient(90deg, #4395f9, #88befc);
+}
+
 /* ==================== Loading Spinner ==================== */
 .loading-spinner {
   border: 3px solid #f3f3f3;

--- a/webui/frontend/src/assets/main.css
+++ b/webui/frontend/src/assets/main.css
@@ -683,8 +683,8 @@ textarea:focus:hover,
 }
 
 .route-loading-bar.loading {
-  width: 70%;
-  transition: width 30s cubic-bezier(0.08, 0.07, 0, 1);
+  width: 90%;
+  transition: width 10s ease-out;
 }
 
 .route-loading-bar.completing {

--- a/webui/frontend/src/composables/useRouteLoading.ts
+++ b/webui/frontend/src/composables/useRouteLoading.ts
@@ -1,0 +1,38 @@
+import { ref } from 'vue'
+import router from '@/router'
+
+type Phase = 'idle' | 'loading' | 'completing'
+
+const phase = ref<Phase>('idle')
+let finishTimeout: ReturnType<typeof setTimeout> | null = null
+let stuckTimeout: ReturnType<typeof setTimeout> | null = null
+let guardsRegistered = false
+
+function reset() {
+  phase.value = 'idle'
+}
+
+export function useRouteLoading() {
+  if (!guardsRegistered) {
+    guardsRegistered = true
+
+    router.beforeEach(() => {
+      if (finishTimeout) clearTimeout(finishTimeout)
+      if (stuckTimeout) clearTimeout(stuckTimeout)
+      phase.value = 'loading'
+      // Safety: auto-reset after 15s if navigation never completes
+      stuckTimeout = setTimeout(reset, 15000)
+    })
+
+    const finish = () => {
+      if (stuckTimeout) clearTimeout(stuckTimeout)
+      phase.value = 'completing'
+      finishTimeout = setTimeout(reset, 350)
+    }
+
+    router.afterEach(finish)
+    router.onError(finish)
+  }
+
+  return { phase }
+}

--- a/webui/frontend/src/composables/useRouteLoading.ts
+++ b/webui/frontend/src/composables/useRouteLoading.ts
@@ -26,6 +26,7 @@ export function useRouteLoading() {
 
       // Wait a tick — if navigation resolves within SHOW_DELAY, bar never appears
       showTimeout = setTimeout(() => {
+        showTimeout = null // tell finish() the bar is now visible
         phase.value = 'loading'
         stuckTimeout = setTimeout(reset, 15000)
       }, SHOW_DELAY)

--- a/webui/frontend/src/composables/useRouteLoading.ts
+++ b/webui/frontend/src/composables/useRouteLoading.ts
@@ -4,9 +4,12 @@ import router from '@/router'
 type Phase = 'idle' | 'loading' | 'completing'
 
 const phase = ref<Phase>('idle')
+let showTimeout: ReturnType<typeof setTimeout> | null = null
 let finishTimeout: ReturnType<typeof setTimeout> | null = null
 let stuckTimeout: ReturnType<typeof setTimeout> | null = null
 let guardsRegistered = false
+
+const SHOW_DELAY = 200 // ms to wait before showing bar (instant navs skip it)
 
 function reset() {
   phase.value = 'idle'
@@ -18,13 +21,24 @@ export function useRouteLoading() {
 
     router.beforeEach(() => {
       if (finishTimeout) clearTimeout(finishTimeout)
+      if (showTimeout) clearTimeout(showTimeout)
       if (stuckTimeout) clearTimeout(stuckTimeout)
-      phase.value = 'loading'
-      // Safety: auto-reset after 15s if navigation never completes
-      stuckTimeout = setTimeout(reset, 15000)
+
+      // Wait a tick — if navigation resolves within SHOW_DELAY, bar never appears
+      showTimeout = setTimeout(() => {
+        phase.value = 'loading'
+        stuckTimeout = setTimeout(reset, 15000)
+      }, SHOW_DELAY)
     })
 
     const finish = () => {
+      if (showTimeout) {
+        // Navigation completed before the threshold — keep it invisible
+        clearTimeout(showTimeout)
+        showTimeout = null
+        return
+      }
+
       if (stuckTimeout) clearTimeout(stuckTimeout)
       phase.value = 'completing'
       finishTimeout = setTimeout(reset, 350)

--- a/webui/frontend/src/views/MainLayout.vue
+++ b/webui/frontend/src/views/MainLayout.vue
@@ -6,6 +6,10 @@
       :class="{ open: sidebarOpen }"
       @click="closeSidebar"
     ></div>
+    <div
+      class="route-loading-bar"
+      :class="routePhase"
+    ></div>
     <AppSidebar :open="sidebarOpen" />
     <div class="flex-1 flex flex-col overflow-hidden">
       <main class="flex-1 flex flex-col" :class="route.meta.pluginPage ? 'overflow-hidden' : 'overflow-auto'">
@@ -29,6 +33,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useRouteLoading } from '@/composables/useRouteLoading'
 import { useI18n } from 'vue-i18n'
 import { usePluginMenuStore } from '@/stores/pluginMenu'
 import AppSidebar from '@/components/layout/AppSidebar.vue'
@@ -40,6 +45,8 @@ const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
 const pluginMenuStore = usePluginMenuStore()
+
+const { phase: routePhase } = useRouteLoading()
 
 const sidebarOpen = ref(false)
 


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Adds a thin progress bar at the top of the page that appears during route transitions. On slow networks, lazy-loaded page chunks can take seconds to download — previously there was no visual feedback, making the app feel unresponsive.

The bar uses a 200ms delay before appearing, so cached/instant navigations don't flash it.

## Type of change

- [x] feat: New feature

## Changes

- Added `src/composables/useRouteLoading.ts` — composable that hooks into Vue Router's `beforeEach`/`afterEach`/`onError` to control progress bar phases (`idle` → `loading` → `completing`)
- Added progress bar element in `MainLayout.vue` — positioned fixed at the top of the viewport
- Added progress bar styles in `main.css` — pure CSS animation (no external deps), supports light/dark modes

## Screenshots / Logs

<!-- If applicable, add screenshots or relevant logs to help reviewers. -->

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a subtle loading bar at the top of the app during route changes.
  * The bar now appears only when navigation takes longer than a brief delay, then completes smoothly when the page finishes loading.
  * Included a dark-mode-friendly appearance for better visibility across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->