### PR TITLE
feat: add in-memory releases cache with 5-minute TTL

### DIFF
--- a/webui/routes/releases.py
+++ b/webui/routes/releases.py
@@ -58,13 +58,18 @@ class ReleasesRoutes(Routes):
             try:
                 releases = await get_all_releases("xxynet", "KiraAI")
             except Exception as e:
-                logger.error(f"Failed to fetch releases: {e}")
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=f"Failed to fetch releases: {e}",
-                ) from e
-            _releases_cache = releases
-            _releases_cache_time = now
+                if _releases_cache is not None:
+                    logger.warning(f"Failed to fetch releases, using stale cache: {e}")
+                    releases = _releases_cache
+                else:
+                    logger.error(f"Failed to fetch releases: {e}")
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail=f"Failed to fetch releases: {e}",
+                    ) from e
+            else:
+                _releases_cache = releases
+                _releases_cache_time = now
         return ReleasesResponse(
             current_version=VERSION,
             releases=[r for r in releases if not r.get("draft")],

--- a/webui/routes/releases.py
+++ b/webui/routes/releases.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 import tempfile
+import time
 import zipfile
 from pathlib import Path
 
@@ -22,6 +23,10 @@ logger = get_logger("releases", "green")
 RESTART_EXIT_CODE = 42
 RESTART_DELAY_SECONDS = 0.5  # Allow HTTP response to flush before hard exit
 _install_lock = asyncio.Lock()
+
+_RELEASES_CACHE_TTL = 300  # 5 minutes
+_releases_cache: list[dict] | None = None
+_releases_cache_time: float = 0
 
 
 class ReleasesRoutes(Routes):
@@ -45,14 +50,21 @@ class ReleasesRoutes(Routes):
         ]
 
     async def get_releases(self):
-        try:
-            releases = await get_all_releases("xxynet", "KiraAI")
-        except Exception as e:
-            logger.error(f"Failed to fetch releases: {e}")
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=f"Failed to fetch releases: {e}",
-            ) from e
+        global _releases_cache, _releases_cache_time
+        now = time.monotonic()
+        if _releases_cache is not None and now - _releases_cache_time < _RELEASES_CACHE_TTL:
+            releases = _releases_cache
+        else:
+            try:
+                releases = await get_all_releases("xxynet", "KiraAI")
+            except Exception as e:
+                logger.error(f"Failed to fetch releases: {e}")
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"Failed to fetch releases: {e}",
+                ) from e
+            _releases_cache = releases
+            _releases_cache_time = now
         return ReleasesResponse(
             current_version=VERSION,
             releases=[r for r in releases if not r.get("draft")],


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Add in-memory cache for the `/api/releases` endpoint to avoid hitting GitHub API on every request, preventing rate limit issues. Cached data expires after 5 minutes.

## Type of change

- [x] feat: New feature

## Changes

- Add `_releases_cache` / `_releases_cache_time` module-level variables with 5-minute TTL
- `get_releases` checks cache freshness via `time.monotonic()` before calling GitHub API
- On API failure, stale cache is preserved so the endpoint still returns data instead of 502

## Checklist

- [x] I have tested these changes locally
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release listing reliability by returning a clearer error response when release data can’t be fetched.
  * Reduced repeated loading of release information, which may make the releases page feel faster and more responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->