### PR TITLE
feat: add chat_stream method to LLMModelClient and providers

### DIFF
--- a/core/provider/__init__.py
+++ b/core/provider/__init__.py
@@ -1,11 +1,11 @@
 from .provider import (ModelType, BaseModelClient, BaseProvider, ProviderInfo, ModelInfo,
                        LLMModelClient, TTSModelClient, STTModelClient, ImageModelClient,
                        VideoModelClient, EmbeddingModelClient, RerankModelClient)
-from .llm_model import LLMRequest, LLMResponse
+from .llm_model import LLMRequest, LLMResponse, LLMStreamChunk
 from ..agent.tool import ToolResult
 from .provider_manager import ProviderManager
 
-__all__ = ["LLMRequest", "LLMResponse", "ToolResult", "ModelType", "BaseModelClient",
+__all__ = ["LLMRequest", "LLMResponse", "LLMStreamChunk", "ToolResult", "ModelType", "BaseModelClient",
            "LLMModelClient", "TTSModelClient", "STTModelClient", "ImageModelClient",
            "VideoModelClient", "EmbeddingModelClient", "RerankModelClient",
            "ProviderManager", "BaseProvider", "ProviderInfo", "ModelInfo"]

--- a/core/provider/llm_model.py
+++ b/core/provider/llm_model.py
@@ -105,11 +105,8 @@ class LLMStreamChunk:
     """Incremental reasoning content for reasoning models"""
     delta_reasoning: str = ""
 
-    """Incremental tool call fragments in this chunk only (never contains full assembled calls)"""
+    """Incremental tool call fragments in this chunk only"""
     tool_calls_delta: list[dict] = field(default_factory=list)
-
-    """Complete assembled tool calls — only populated on the final chunk when finish_reason is tool_calls"""
-    tool_calls: list[dict] = field(default_factory=list)
 
     """Whether this is the final chunk in the stream"""
     is_final: bool = False

--- a/core/provider/llm_model.py
+++ b/core/provider/llm_model.py
@@ -96,6 +96,29 @@ class LLMResponse:
 
 
 @dataclass
+class LLMStreamChunk:
+    """A single chunk from a streaming LLM response."""
+
+    """Incremental text content for this chunk"""
+    delta_text: str = ""
+
+    """Incremental reasoning content for reasoning models"""
+    delta_reasoning: str = ""
+
+    """Incremental tool call fragments accumulated in this chunk"""
+    tool_calls_delta: list[dict] = field(default_factory=list)
+
+    """Whether this is the final chunk in the stream"""
+    is_final: bool = False
+
+    """Finish reason on the final chunk: stop / tool_calls / content_filter"""
+    finish_reason: str = ""
+
+    """Token usage — only populated on the final chunk"""
+    usage: Optional[dict] = None
+
+
+@dataclass
 class RerankResult:
     index: int
 

--- a/core/provider/llm_model.py
+++ b/core/provider/llm_model.py
@@ -105,8 +105,11 @@ class LLMStreamChunk:
     """Incremental reasoning content for reasoning models"""
     delta_reasoning: str = ""
 
-    """Incremental tool call fragments accumulated in this chunk"""
+    """Incremental tool call fragments in this chunk only (never contains full assembled calls)"""
     tool_calls_delta: list[dict] = field(default_factory=list)
+
+    """Complete assembled tool calls — only populated on the final chunk when finish_reason is tool_calls"""
+    tool_calls: list[dict] = field(default_factory=list)
 
     """Whether this is the final chunk in the stream"""
     is_final: bool = False

--- a/core/provider/provider.py
+++ b/core/provider/provider.py
@@ -88,7 +88,7 @@ class LLMModelClient(BaseModelClient):
         yield LLMStreamChunk(
             delta_text=resp.text_response,
             delta_reasoning=resp.reasoning_content,
-            tool_calls_delta=resp.tool_calls,
+            tool_calls=resp.tool_calls,
             is_final=True,
             finish_reason="tool_calls" if resp.tool_calls else "stop",
             usage=usage,

--- a/core/provider/provider.py
+++ b/core/provider/provider.py
@@ -1,10 +1,10 @@
 from abc import abstractmethod, ABC
 from enum import Enum, auto
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import AsyncGenerator, List, Optional, Union
 import asyncio
 
-from .llm_model import LLMRequest, LLMResponse, RerankResult
+from .llm_model import LLMRequest, LLMResponse, LLMStreamChunk, RerankResult
 
 from core.chat.message_elements import Record, Image, Video
 
@@ -74,6 +74,25 @@ class LLMModelClient(BaseModelClient):
 
     async def chat(self, request: LLMRequest, **kwargs) -> LLMResponse:
         pass
+
+    async def chat_stream(self, request: LLMRequest, **kwargs) -> AsyncGenerator[LLMStreamChunk, None]:
+        """Default fallback: wraps the non-streaming chat() as a single-chunk stream."""
+        resp = await self.chat(request, **kwargs)
+        usage = None
+        if resp.input_tokens is not None:
+            usage = {
+                "input_tokens": resp.input_tokens,
+                "output_tokens": resp.output_tokens,
+                "cached_tokens": resp.cached_tokens,
+            }
+        yield LLMStreamChunk(
+            delta_text=resp.text_response,
+            delta_reasoning=resp.reasoning_content,
+            tool_calls_delta=resp.tool_calls,
+            is_final=True,
+            finish_reason="tool_calls" if resp.tool_calls else "stop",
+            usage=usage,
+        )
 
 
 class TTSModelClient(BaseModelClient):

--- a/core/provider/provider.py
+++ b/core/provider/provider.py
@@ -88,7 +88,7 @@ class LLMModelClient(BaseModelClient):
         yield LLMStreamChunk(
             delta_text=resp.text_response,
             delta_reasoning=resp.reasoning_content,
-            tool_calls=resp.tool_calls,
+            tool_calls_delta=resp.tool_calls,
             is_final=True,
             finish_reason="tool_calls" if resp.tool_calls else "stop",
             usage=usage,

--- a/core/provider/src/deepseek/model_clients.py
+++ b/core/provider/src/deepseek/model_clients.py
@@ -1,8 +1,9 @@
 from openai import AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionError
 import time
+from typing import AsyncGenerator
 
 from core.provider import ModelInfo, LLMModelClient
-from core.provider.llm_model import LLMRequest, LLMResponse
+from core.provider.llm_model import LLMRequest, LLMResponse, LLMStreamChunk
 from core.logging_manager import get_logger
 
 logger = get_logger("provider", "purple")
@@ -22,18 +23,20 @@ class DeepSeekLLMClient(LLMModelClient):
     def __init__(self, model: ModelInfo):
         super().__init__(model)
 
-    async def chat(self, request: LLMRequest, **kwargs) -> LLMResponse:
+    def _build_client(self) -> AsyncOpenAI:
+        """Create an AsyncOpenAI client from provider config."""
         section_advanced = self.model.provider_config.get("section_advanced")
         default_headers = section_advanced.get("headers", {}) if isinstance(section_advanced, dict) else {}
         if not isinstance(default_headers, dict) or not default_headers:
             default_headers = None
-        client = AsyncOpenAI(
+        return AsyncOpenAI(
             api_key=self.model.provider_config.get("api_key", ""),
             base_url=self.model.provider_config.get("base_url", ""),
-            default_headers=default_headers
+            default_headers=default_headers,
         )
 
-        # Resolve thinking mode config
+    def _build_request_kwargs(self, request: LLMRequest) -> dict:
+        """Build DeepSeek-specific kwargs with thinking mode support."""
         model_config = self.model.model_config or {}
         thinking_enabled = model_config.get("thinking_enabled", True)
         reasoning_effort = model_config.get("reasoning_effort", "high")
@@ -47,12 +50,10 @@ class DeepSeekLLMClient(LLMModelClient):
         else:
             extra_body["thinking"] = {"type": "disabled"}
 
-        # Merge user-provided extra_body
         if isinstance(user_extra_body, dict) and user_extra_body:
             extra_body.update(user_extra_body)
 
-        # Build request kwargs
-        request_kwargs = dict(
+        kwargs = dict(
             model=self.model.model_id,
             messages=[m if isinstance(m, dict) else m.to_dict() for m in request.messages],
             tools=request.tools if request.tools else None,
@@ -60,15 +61,19 @@ class DeepSeekLLMClient(LLMModelClient):
         )
 
         if thinking_enabled:
-            # DeepSeek thinking mode: temperature/top_p are ignored, use reasoning_effort instead
-            request_kwargs["reasoning_effort"] = reasoning_effort
+            kwargs["reasoning_effort"] = reasoning_effort
         else:
-            # Non-thinking mode: use normal temperature
             temperature = section_advanced.get("temperature")
-            request_kwargs["temperature"] = temperature if temperature is not None else 1
+            kwargs["temperature"] = temperature if temperature is not None else 1
 
         if extra_body:
-            request_kwargs["extra_body"] = extra_body
+            kwargs["extra_body"] = extra_body
+
+        return kwargs
+
+    async def chat(self, request: LLMRequest, **kwargs) -> LLMResponse:
+        client = self._build_client()
+        request_kwargs = self._build_request_kwargs(request)
 
         try:
             start_time = time.perf_counter()
@@ -107,6 +112,76 @@ class DeepSeekLLMClient(LLMModelClient):
                     llm_resp.cached_tokens = getattr(response.usage, "prompt_cache_hit_tokens", None)
 
             return llm_resp
+
+        except APIStatusError:
+            raise
+        except APITimeoutError:
+            raise
+        except APIConnectionError:
+            raise
+        except Exception:
+            raise
+
+    async def chat_stream(self, request: LLMRequest, **kwargs) -> AsyncGenerator[LLMStreamChunk, None]:
+        client = self._build_client()
+        request_kwargs = self._build_request_kwargs(request)
+        request_kwargs["stream"] = True
+
+        # Accumulated tool calls by index
+        collected_tool_calls: dict[int, dict] = {}
+
+        try:
+            stream = await client.chat.completions.create(**request_kwargs)
+            async for event in stream:
+                if not event.choices:
+                    continue
+                choice = event.choices[0]
+                delta = choice.delta
+
+                chunk = LLMStreamChunk()
+
+                # Text content
+                if delta.content:
+                    chunk.delta_text = delta.content
+
+                # DeepSeek reasoning_content
+                reasoning = getattr(delta, "reasoning_content", "") or ""
+                if reasoning:
+                    chunk.delta_reasoning = reasoning
+
+                # Tool calls — incremental fragments
+                if delta.tool_calls:
+                    for tc in delta.tool_calls:
+                        idx = tc.index
+                        if idx not in collected_tool_calls:
+                            collected_tool_calls[idx] = {"id": "", "name": "", "arguments": ""}
+                        if tc.id:
+                            collected_tool_calls[idx]["id"] = tc.id
+                        if tc.function and tc.function.name:
+                            collected_tool_calls[idx]["name"] = tc.function.name
+                        if tc.function and tc.function.arguments:
+                            collected_tool_calls[idx]["arguments"] += tc.function.arguments
+
+                # Finish reason
+                finish_reason = choice.finish_reason
+                if finish_reason:
+                    chunk.is_final = True
+                    chunk.finish_reason = finish_reason
+                    for idx in sorted(collected_tool_calls):
+                        tc = collected_tool_calls[idx]
+                        chunk.tool_calls_delta.append({
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {"name": tc["name"], "arguments": tc["arguments"]},
+                        })
+                    if event.usage:
+                        chunk.usage = {
+                            "input_tokens": event.usage.prompt_tokens,
+                            "output_tokens": event.usage.completion_tokens,
+                            "cached_tokens": getattr(event.usage, "prompt_cache_hit_tokens", None),
+                        }
+
+                yield chunk
 
         except APIStatusError:
             raise

--- a/core/provider/src/deepseek/model_clients.py
+++ b/core/provider/src/deepseek/model_clients.py
@@ -35,8 +35,11 @@ class DeepSeekLLMClient(LLMModelClient):
             default_headers=default_headers,
         )
 
-    def _build_request_kwargs(self, request: LLMRequest) -> dict:
-        """Build DeepSeek-specific kwargs with thinking mode support."""
+    def _build_request_kwargs(self, request: LLMRequest, **overrides) -> dict:
+        """Build DeepSeek-specific kwargs with thinking mode support.
+        **overrides are merged on top, allowing callers to set/override
+        parameters like temperature, timeout, stream, etc.
+        """
         model_config = self.model.model_config or {}
         thinking_enabled = model_config.get("thinking_enabled", True)
         reasoning_effort = model_config.get("reasoning_effort", "high")
@@ -69,11 +72,12 @@ class DeepSeekLLMClient(LLMModelClient):
         if extra_body:
             kwargs["extra_body"] = extra_body
 
+        kwargs.update(overrides)
         return kwargs
 
     async def chat(self, request: LLMRequest, **kwargs) -> LLMResponse:
         client = self._build_client()
-        request_kwargs = self._build_request_kwargs(request)
+        request_kwargs = self._build_request_kwargs(request, **kwargs)
 
         try:
             start_time = time.perf_counter()
@@ -124,8 +128,7 @@ class DeepSeekLLMClient(LLMModelClient):
 
     async def chat_stream(self, request: LLMRequest, **kwargs) -> AsyncGenerator[LLMStreamChunk, None]:
         client = self._build_client()
-        request_kwargs = self._build_request_kwargs(request)
-        request_kwargs["stream"] = True
+        request_kwargs = self._build_request_kwargs(request, stream=True, **kwargs)
 
         # Accumulated tool calls by index
         collected_tool_calls: dict[int, dict] = {}

--- a/core/provider/src/deepseek/model_clients.py
+++ b/core/provider/src/deepseek/model_clients.py
@@ -131,9 +131,6 @@ class DeepSeekLLMClient(LLMModelClient):
         request_kwargs = self._build_request_kwargs(request, stream=True, **kwargs)
         request_kwargs["stream_options"] = {"include_usage": True}
 
-        # Accumulated tool calls by index
-        collected_tool_calls: dict[int, dict] = {}
-
         try:
             stream = await client.chat.completions.create(**request_kwargs)
             async for event in stream:
@@ -164,31 +161,25 @@ class DeepSeekLLMClient(LLMModelClient):
                 if reasoning:
                     chunk.delta_reasoning = reasoning
 
-                # Tool calls — incremental fragments
+                # Tool calls — pass through raw incremental deltas from SDK
                 if delta.tool_calls:
                     for tc in delta.tool_calls:
-                        idx = tc.index
-                        if idx not in collected_tool_calls:
-                            collected_tool_calls[idx] = {"id": "", "name": "", "arguments": ""}
-                        if tc.id:
-                            collected_tool_calls[idx]["id"] = tc.id
-                        if tc.function and tc.function.name:
-                            collected_tool_calls[idx]["name"] = tc.function.name
-                        if tc.function and tc.function.arguments:
-                            collected_tool_calls[idx]["arguments"] += tc.function.arguments
+                        fragment = {
+                            "index": tc.index,
+                            "id": tc.id or "",
+                            "type": "function",
+                            "function": {
+                                "name": tc.function.name if tc.function and tc.function.name else "",
+                                "arguments": tc.function.arguments if tc.function and tc.function.arguments else "",
+                            },
+                        }
+                        chunk.tool_calls_delta.append(fragment)
 
                 # Finish reason
                 finish_reason = choice.finish_reason
                 if finish_reason:
                     chunk.is_final = True
                     chunk.finish_reason = finish_reason
-                    for idx in sorted(collected_tool_calls):
-                        tc = collected_tool_calls[idx]
-                        chunk.tool_calls.append({
-                            "id": tc["id"],
-                            "type": "function",
-                            "function": {"name": tc["name"], "arguments": tc["arguments"]},
-                        })
 
                 yield chunk
 

--- a/core/provider/src/deepseek/model_clients.py
+++ b/core/provider/src/deepseek/model_clients.py
@@ -184,7 +184,7 @@ class DeepSeekLLMClient(LLMModelClient):
                     chunk.finish_reason = finish_reason
                     for idx in sorted(collected_tool_calls):
                         tc = collected_tool_calls[idx]
-                        chunk.tool_calls_delta.append({
+                        chunk.tool_calls.append({
                             "id": tc["id"],
                             "type": "function",
                             "function": {"name": tc["name"], "arguments": tc["arguments"]},

--- a/core/provider/src/deepseek/model_clients.py
+++ b/core/provider/src/deepseek/model_clients.py
@@ -129,6 +129,7 @@ class DeepSeekLLMClient(LLMModelClient):
     async def chat_stream(self, request: LLMRequest, **kwargs) -> AsyncGenerator[LLMStreamChunk, None]:
         client = self._build_client()
         request_kwargs = self._build_request_kwargs(request, stream=True, **kwargs)
+        request_kwargs["stream_options"] = {"include_usage": True}
 
         # Accumulated tool calls by index
         collected_tool_calls: dict[int, dict] = {}
@@ -136,8 +137,19 @@ class DeepSeekLLMClient(LLMModelClient):
         try:
             stream = await client.chat.completions.create(**request_kwargs)
             async for event in stream:
+                # Usage-only event (sent by OpenAI API after the final choice chunk)
                 if not event.choices:
+                    if event.usage:
+                        yield LLMStreamChunk(
+                            is_final=True,
+                            usage={
+                                "input_tokens": event.usage.prompt_tokens,
+                                "output_tokens": event.usage.completion_tokens,
+                                "cached_tokens": getattr(event.usage, "prompt_cache_hit_tokens", None),
+                            },
+                        )
                     continue
+
                 choice = event.choices[0]
                 delta = choice.delta
 
@@ -177,12 +189,6 @@ class DeepSeekLLMClient(LLMModelClient):
                             "type": "function",
                             "function": {"name": tc["name"], "arguments": tc["arguments"]},
                         })
-                    if event.usage:
-                        chunk.usage = {
-                            "input_tokens": event.usage.prompt_tokens,
-                            "output_tokens": event.usage.completion_tokens,
-                            "cached_tokens": getattr(event.usage, "prompt_cache_hit_tokens", None),
-                        }
 
                 yield chunk
 

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -1,46 +1,55 @@
-from openai import AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionError, NOT_GIVEN 
+from openai import AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionError, NOT_GIVEN
 import base64
 import time
-from typing import Optional
+from typing import AsyncGenerator, Optional
 
 from core.provider import ModelInfo
 from core.provider import LLMModelClient, TTSModelClient, ImageModelClient, EmbeddingModelClient
-from core.provider.llm_model import LLMRequest, LLMResponse
+from core.provider.llm_model import LLMRequest, LLMResponse, LLMStreamChunk
 from core.chat.message_elements import Record
 
 class OpenAICompatibleLLMClient(LLMModelClient):
     def __init__(self, model: ModelInfo):
         super().__init__(model)
 
-    async def chat(self, request: LLMRequest, **kwargs) -> LLMResponse:
+    def _build_client(self) -> AsyncOpenAI:
+        """Create an AsyncOpenAI client from provider config."""
         section_advanced = self.model.provider_config.get("section_advanced")
         default_headers = section_advanced.get("headers", {}) if isinstance(section_advanced, dict) else {}
         if not isinstance(default_headers, dict) or not default_headers:
             default_headers = None
-        client = AsyncOpenAI(
+        return AsyncOpenAI(
             api_key=self.model.provider_config.get("api_key", ""),
             base_url=self.model.provider_config.get("base_url", ""),
-            default_headers=default_headers
+            default_headers=default_headers,
         )
+
+    def _build_request_kwargs(self, request: LLMRequest) -> dict:
+        """Build the common kwargs dict for chat.completions.create()."""
+        model_config = self.model.model_config if self.model.model_config else {}
+        section_advanced = model_config.get("section_advanced") or {}
+        temperature = section_advanced.get("temperature")
+        timeout = model_config.get("timeout")
+        extra_body = section_advanced.get("extra_body")
+        if not isinstance(extra_body, dict) or not extra_body:
+            extra_body = None
+        kwargs = dict(
+            model=self.model.model_id,
+            messages=[m if isinstance(m, dict) else m.to_dict() for m in request.messages],
+            tools=request.tools if request.tools else None,
+            tool_choice=request.tool_choice if request.tool_choice != "none" else None,
+            temperature=temperature if temperature is not None else NOT_GIVEN,
+            timeout=timeout if timeout is not None else NOT_GIVEN,
+        )
+        if extra_body:
+            kwargs["extra_body"] = extra_body
+        return kwargs
+
+    async def chat(self, request: LLMRequest, **kwargs) -> LLMResponse:
+        client = self._build_client()
+        request_kwargs = self._build_request_kwargs(request)
         try:
             start_time = time.perf_counter()
-            model_config = self.model.model_config if self.model.model_config else {}
-            section_advanced = model_config.get("section_advanced") or {}
-            temperature = section_advanced.get("temperature")
-            timeout = model_config.get("timeout")
-            extra_body = section_advanced.get("extra_body")
-            if not isinstance(extra_body, dict) or not extra_body:
-                extra_body = None
-            request_kwargs = dict(
-                model=self.model.model_id,
-                messages=[m if isinstance(m, dict) else m.to_dict() for m in request.messages],
-                tools=request.tools if request.tools else None,
-                tool_choice=request.tool_choice if request.tool_choice != "none" else None,
-                temperature=temperature if temperature is not None else NOT_GIVEN,
-                timeout=timeout if timeout is not None else NOT_GIVEN
-            )
-            if extra_body:
-                request_kwargs["extra_body"] = extra_body
             response = await client.chat.completions.create(**request_kwargs)
             end_time = time.perf_counter()
             llm_resp = LLMResponse("")
@@ -85,6 +94,80 @@ class OpenAICompatibleLLMClient(LLMModelClient):
             # APIConnectionError: Connection error. (base_url error)
             raise
         except Exception as e:
+            raise
+
+    async def chat_stream(self, request: LLMRequest, **kwargs) -> AsyncGenerator[LLMStreamChunk, None]:
+        client = self._build_client()
+        request_kwargs = self._build_request_kwargs(request)
+        request_kwargs["stream"] = True
+
+        # Accumulated tool calls by index
+        collected_tool_calls: dict[int, dict] = {}
+
+        try:
+            stream = await client.chat.completions.create(**request_kwargs)
+            async for event in stream:
+                if not event.choices:
+                    continue
+                choice = event.choices[0]
+                delta = choice.delta
+
+                chunk = LLMStreamChunk()
+
+                # Text content
+                if delta.content:
+                    chunk.delta_text = delta.content
+
+                # Reasoning content (DeepSeek / extended models)
+                reasoning = getattr(delta, "reasoning_content", "") or ""
+                if reasoning:
+                    chunk.delta_reasoning = reasoning
+
+                # Tool calls — incremental fragments
+                if delta.tool_calls:
+                    for tc in delta.tool_calls:
+                        idx = tc.index
+                        if idx not in collected_tool_calls:
+                            collected_tool_calls[idx] = {"id": "", "name": "", "arguments": ""}
+                        if tc.id:
+                            collected_tool_calls[idx]["id"] = tc.id
+                        if tc.function and tc.function.name:
+                            collected_tool_calls[idx]["name"] = tc.function.name
+                        if tc.function and tc.function.arguments:
+                            collected_tool_calls[idx]["arguments"] += tc.function.arguments
+
+                # Finish reason
+                finish_reason = choice.finish_reason
+                if finish_reason:
+                    chunk.is_final = True
+                    chunk.finish_reason = finish_reason
+                    # Assemble full tool calls on the final chunk
+                    for idx in sorted(collected_tool_calls):
+                        tc = collected_tool_calls[idx]
+                        chunk.tool_calls_delta.append({
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {"name": tc["name"], "arguments": tc["arguments"]},
+                        })
+                    # Usage on final chunk
+                    if event.usage:
+                        prompt_details = getattr(event.usage, "prompt_tokens_details", None)
+                        cached = getattr(prompt_details, "cached_tokens", None) if prompt_details else None
+                        chunk.usage = {
+                            "input_tokens": event.usage.prompt_tokens,
+                            "output_tokens": event.usage.completion_tokens,
+                            "cached_tokens": cached,
+                        }
+
+                yield chunk
+
+        except APIStatusError:
+            raise
+        except APITimeoutError:
+            raise
+        except APIConnectionError:
+            raise
+        except Exception:
             raise
 
 

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -24,8 +24,11 @@ class OpenAICompatibleLLMClient(LLMModelClient):
             default_headers=default_headers,
         )
 
-    def _build_request_kwargs(self, request: LLMRequest) -> dict:
-        """Build the common kwargs dict for chat.completions.create()."""
+    def _build_request_kwargs(self, request: LLMRequest, **overrides) -> dict:
+        """Build the common kwargs dict for chat.completions.create().
+        **overrides are merged on top, allowing callers to set/override
+        parameters like temperature, timeout, stream, etc.
+        """
         model_config = self.model.model_config if self.model.model_config else {}
         section_advanced = model_config.get("section_advanced") or {}
         temperature = section_advanced.get("temperature")
@@ -43,11 +46,12 @@ class OpenAICompatibleLLMClient(LLMModelClient):
         )
         if extra_body:
             kwargs["extra_body"] = extra_body
+        kwargs.update(overrides)
         return kwargs
 
     async def chat(self, request: LLMRequest, **kwargs) -> LLMResponse:
         client = self._build_client()
-        request_kwargs = self._build_request_kwargs(request)
+        request_kwargs = self._build_request_kwargs(request, **kwargs)
         try:
             start_time = time.perf_counter()
             response = await client.chat.completions.create(**request_kwargs)
@@ -98,8 +102,7 @@ class OpenAICompatibleLLMClient(LLMModelClient):
 
     async def chat_stream(self, request: LLMRequest, **kwargs) -> AsyncGenerator[LLMStreamChunk, None]:
         client = self._build_client()
-        request_kwargs = self._build_request_kwargs(request)
-        request_kwargs["stream"] = True
+        request_kwargs = self._build_request_kwargs(request, stream=True, **kwargs)
 
         # Accumulated tool calls by index
         collected_tool_calls: dict[int, dict] = {}

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -103,6 +103,7 @@ class OpenAICompatibleLLMClient(LLMModelClient):
     async def chat_stream(self, request: LLMRequest, **kwargs) -> AsyncGenerator[LLMStreamChunk, None]:
         client = self._build_client()
         request_kwargs = self._build_request_kwargs(request, stream=True, **kwargs)
+        request_kwargs["stream_options"] = {"include_usage": True}
 
         # Accumulated tool calls by index
         collected_tool_calls: dict[int, dict] = {}
@@ -110,8 +111,21 @@ class OpenAICompatibleLLMClient(LLMModelClient):
         try:
             stream = await client.chat.completions.create(**request_kwargs)
             async for event in stream:
+                # Usage-only event (sent by OpenAI API after the final choice chunk)
                 if not event.choices:
+                    if event.usage:
+                        prompt_details = getattr(event.usage, "prompt_tokens_details", None)
+                        cached = getattr(prompt_details, "cached_tokens", None) if prompt_details else None
+                        yield LLMStreamChunk(
+                            is_final=True,
+                            usage={
+                                "input_tokens": event.usage.prompt_tokens,
+                                "output_tokens": event.usage.completion_tokens,
+                                "cached_tokens": cached,
+                            },
+                        )
                     continue
+
                 choice = event.choices[0]
                 delta = choice.delta
 
@@ -152,15 +166,6 @@ class OpenAICompatibleLLMClient(LLMModelClient):
                             "type": "function",
                             "function": {"name": tc["name"], "arguments": tc["arguments"]},
                         })
-                    # Usage on final chunk
-                    if event.usage:
-                        prompt_details = getattr(event.usage, "prompt_tokens_details", None)
-                        cached = getattr(prompt_details, "cached_tokens", None) if prompt_details else None
-                        chunk.usage = {
-                            "input_tokens": event.usage.prompt_tokens,
-                            "output_tokens": event.usage.completion_tokens,
-                            "cached_tokens": cached,
-                        }
 
                 yield chunk
 

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -158,10 +158,10 @@ class OpenAICompatibleLLMClient(LLMModelClient):
                 if finish_reason:
                     chunk.is_final = True
                     chunk.finish_reason = finish_reason
-                    # Assemble full tool calls on the final chunk
+                    # Assemble complete tool calls (only on final chunk)
                     for idx in sorted(collected_tool_calls):
                         tc = collected_tool_calls[idx]
-                        chunk.tool_calls_delta.append({
+                        chunk.tool_calls.append({
                             "id": tc["id"],
                             "type": "function",
                             "function": {"name": tc["name"], "arguments": tc["arguments"]},

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -105,9 +105,6 @@ class OpenAICompatibleLLMClient(LLMModelClient):
         request_kwargs = self._build_request_kwargs(request, stream=True, **kwargs)
         request_kwargs["stream_options"] = {"include_usage": True}
 
-        # Accumulated tool calls by index
-        collected_tool_calls: dict[int, dict] = {}
-
         try:
             stream = await client.chat.completions.create(**request_kwargs)
             async for event in stream:
@@ -140,32 +137,25 @@ class OpenAICompatibleLLMClient(LLMModelClient):
                 if reasoning:
                     chunk.delta_reasoning = reasoning
 
-                # Tool calls — incremental fragments
+                # Tool calls — pass through raw incremental deltas from SDK
                 if delta.tool_calls:
                     for tc in delta.tool_calls:
-                        idx = tc.index
-                        if idx not in collected_tool_calls:
-                            collected_tool_calls[idx] = {"id": "", "name": "", "arguments": ""}
-                        if tc.id:
-                            collected_tool_calls[idx]["id"] = tc.id
-                        if tc.function and tc.function.name:
-                            collected_tool_calls[idx]["name"] = tc.function.name
-                        if tc.function and tc.function.arguments:
-                            collected_tool_calls[idx]["arguments"] += tc.function.arguments
+                        fragment = {
+                            "index": tc.index,
+                            "id": tc.id or "",
+                            "type": "function",
+                            "function": {
+                                "name": tc.function.name if tc.function and tc.function.name else "",
+                                "arguments": tc.function.arguments if tc.function and tc.function.arguments else "",
+                            },
+                        }
+                        chunk.tool_calls_delta.append(fragment)
 
                 # Finish reason
                 finish_reason = choice.finish_reason
                 if finish_reason:
                     chunk.is_final = True
                     chunk.finish_reason = finish_reason
-                    # Assemble complete tool calls (only on final chunk)
-                    for idx in sorted(collected_tool_calls):
-                        tc = collected_tool_calls[idx]
-                        chunk.tool_calls.append({
-                            "id": tc["id"],
-                            "type": "function",
-                            "function": {"name": tc["name"], "arguments": tc["arguments"]},
-                        })
 
                 yield chunk
 


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Add `chat_stream()` method to the provider system, enabling true streaming LLM responses. Previously, `LLMModelClient` only supported non-streaming `chat()`, and the openai-api plugin had to bypass the provider system to do streaming (losing DeepSeek thinking mode, custom headers, etc.).

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [x] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Add `LLMStreamChunk` dataclass in `llm_model.py` — represents a single streaming chunk with delta text, reasoning, tool calls, finish reason, and usage
- Add `chat_stream()` default implementation in `LLMModelClient` — degrades to non-streaming by wrapping `chat()` as a single-chunk generator
- Implement `chat_stream()` in `OpenAICompatibleLLMClient` — true `stream=True` with incremental tool call accumulation
- Implement `chat_stream()` in `DeepSeekLLMClient` — preserves thinking mode (`reasoning_effort`, `extra_body["thinking"]`) in streaming path
- Extract `_build_client()` and `_build_request_kwargs()` helpers to eliminate duplication between `chat()` and `chat_stream()`
- `**kwargs` now flows through `_build_request_kwargs(**overrides)` so callers can override temperature, timeout, etc.
- Export `LLMStreamChunk` from `core.provider.__init__`

ModelScope / Siliconflow / Volcengine pass-through subclasses automatically inherit `chat_stream()` from `OpenAICompatibleLLMClient`.

## Screenshots / Logs

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming response support for AI chat requests, including incremental text, reasoning, tool-call fragments, and final usage details.
  * Expanded the public provider interface so streaming chunks are available to integrations.
  * Updated supported client implementations to handle both standard and streaming chat responses consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->