### PR TITLE
fix: prevent CustomMultiSelect dropdown from closing on internal scroll

### DIFF
--- a/webui/frontend/src/components/common/CustomMultiSelect.vue
+++ b/webui/frontend/src/components/common/CustomMultiSelect.vue
@@ -174,7 +174,7 @@ function openDropdown() {
     if (scrollAncestor) {
       scrollAncestor.addEventListener('scroll', closeDropdown, { passive: true })
     }
-    window.addEventListener('scroll', closeDropdown, true)
+    window.addEventListener('scroll', handleWindowScroll, true)
     window.addEventListener('resize', adjustPosition)
     document.addEventListener('click', handleClickOutside)
   }, 0)
@@ -196,7 +196,7 @@ function closeDropdown() {
     scrollAncestor.removeEventListener('scroll', closeDropdown)
     scrollAncestor = null
   }
-  window.removeEventListener('scroll', closeDropdown, true)
+  window.removeEventListener('scroll', handleWindowScroll, true)
   window.removeEventListener('resize', adjustPosition)
 }
 
@@ -265,6 +265,12 @@ function handleClickOutside(event: MouseEvent) {
   if (!containerRef.value?.contains(target)) {
     closeDropdown()
   }
+}
+
+function handleWindowScroll(event: Event) {
+  // Ignore scrolls originating from inside the dropdown itself
+  if (optionsRef.value?.contains(event.target as Node)) return
+  closeDropdown()
 }
 
 function handleArrowDown() {


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why. Link related issues: Fixes #123, Closes #456 -->
Fix a bug where scrolling through options in  would cause the dropdown to close itself, because the window scroll listener called `closeDropdown` unconditionally. Added `handleWindowScroll` to filter out scroll events originating from inside the dropdown itself, matching the existing behavior in .

## Type of change

<!-- Check the one that applies. -->

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

<!-- List the key changes in this PR. -->

- Added `handleWindowScroll` function that ignores scroll events originating from inside the dropdown's options list
- Changed the window scroll listener from `closeDropdown` to `handleWindowScroll`

## Screenshots / Logs

<!-- If applicable, add screenshots or relevant logs to help reviewers. -->

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown behavior so it no longer closes when scrolling inside its own options list.
  * Window scrolls outside the dropdown still close it as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->