### PR TITLE
fix: commit pending draft text in TagInput on blur to avoid losing input on save

### DIFF
--- a/webui/frontend/src/components/common/TagInput.vue
+++ b/webui/frontend/src/components/common/TagInput.vue
@@ -35,6 +35,7 @@
         :placeholder="modelValue.length === 0 ? (placeholder || '') : ''"
         @keydown.enter.prevent="addItem"
         @keydown.backspace="onBackspace"
+        @blur="addItem"
       />
     </form>
   </div>


### PR DESCRIPTION
## Summary

When the user types text into a `type=list` (TagInput) field and clicks "Save" without pressing Enter first, the pending draft text was silently lost because the `addItem()` function only ran on Enter keydown. Added `@blur="addItem"` so the pending text is automatically committed as a new tag when focus leaves the input.

## Type of change

- [x] fix: Bug fix

## Changes

- Added `@blur="addItem"` on the new-item input in `TagInput.vue` so pending draft text is committed on blur (e.g., when clicking Save)

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tags are now added automatically when the tag input loses focus, in addition to pressing Enter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->