### PR TITLE
feat: seed default Official plugin store source on first run

### DIFF
--- a/core/db/migrate_to_db.py
+++ b/core/db/migrate_to_db.py
@@ -1,5 +1,7 @@
 import json
 import os
+import time
+from uuid import uuid4
 
 from sqlalchemy import select, text
 
@@ -95,6 +97,25 @@ async def migrate_persona(db_service: DatabaseService) -> None:
     logger.info("Migrated default persona to database")
 
 
+async def migrate_plugin_store_sources(db_service: DatabaseService) -> None:
+    """Seed the default Official plugin store source if the table is empty."""
+    sources = await db_service.list_plugin_store_sources()
+    if sources:
+        logger.info("Plugin store sources table is not empty, skipping default seed")
+        return
+
+    now = int(time.time())
+    await db_service.add_plugin_store_source(
+        source_id=uuid4().hex,
+        name="Official",
+        url="https://plugins.kira-ai.top/api/plugins/all",
+        updated_at=now,
+        is_current=True,
+        created_at=now,
+    )
+    logger.info("Seeded default 'Official' plugin store source")
+
+
 async def migrate_persona_is_active(db_service: DatabaseService) -> None:
     """Add is_active column to personas table if it doesn't exist."""
     logger.info("Checking if is_active column needs to be added to personas table")
@@ -144,3 +165,4 @@ async def run_migrations(db_service: DatabaseService) -> None:
     # Ensure the is_active column exists before migrate_persona reads the table
     await migrate_persona_is_active(db_service)
     await migrate_persona(db_service)
+    await migrate_plugin_store_sources(db_service)


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

插件商店插件源默认添加一个 Official 源，用户无需手动配置即可浏览官方插件。

## Type of change

<!-- Check the one that applies. -->

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

<!-- List the key changes in this PR. -->

- Added `migrate_plugin_store_sources()` in `core/db/migrate_to_db.py` to seed an Official plugin source on first database initialization
- Integrated the new migration into `run_migrations()` so it runs during app startup

## Screenshots / Logs

<!-- If applicable, add screenshots or relevant logs to help reviewers. -->

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a default **Official** plugin store source for new or existing setups when no plugin store sources are present.
  * Existing data is preserved; the default source is only added if the list is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->