### PR TITLE
fix(qq): wrap at-element get_user_info in try/except

### DIFF
--- a/core/adapter/src/qq/qq.py
+++ b/core/adapter/src/qq/qq.py
@@ -430,9 +430,12 @@ class QQAdapter(IMAdapter):
             elif ele.get("type") == "at":
                 at_obj = At(str(ele.get("data").get("qq")))
                 if str(ele.get("data").get("qq")) != "all":
-                    at_user_info = await self.bot.get_user_info(user_id=str(ele.get("data").get("qq")))
-                    at_nickname = at_user_info["data"]["nickname"]
-                    at_obj.nickname = at_nickname
+                    try:
+                        at_user_info = await self.bot.get_user_info(user_id=str(ele.get("data").get("qq")))
+                        at_obj.nickname = at_user_info["data"]["nickname"]
+                    except Exception as e:
+                        import traceback
+                        self.logger.error(traceback.format_exc())
                 message_content.append(at_obj)
             elif ele.get("type") == "reply":
                 try:


### PR DESCRIPTION
## Summary

`QQAdapter.process_incoming_message` 中处理 `at` 元素的分支是所有元素分支里唯一没有 try/except 的分支。当 NapCat 对 `get_stranger_info` 超时（10s）时，`get_user_info` 抛出的 `TimeoutError` 未被捕获，异常上抛导致**整条消息处理中断**（典型场景：处理一条引用回复时，递归处理其原消息，原消息含 @，取昵称超时即整条挂掉）。

本 PR 给 `get_user_info` 调用加上 try/except，与 `reply` / `video` / `file` / `forward` / `record` 各兄弟分支一致。失败时 `At.nickname` 保持 `None`（`At.repr` 已兼容），`At` 元素照常加入，消息处理继续。

## Type of change

- [x] fix: Bug fix

## Changes

- `core/adapter/src/qq/qq.py`：`process_incoming_message` 的 `at` 元素分支，将 `get_user_info` 调用包裹进 try/except，结构与其余兄弟分支一致。
- 失败时（如 `get_stranger_info` 超时）不设昵称，`At` 元素仍加入消息链，避免单个昵称查询超时打断整条消息处理。

## Screenshots / Logs

修复前的错误日志（处理一条含 @ 的引用回复时，`get_stranger_info` 超时导致 `process_incoming_message` 中断）：

```
File ".../core/adapter/src/qq/qq.py", line 433, in process_incoming_message
    at_user_info = await self.bot.get_user_info(user_id=str(ele.get("data").get("qq")))
  File ".../core/adapter/src/qq/napcat_client/client.py", line 369, in send_action
    raise TimeoutError(f"请求 {action} 超时")
TimeoutError: 请求 get_stranger_info 超时
```

## Checklist

- [ ] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

> 本地验证：`py_compile` 通过；改动结构与同方法内 `reply` / `record` 等分支的 try/except 完全一致。原始超时由上报者在生产环境复现确认。`get_stranger_info` / `get_record` 超时本身属 NapCat 侧问题（隐私 / ffmpeg / 版本），本 PR 仅保证超时不再打断消息处理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when retrieving mentioned-user information.
  * Lookup failures are now logged without interrupting incoming message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->