### PR TITLE
feat: add custom WebUI title setting

### DIFF
--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -697,6 +697,8 @@ export default {
     theme: 'Theme',
     theme_light: 'Light',
     theme_dark: 'Dark',
+    custom_webui_title: 'Custom WebUI title',
+    custom_webui_title_placeholder: 'Leave blank to use the default title',
     custom_css: 'Custom CSS',
     custom_js: 'Custom JavaScript',
     save: 'Save Settings',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -697,6 +697,8 @@ export default {
     theme: '主题',
     theme_light: '浅色',
     theme_dark: '深色',
+    custom_webui_title: '自定义 WebUI 标题',
+    custom_webui_title_placeholder: '留空使用默认标题',
     custom_css: '自定义 CSS',
     custom_js: '自定义 JavaScript',
     save: '保存设置',

--- a/webui/frontend/src/main.ts
+++ b/webui/frontend/src/main.ts
@@ -6,8 +6,11 @@ import App from './App.vue'
 import router from './router'
 import i18n from './i18n'
 import './assets/main.css'
+import { applyWebUITitle, CUSTOM_WEBUI_TITLE_KEY } from './utils/customWebUI'
 
-// Apply custom CSS / JS from localStorage on app startup
+// Apply custom WebUI settings from localStorage on app startup
+applyWebUITitle(localStorage.getItem(CUSTOM_WEBUI_TITLE_KEY))
+
 const customCSS = localStorage.getItem('custom_css') || ''
 if (customCSS) {
   const tag = document.createElement('style')

--- a/webui/frontend/src/utils/customWebUI.ts
+++ b/webui/frontend/src/utils/customWebUI.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_WEBUI_TITLE = 'KiraAI Admin Panel'
+export const CUSTOM_WEBUI_TITLE_KEY = 'custom_webui_title'
+
+export function resolveWebUITitle(title: string | null): string {
+  const value = title?.trim()
+  return value || DEFAULT_WEBUI_TITLE
+}
+
+export function applyWebUITitle(title: string | null) {
+  document.title = resolveWebUITitle(title)
+}

--- a/webui/frontend/src/views/SettingsView.vue
+++ b/webui/frontend/src/views/SettingsView.vue
@@ -211,6 +211,19 @@
     <!-- Custom CSS/JS Tab -->
     <div v-show="activeTab === 'custom'" class="space-y-6">
       <div>
+        <label for="custom-webui-title" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          {{ $t('settings.custom_webui_title') }}
+        </label>
+        <input
+          id="custom-webui-title"
+          v-model="customWebUITitle"
+          type="text"
+          class="w-full px-3 py-2 text-sm text-gray-800 dark:text-gray-100 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          :placeholder="$t('settings.custom_webui_title_placeholder')"
+        />
+      </div>
+
+      <div>
         <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
           {{ $t('settings.custom_css') }}
         </label>
@@ -395,6 +408,7 @@ import MonacoEditor from '@/components/common/MonacoEditor.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import Modal from '@/components/common/Modal.vue'
 import FileDropzone from '@/components/common/FileDropzone.vue'
+import { applyWebUITitle, CUSTOM_WEBUI_TITLE_KEY } from '@/utils/customWebUI'
 import {
   getStorageInfo,
   createBackup,
@@ -424,6 +438,7 @@ const tabs = computed(() => [
 
 const customCSS = ref('')
 const customJS = ref('')
+const customWebUITitle = ref('')
 
 // ── Storage ─────────────────────────────────────────────────────────────
 
@@ -608,6 +623,7 @@ async function handleRestore() {
 // ── Init ────────────────────────────────────────────────────────────────
 
 onMounted(() => {
+  customWebUITitle.value = localStorage.getItem(CUSTOM_WEBUI_TITLE_KEY) || ''
   customCSS.value = localStorage.getItem('custom_css') || ''
   customJS.value = localStorage.getItem('custom_js') || ''
 
@@ -648,8 +664,10 @@ function applyCustomJS() {
 async function handleSave() {
   saving.value = true
   try {
+    localStorage.setItem(CUSTOM_WEBUI_TITLE_KEY, customWebUITitle.value)
     localStorage.setItem('custom_css', customCSS.value)
     localStorage.setItem('custom_js', customJS.value)
+    applyWebUITitle(customWebUITitle.value)
     applyCustomCSS()
     applyCustomJS()
 


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Adds a custom WebUI title setting under Settings -> Custom. When left blank, the browser title falls back to the default KiraAI Admin Panel title.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Added a custom WebUI title input before Custom CSS in the Custom settings tab.
- Applied the stored title on app startup and immediately after saving settings.
- Added shared title fallback helpers and synchronized English/Chinese i18n strings.

## Screenshots / Logs

`npm run build` passed locally. Vite reported existing large chunk warnings.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the WebUI page title from the Settings page.
  * Custom titles are saved and applied immediately, including after restarting the application.
  * Added English and Chinese translations for the new setting.
  * Blank titles automatically use the default “KiraAI Admin Panel” title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->