### PR TITLE
fix(provider): harden AliyunBailian image/TTS and use remote-only model list

### DIFF
--- a/core/provider/src/aliyun_bailian/manifest.json
+++ b/core/provider/src/aliyun_bailian/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "AliyunBailian",
-    "version": "2.3.4",
-    "author": "KiraAI",
+    "version": "2.3.9",
+    "author": "znq19",
     "description": "AliyunBailian (DashScope) full provider: LLM, CosyVoice TTS, STT, Image, Embedding, Rerank.",
     "repo": null,
     "locales": {

--- a/core/provider/src/aliyun_bailian/manifest.json
+++ b/core/provider/src/aliyun_bailian/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "AliyunBailian",
-    "version": "2.3.9",
+    "version": "2.4.0",
     "author": "znq19",
     "description": "AliyunBailian (DashScope) full provider: LLM, CosyVoice TTS, STT, Image, Embedding, Rerank.",
     "repo": null,

--- a/core/provider/src/aliyun_bailian/model_clients.py
+++ b/core/provider/src/aliyun_bailian/model_clients.py
@@ -1,6 +1,6 @@
 import asyncio
 import base64
-import concurrent.futures
+import inspect
 import os
 import re
 import tempfile
@@ -1949,35 +1949,38 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
         )
 
         try:
-            # Single overall deadline for lock wait + synthesis (not additive).
+            # Run blocking synthesis off the event loop. The sync path holds
+            # _DASHSCOPE_LOCK until the SDK call actually returns; timeout is
+            # enforced inside the SDK (timeout_millis), not by abandoning a
+            # future and unlocking early.
             loop = asyncio.get_running_loop()
-            audio_bytes = await asyncio.wait_for(
-                loop.run_in_executor(
-                    None,
-                    lambda: self._synth_sync(
-                        text=text,
-                        api_key=api_key,
-                        model_id=model_id,
-                        voice=voice,
-                        region=region,
-                        workspace_id=workspace_id,
-                        volume=volume,
-                        speech_rate=speech_rate,
-                        pitch_rate=pitch_rate,
-                        audio_format=audio_format,
-                        language_hints=language_hints,
-                        instruction=instruction,
-                        enable_markdown_filter=enable_markdown_filter,
-                        timeout_sec=timeout,
-                    ),
+            audio_bytes = await loop.run_in_executor(
+                None,
+                lambda: self._synth_sync(
+                    text=text,
+                    api_key=api_key,
+                    model_id=model_id,
+                    voice=voice,
+                    region=region,
+                    workspace_id=workspace_id,
+                    volume=volume,
+                    speech_rate=speech_rate,
+                    pitch_rate=pitch_rate,
+                    audio_format=audio_format,
+                    language_hints=language_hints,
+                    instruction=instruction,
+                    enable_markdown_filter=enable_markdown_filter,
+                    timeout_sec=timeout,
                 ),
-                timeout=max(1, int(timeout or 60)) + 1,
             )
-        except asyncio.TimeoutError:
-            logger.error(f"Bailian CosyVoice TTS timed out after {timeout}s (model={model_id})")
-            return None
         except Exception as e:
-            logger.error(f"Bailian CosyVoice TTS failed: {e}")
+            # Surface SDK/timeout failures; do not invent silent empty audio.
+            if isinstance(e, TimeoutError) or "timed out" in str(e).lower():
+                logger.error(
+                    f"Bailian CosyVoice TTS timed out after {timeout}s (model={model_id})"
+                )
+            else:
+                logger.error(f"Bailian CosyVoice TTS failed: {e}")
             return None
 
         if not audio_bytes:
@@ -1986,6 +1989,23 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
 
         b64_str = base64.b64encode(audio_bytes).decode("utf-8")
         return Record(record=b64_str, mime=_resolve_mime(audio_format))
+
+    @staticmethod
+    def _call_speech_synthesizer(synthesizer, text: str, timeout_ms: int):
+        """Invoke CosyVoice synthesizer.call with SDK-native timeout when available.
+
+        Must be called while holding `_DASHSCOPE_LOCK`. The call is synchronous:
+        we never unlock while synthesis may still be in flight.
+        """
+        try:
+            sig = inspect.signature(synthesizer.call)
+            if "timeout_millis" in sig.parameters:
+                return synthesizer.call(text, timeout_millis=timeout_ms)
+        except (TypeError, ValueError) as e:
+            logger.debug(f"Bailian CosyVoice: timeout_millis unavailable ({e})")
+        # Older SDKs without timeout_millis: block until the SDK returns.
+        # Premature unlock would race on process-global dashscope.api_key.
+        return synthesizer.call(text)
 
     def _synth_sync(
         self,
@@ -2007,8 +2027,9 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
         """Synchronous CosyVoice synthesis via DashScope SDK (run in thread).
 
         Mutates process-global dashscope.api_key under `_DASHSCOPE_LOCK`.
-        Uses ONE shared deadline for lock acquisition + synthesis wait so total
-        wait cannot exceed the configured timeout (lock budget is not additive).
+        Uses ONE shared deadline for lock acquisition + synthesis. The lock is
+        held until the SDK call returns (success, error, or SDK-native timeout).
+        Never releases the lock based on a local future wait alone.
         """
         from dashscope.audio.tts_v2 import SpeechSynthesizer
 
@@ -2035,7 +2056,7 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
         if additional_params:
             kwargs["additional_params"] = additional_params
 
-        # Single overall deadline shared by lock acquisition and synthesis call.
+        # Single overall deadline: lock wait budget + remaining synthesis budget.
         call_timeout = max(1, int(timeout_sec or 60))
         deadline = time.monotonic() + call_timeout
         synthesizer = None
@@ -2056,7 +2077,6 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
                 )
 
             import dashscope
-            import inspect
 
             dashscope.api_key = api_key
             synthesizer = SpeechSynthesizer(
@@ -2073,37 +2093,8 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
                 )
             timeout_ms = max(1, int(remaining * 1000))
 
-            def _do_call() -> object:
-                # Newer SDKs: call(text, timeout_millis=...)
-                try:
-                    sig = inspect.signature(synthesizer.call)
-                    if "timeout_millis" in sig.parameters:
-                        return synthesizer.call(text, timeout_millis=timeout_ms)
-                except (TypeError, ValueError):
-                    pass
-                return synthesizer.call(text)
-
-            pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                future = pool.submit(_do_call)
-                try:
-                    audio = future.result(timeout=max(0.01, remaining))
-                except concurrent.futures.TimeoutError:
-                    for closer in ("close", "shutdown", "cancel"):
-                        try:
-                            fn = getattr(synthesizer, closer, None)
-                            if callable(fn):
-                                fn()
-                        except Exception:
-                            pass
-                    raise TimeoutError(
-                        f"CosyVoice SpeechSynthesizer.call timed out after {call_timeout}s"
-                    )
-            finally:
-                try:
-                    pool.shutdown(wait=False, cancel_futures=True)
-                except TypeError:
-                    pool.shutdown(wait=False)
+            # Blocking SDK call under the lock. Unlock only after this returns.
+            audio = self._call_speech_synthesizer(synthesizer, text, timeout_ms)
         finally:
             _DASHSCOPE_LOCK.release()
 
@@ -2112,8 +2103,8 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
                 if synthesizer is not None:
                     resp = synthesizer.get_response()
                     logger.error(f"Bailian CosyVoice empty audio, response={resp}")
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Bailian CosyVoice get_response after empty audio failed: {e}")
             raise RuntimeError("CosyVoice returned empty audio")
 
         if isinstance(audio, (bytes, bytearray)):

--- a/core/provider/src/aliyun_bailian/model_clients.py
+++ b/core/provider/src/aliyun_bailian/model_clients.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import concurrent.futures
 import os
 import re
 import tempfile
@@ -156,8 +157,10 @@ class BailianEmbeddingClient(EmbeddingModelClient):
                     "model": self.model.model_id,
                     "input": texts,
                 }
-                # dimensions only for v3/v4
-                if dimensions:
+                # dimensions only for built-in text-embedding-v3 / v4
+                # (v2 rejects it; avoid matching custom ids like company-v3-embedding)
+                mid = (self.model.model_id or "").lower().strip()
+                if dimensions and mid in {"text-embedding-v3", "text-embedding-v4"}:
                     kwargs["dimensions"] = int(dimensions)
                     kwargs["encoding_format"] = "float"
 
@@ -347,16 +350,46 @@ class _ImageSizeLimits:
     allow_k_tokens: tuple[str, ...] = ()
 
 
-def _image_size_limits(model_id: str) -> _ImageSizeLimits:
+def _image_size_limits(
+    model_id: str, *, editing: bool = False, interleave: bool = False
+) -> _ImageSizeLimits:
     """Return size limits for a DashScope image model.
 
     Sources (Aliyun docs / community mirrors, 2025-2026):
       - wan2.6-t2i / wan2.5-t2i: total [1280^2, 1440^2], aspect [1:4, 4:1]
       - wan2.7-image: total [768^2, 2048^2], aspect [1:8, 8:1], tokens 1K/2K
       - wan2.7-image-pro (t2i): total [768^2, 4096^2], tokens 1K/2K/4K
+      - image edit / ref-image (enable_interleave=false): max 2K (never 4K)
+      - wan2.6-image text/interleave (enable_interleave=true): max ~1280^2
       - wan2.2 / wanx*: side [512, 1440], max ~1440^2
     """
     mid = (model_id or "").lower().replace("_", ".")
+
+    # Official wan2.6-image interleave/text-only path: total [768^2, 1280^2]
+    if interleave:
+        return _ImageSizeLimits(
+            min_total=768 * 768,
+            max_total=1280 * 1280,
+            min_side=256,
+            max_side=1280,
+            min_aspect=1 / 4,
+            max_aspect=4 / 1,
+            multiple=16,
+            allow_k_tokens=("1K",),
+        )
+
+    # Reference-image / edit mode never accepts 4K (including wan2.7-image-pro).
+    if editing:
+        return _ImageSizeLimits(
+            min_total=768 * 768,
+            max_total=2048 * 2048,
+            min_side=256,
+            max_side=2048,
+            min_aspect=1 / 8,
+            max_aspect=8 / 1,
+            multiple=16,
+            allow_k_tokens=("1K", "2K"),
+        )
 
     if mid.startswith("wan2.7") and "pro" in mid:
         return _ImageSizeLimits(
@@ -379,6 +412,18 @@ def _image_size_limits(model_id: str) -> _ImageSizeLimits:
             max_aspect=8 / 1,
             multiple=16,
             allow_k_tokens=("1K", "2K"),  # no 4K on standard
+        )
+    if mid.startswith("wan2.6") and "t2i" not in mid:
+        # wan2.6-image (edit): total [768^2, 2048^2], tokens 1K/2K
+        return _ImageSizeLimits(
+            min_total=768 * 768,
+            max_total=2048 * 2048,
+            min_side=256,
+            max_side=2048,
+            min_aspect=1 / 4,
+            max_aspect=4 / 1,
+            multiple=16,
+            allow_k_tokens=("1K", "2K"),
         )
     if mid.startswith("wan2.6") or mid.startswith("wan2.5"):
         # Pure t2i: total roughly [~1.2M, 1440^2]; official presets like
@@ -586,9 +631,11 @@ def _build_size_pixels(
     k_level: float | None,
     explicit_wh: tuple[int, int] | None,
     model_id: str,
+    editing: bool = False,
+    interleave: bool = False,
 ) -> str | None:
     """Build final size string for API (always clamped)."""
-    limits = _image_size_limits(model_id)
+    limits = _image_size_limits(model_id, editing=editing, interleave=interleave)
 
     if explicit_wh is not None:
         w, h = explicit_wh
@@ -694,7 +741,13 @@ def _detect_k_level_from_prompt(prompt: str) -> float | None:
     return max(levels)
 
 
-def _detect_size_from_prompt(prompt: str, model_id: str) -> str | None:
+def _detect_size_from_prompt(
+    prompt: str,
+    model_id: str,
+    *,
+    editing: bool = False,
+    interleave: bool = False,
+) -> str | None:
     """Parse size intent from prompt → clamped width*height (or official token)."""
     if not prompt:
         return None
@@ -705,7 +758,12 @@ def _detect_size_from_prompt(prompt: str, model_id: str) -> str | None:
         w, h = int(m.group("w")), int(m.group("h"))
         if 64 <= w <= 16384 and 64 <= h <= 16384:
             return _build_size_pixels(
-                aspect=None, k_level=None, explicit_wh=(w, h), model_id=model_id
+                aspect=None,
+                k_level=None,
+                explicit_wh=(w, h),
+                model_id=model_id,
+                editing=editing,
+                interleave=interleave,
             )
 
     # 2) aspect + K (aspect may be None; K may be None)
@@ -714,11 +772,23 @@ def _detect_size_from_prompt(prompt: str, model_id: str) -> str | None:
     if aspect is None and k_level is None:
         return None
     return _build_size_pixels(
-        aspect=aspect, k_level=k_level, explicit_wh=None, model_id=model_id
+        aspect=aspect,
+        k_level=k_level,
+        explicit_wh=None,
+        model_id=model_id,
+        editing=editing,
+        interleave=interleave,
     )
 
 
-def _resolve_image_size(mc: dict, prompt: str, model_id: str) -> str | None:
+def _resolve_image_size(
+    mc: dict,
+    prompt: str,
+    model_id: str,
+    *,
+    editing: bool = False,
+    interleave: bool = False,
+) -> str | None:
     """Resolve final size for API.
 
     Priority:
@@ -729,6 +799,8 @@ def _resolve_image_size(mc: dict, prompt: str, model_id: str) -> str | None:
     Always:
       - convert N K to real pixels with aspect
       - clamp to the target model's max/min limits
+      - editing/ref-image mode clamps to 2K max (never 4K)
+      - interleave/text-only wan2.6-image clamps to ~1280^2
     """
     mc = mc or {}
     cfg = _normalize_size_token(mc.get("size"))
@@ -737,11 +809,21 @@ def _resolve_image_size(mc: dict, prompt: str, model_id: str) -> str | None:
         k_level = _parse_k_level(cfg)
         if k_level is not None:
             return _build_size_pixels(
-                aspect=None, k_level=k_level, explicit_wh=None, model_id=model_id
+                aspect=None,
+                k_level=k_level,
+                explicit_wh=None,
+                model_id=model_id,
+                editing=editing,
+                interleave=interleave,
             )
         if re.fullmatch(r"\d{1,2}:\d{1,2}", cfg):
             return _build_size_pixels(
-                aspect=cfg, k_level=None, explicit_wh=None, model_id=model_id
+                aspect=cfg,
+                k_level=None,
+                explicit_wh=None,
+                model_id=model_id,
+                editing=editing,
+                interleave=interleave,
             )
         m = _SIZE_EXPLICIT_RE.fullmatch(cfg.replace("×", "*").replace("x", "*").replace("X", "*"))
         if m:
@@ -750,6 +832,8 @@ def _resolve_image_size(mc: dict, prompt: str, model_id: str) -> str | None:
                 k_level=None,
                 explicit_wh=(int(m.group("w")), int(m.group("h"))),
                 model_id=model_id,
+                editing=editing,
+                interleave=interleave,
             )
         # unknown fixed string — still try clamp if looks like w*h
         m = _SIZE_EXPLICIT_RE.search(str(cfg))
@@ -759,10 +843,26 @@ def _resolve_image_size(mc: dict, prompt: str, model_id: str) -> str | None:
                 k_level=None,
                 explicit_wh=(int(m.group("w")), int(m.group("h"))),
                 model_id=model_id,
+                editing=editing,
+                interleave=interleave,
             )
+        # token passthrough (e.g. "4K") is unsafe in constrained modes
+        if editing or interleave:
+            k_edit = _parse_k_level(cfg)
+            if k_edit is not None:
+                return _build_size_pixels(
+                    aspect=None,
+                    k_level=min(k_edit, 1.0 if interleave else 2.0),
+                    explicit_wh=None,
+                    model_id=model_id,
+                    editing=editing,
+                    interleave=interleave,
+                )
         return cfg  # last resort pass-through
 
-    return _detect_size_from_prompt(prompt or "", model_id)
+    return _detect_size_from_prompt(
+        prompt or "", model_id, editing=editing, interleave=interleave
+    )
 
 
 class BailianImageClient(ImageModelClient):
@@ -788,6 +888,143 @@ class BailianImageClient(ImageModelClient):
         """wan2.6+ use messages protocol; older use input.prompt."""
         mid = (model_id or "").lower().replace("_", ".")
         return mid.startswith("wan2.6") or mid.startswith("wan2.7")
+
+    @staticmethod
+    def _is_pure_t2i_model(model_id: str) -> bool:
+        """Pure text-to-image models that reject reference images."""
+        mid = (model_id or "").lower().replace("_", ".")
+        # wan2.6-t2i / wan2.5-t2i-* / wan2.2-t2i-* / wanx*-t2i-*
+        if "t2i" in mid:
+            return True
+        return False
+
+    @staticmethod
+    def _is_edit_image_model(model_id: str) -> bool:
+        """Models designed for image edit / multimodal (accept refs)."""
+        mid = (model_id or "").lower().replace("_", ".")
+        if mid.startswith("wan2.7"):
+            return True
+        if mid.startswith("wan2.6") and "t2i" not in mid:
+            return True
+        return False
+
+    @staticmethod
+    def _supports_legacy_ref_img(model_id: str) -> bool:
+        """Older models that accept input.ref_img on text2image endpoint."""
+        mid = (model_id or "").lower().replace("_", ".")
+        return mid in ("wanx-v1", "wanx_v1")
+
+    @staticmethod
+    def _supports_messages_img2img(model_id: str) -> bool:
+        """Models that accept reference images via messages content[].image."""
+        return BailianImageClient._is_edit_image_model(model_id)
+
+    @staticmethod
+    def _auto_route_enabled(mc: dict | None) -> bool:
+        """Whether model auto-routing is enabled (default: False)."""
+        if not mc:
+            return False
+        return bool(mc.get("auto_route", False))
+
+    @staticmethod
+    def _resolve_img2img_model(model_id: str, auto_route: bool = False) -> str:
+        """Optionally map pure t2i ids to an edit-capable model when ref is required.
+
+        Only remaps when auto_route=True. Default is off: always keep configured id.
+        """
+        if not auto_route:
+            return model_id
+        mid = (model_id or "").lower().replace("_", ".")
+        if BailianImageClient._supports_messages_img2img(model_id):
+            return model_id
+        if BailianImageClient._supports_legacy_ref_img(model_id):
+            return model_id
+        # Any pure t2i or unknown wan image model with refs → modern edit model
+        if "t2i" in mid or mid.startswith("wan"):
+            return "wan2.6-image"
+        return model_id
+
+    @staticmethod
+    def _resolve_t2i_model(model_id: str, auto_route: bool = False) -> str:
+        """Optionally prefer pure-t2i model for text-only generation.
+
+        Only remaps when auto_route=True. Default is off: always keep configured id.
+        """
+        if not auto_route:
+            return model_id
+        mid = (model_id or "").lower().replace("_", ".")
+        if mid.startswith("wan2.6") and "t2i" not in mid and "image" in mid:
+            return "wan2.6-t2i"
+        return model_id
+
+    async def _image_to_ref_uri(self, image: Image) -> str | None:
+        """Convert KiraAI Image to a DashScope-accepted image URI (url or data-url)."""
+        if image is None:
+            return None
+        file_type = getattr(image, "file_type", None) or getattr(image, "image_type", None)
+        file_val = getattr(image, "file", None) or getattr(image, "image", None)
+        if file_type == "url" and file_val:
+            return str(file_val)
+        # Prefer data URL for local/base64 images
+        if hasattr(image, "to_data_url"):
+            try:
+                data_url = await image.to_data_url()
+                # Reject empty/invalid data URIs (e.g. "data:image/png;base64,")
+                if data_url and "base64," in str(data_url):
+                    b64_part = str(data_url).split("base64,", 1)[-1].strip()
+                    if b64_part:
+                        return str(data_url)
+                elif data_url and str(data_url).startswith(("http://", "https://")):
+                    return str(data_url)
+            except Exception as e:
+                logger.warning(f"Bailian Image: to_data_url failed: {e}")
+        if file_val and str(file_val).startswith(("http://", "https://", "data:")):
+            val = str(file_val)
+            if val.startswith("data:") and "base64," in val:
+                if not val.split("base64,", 1)[-1].strip():
+                    return None
+            return val
+        if hasattr(image, "to_base64"):
+            try:
+                b64 = await image.to_base64()
+                if not b64:
+                    return None
+                mime = getattr(image, "mime", None) or "image/png"
+                return f"data:{mime};base64,{b64}"
+            except Exception as e:
+                logger.warning(f"Bailian Image: to_base64 failed: {e}")
+        return None
+
+    async def _poll_image_task(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        http_base: str,
+        api_key: str,
+        task_id: str,
+        timeout: int,
+        label: str = "Image",
+    ) -> Image:
+        task_url = f"{http_base}/tasks/{task_id}"
+        poll_headers = {"Authorization": f"Bearer {api_key}"}
+        start = time.time()
+        while time.time() - start < timeout:
+            tr = await client.get(task_url, headers=poll_headers)
+            tr.raise_for_status()
+            tdata = tr.json()
+            output = (tdata.get("output") or {}) if isinstance(tdata, dict) else {}
+            status = (output.get("task_status") or tdata.get("task_status") or "").upper()
+            if status == "SUCCEEDED":
+                url = self._extract_image_url(output, tdata)
+                if not url:
+                    raise RuntimeError(f"Bailian {label} succeeded but no url: {tdata}")
+                return Image(image=url)
+            if status in ("FAILED", "CANCELED", "UNKNOWN"):
+                msg = output.get("message") or tdata.get("message") or status
+                code = output.get("code") or tdata.get("code") or ""
+                raise RuntimeError(f"Bailian {label} failed: {code} {msg}".strip())
+            await asyncio.sleep(2)
+        raise TimeoutError(f"Bailian {label} timed out after {timeout}s")
 
     @staticmethod
     def _extract_image_url(output: dict, tdata: dict | None = None) -> str | None:
@@ -836,12 +1073,9 @@ class BailianImageClient(ImageModelClient):
                     return tdata.get(key)
         return None
 
-    def _build_payload(self, prompt: str, size: str | None = None) -> dict:
+    def _build_payload(self, prompt: str, size: str | None = None, model_id: str | None = None) -> dict:
         mc = self.model.model_config or {}
-        model_id = self.model.model_id
-        # size: None means omit (API model default); never force 1024*1024
-        if size is None:
-            size = _resolve_image_size(mc, prompt, model_id)
+        model_id = model_id or self.model.model_id
         n = int(mc.get("n", 1) or 1)
         n = max(1, min(4, n))
         negative_prompt = (mc.get("negative_prompt") or "").strip()
@@ -852,11 +1086,26 @@ class BailianImageClient(ImageModelClient):
         mid = (model_id or "").lower().replace("_", ".")
         # wan2.6 / wan2.7 use messages protocol (official)
         if self._is_messages_image_model(model_id):
+            # Text-only wan2.6-image is treated as generation (not edit).
+            # Without enable_interleave the API may reject prompt-only calls.
+            text_only_wan26_image = (
+                mid.startswith("wan2.6")
+                and "t2i" not in mid
+                and "image" in mid
+            )
+            # size: None means omit (API model default); never force 1024*1024
+            if size is None:
+                size = _resolve_image_size(
+                    mc, prompt, model_id, interleave=text_only_wan26_image
+                )
             parameters = {
-                "n": n,
+                "n": 1 if text_only_wan26_image else n,
                 "prompt_extend": bool(prompt_extend),
                 "watermark": bool(watermark),
             }
+            if text_only_wan26_image:
+                parameters["enable_interleave"] = True
+                parameters["max_images"] = 1
             if size:
                 parameters["size"] = size
             if negative_prompt:
@@ -867,7 +1116,7 @@ class BailianImageClient(ImageModelClient):
                 except (TypeError, ValueError):
                     pass
             # wan2.7 supports thinking_mode; keep optional from config
-            if "thinking_mode" in mc:
+            if "thinking_mode" in mc and mid.startswith("wan2.7"):
                 parameters["thinking_mode"] = bool(mc.get("thinking_mode"))
             payload = {
                 "model": model_id,
@@ -883,6 +1132,10 @@ class BailianImageClient(ImageModelClient):
                 "parameters": parameters,
             }
             return payload
+
+        # size for older non-messages models
+        if size is None:
+            size = _resolve_image_size(mc, prompt, model_id)
 
         payload = {
             "model": model_id,
@@ -919,24 +1172,40 @@ class BailianImageClient(ImageModelClient):
         if not api_key:
             raise RuntimeError("Bailian Image: api_key is not configured")
 
+        configured = self.model.model_id
+        auto_route = self._auto_route_enabled(mc)
+        model_id = self._resolve_t2i_model(configured, auto_route=auto_route)
+        if model_id != configured:
+            logger.info(
+                f"Bailian Image auto_route: pure-text {configured!r} → {model_id!r}"
+            )
+
         timeout = int(mc.get("timeout", 120) or 120)
         http_base = resolve_http_base_url(mp).rstrip("/")
-        create_url = self._create_url(http_base, self.model.model_id)
+        create_url = self._create_url(http_base, model_id)
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
             "X-DashScope-Async": "enable",
         }
-        size = _resolve_image_size(mc, prompt, self.model.model_id)
-        payload = self._build_payload(prompt, size=size)
+        # _build_payload resolves size with model-specific mode
+        # (e.g. wan2.6-image text-only uses interleave limits ~1280^2).
+        payload = self._build_payload(prompt, size=None, model_id=model_id)
+        size = (payload.get("parameters") or {}).get("size")
         logger.info(
             f"Bailian Image size resolved: config={mc.get('size')!r} -> {size!r} "
-            f"(model={self.model.model_id})"
+            f"(model={model_id})"
         )
 
         async with httpx.AsyncClient(timeout=30) as client:
             resp = await client.post(create_url, json=payload, headers=headers)
-            resp.raise_for_status()
+            if resp.status_code >= 400:
+                try:
+                    err_body = resp.text
+                except Exception:
+                    err_body = ""
+                logger.error(f"Bailian Image HTTP {resp.status_code}: {err_body[:800]}")
+                resp.raise_for_status()
             data = resp.json()
 
             task_id = None
@@ -946,34 +1215,25 @@ class BailianImageClient(ImageModelClient):
             if not task_id:
                 raise RuntimeError(f"Bailian Image: no task_id in response: {data}")
 
-            task_url = f"{http_base}/tasks/{task_id}"
-            poll_headers = {
-                "Authorization": f"Bearer {api_key}",
-            }
-            start = time.time()
-            while time.time() - start < timeout:
-                tr = await client.get(task_url, headers=poll_headers)
-                tr.raise_for_status()
-                tdata = tr.json()
-                output = (tdata.get("output") or {}) if isinstance(tdata, dict) else {}
-                status = (output.get("task_status") or tdata.get("task_status") or "").upper()
-
-                if status == "SUCCEEDED":
-                    url = self._extract_image_url(output, tdata)
-                    if not url:
-                        raise RuntimeError(f"Bailian Image succeeded but no url: {tdata}")
-                    return Image(image=url)
-
-                if status in ("FAILED", "CANCELED", "UNKNOWN"):
-                    msg = output.get("message") or tdata.get("message") or status
-                    raise RuntimeError(f"Bailian Image failed: {msg}")
-
-                await asyncio.sleep(2)
-
-        raise TimeoutError(f"Bailian Image timed out after {timeout}s")
+            return await self._poll_image_task(
+                client,
+                http_base=http_base,
+                api_key=api_key,
+                task_id=task_id,
+                timeout=timeout,
+                label="Image",
+            )
 
     async def image_to_image(self, prompt: str, image: Union[Image, list[Image]]) -> Image:
-        # Best-effort: wanx-v1 supports ref_img; others may not.
+        """Image-to-image / edit with reference image(s).
+
+        Protocol (always, independent of auto_route):
+          - wan2.6-image / wan2.7-image*: messages + content[].image
+          - wanx-v1: legacy text2image + ref_img
+          - pure t2i without auto_route: raise clear error (model cannot take refs)
+          - pure t2i with auto_route=True: remap to wan2.6-image
+          - if no usable ref URI: fall back to text_to_image(prompt)
+        """
         if isinstance(image, Image):
             images = [image]
         else:
@@ -985,39 +1245,137 @@ class BailianImageClient(ImageModelClient):
         if not api_key:
             raise RuntimeError("Bailian Image: api_key is not configured")
 
-        ref_url = None
-        if images:
-            # Prefer public URL if already url type
-            first = images[0]
-            if getattr(first, "file_type", None) == "url":
-                ref_url = first.file
-            else:
-                # Fall back to data url — may not be accepted by all models
-                ref_url = await first.to_data_url()
+        # Collect up to 4 reference URIs (official edit limit)
+        ref_uris: list[str] = []
+        for img in images[:4]:
+            uri = await self._image_to_ref_uri(img)
+            if uri:
+                ref_uris.append(uri)
+
+        configured_model = self.model.model_id
+        if not ref_uris:
+            logger.warning(
+                "Bailian Image2Image: no usable reference image, falling back to text_to_image "
+                f"(model={configured_model})"
+            )
+            return await self.text_to_image(prompt)
+
+        auto_route = self._auto_route_enabled(mc)
+        model_id = self._resolve_img2img_model(configured_model, auto_route=auto_route)
+        if model_id != configured_model:
+            logger.info(
+                f"Bailian Image2Image auto_route: {configured_model!r} → {model_id!r} "
+                f"(reference image requires an edit-capable model)"
+            )
+
+        # Configured model cannot take refs and auto_route is off
+        if (
+            not self._supports_messages_img2img(model_id)
+            and not self._supports_legacy_ref_img(model_id)
+        ):
+            raise RuntimeError(
+                f"Bailian Image2Image: model {model_id!r} does not support reference images. "
+                f"Use wan2.6-image / wan2.7-image, or enable model_config.auto_route "
+                f"(default is off)."
+            )
 
         timeout = int(mc.get("timeout", 120) or 120)
         http_base = resolve_http_base_url(mp).rstrip("/")
-        create_url = f"{http_base}/services/aigc/text2image/image-synthesis"
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
             "X-DashScope-Async": "enable",
         }
 
-        size = _resolve_image_size(mc, prompt, self.model.model_id)
-        payload = {
-            "model": self.model.model_id,
-            "input": {
-                "prompt": prompt,
-            },
-            "parameters": {
+        # Size: resolve against the *actual* model we will call.
+        # Editing / ref-image path must clamp to 2K (never send 4K).
+        size = _resolve_image_size(mc, prompt, model_id, editing=True)
+        negative_prompt = (mc.get("negative_prompt") or "").strip()
+        prompt_extend = mc.get("prompt_extend", True)
+        watermark = mc.get("watermark", False)
+        seed = mc.get("seed")
+
+        # ── Path A: modern messages img2img (wan2.6-image / wan2.7-*) ──
+        if self._supports_messages_img2img(model_id):
+            create_url = f"{http_base}/services/aigc/image-generation/generation"
+            content: list[dict] = [{"text": prompt}]
+            for uri in ref_uris:
+                content.append({"image": uri})
+
+            parameters: dict = {
                 "n": 1,
-            },
-        }
-        if size:
-            payload["parameters"]["size"] = size
-        if ref_url:
-            payload["input"]["ref_img"] = ref_url
+                "prompt_extend": bool(prompt_extend),
+                "watermark": bool(watermark),
+                "enable_interleave": False,  # image edit mode (requires refs)
+            }
+            if size:
+                parameters["size"] = size
+            if negative_prompt:
+                parameters["negative_prompt"] = negative_prompt
+            if seed is not None and str(seed).strip() != "":
+                try:
+                    parameters["seed"] = int(seed)
+                except (TypeError, ValueError):
+                    pass
+            if "thinking_mode" in mc and str(model_id).lower().startswith("wan2.7"):
+                parameters["thinking_mode"] = bool(mc.get("thinking_mode"))
+
+            payload = {
+                "model": model_id,
+                "input": {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": content,
+                        }
+                    ]
+                },
+                "parameters": parameters,
+            }
+            logger.info(
+                f"Bailian Image2Image (messages): model={model_id}, refs={len(ref_uris)}, size={size!r}"
+            )
+
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(create_url, json=payload, headers=headers)
+                if resp.status_code >= 400:
+                    try:
+                        err_body = resp.text
+                    except Exception:
+                        err_body = ""
+                    logger.error(
+                        f"Bailian Image2Image HTTP {resp.status_code}: {err_body[:800]}"
+                    )
+                    resp.raise_for_status()
+                data = resp.json()
+                output = data.get("output") or {}
+                task_id = output.get("task_id") or data.get("task_id")
+                if not task_id:
+                    raise RuntimeError(f"Bailian Image2Image: no task_id: {data}")
+                return await self._poll_image_task(
+                    client,
+                    http_base=http_base,
+                    api_key=api_key,
+                    task_id=task_id,
+                    timeout=timeout,
+                    label="Image2Image",
+                )
+
+        # ── Path B: legacy wanx-v1 style ref_img only ──
+        if self._supports_legacy_ref_img(model_id):
+            create_url = f"{http_base}/services/aigc/text2image/image-synthesis"
+            payload = {
+                "model": model_id,
+                "input": {
+                    "prompt": prompt,
+                    "ref_img": ref_uris[0],
+                },
+                "parameters": {
+                    "n": 1,
+                },
+            }
+            if size:
+                payload["parameters"]["size"] = size
             ref_mode = (mc.get("ref_mode") or "repaint").strip()
             payload["parameters"]["ref_mode"] = ref_mode
             if mc.get("ref_strength") is not None:
@@ -1025,35 +1383,41 @@ class BailianImageClient(ImageModelClient):
                     payload["parameters"]["ref_strength"] = float(mc.get("ref_strength"))
                 except (TypeError, ValueError):
                     pass
+            if negative_prompt:
+                payload["input"]["negative_prompt"] = negative_prompt
 
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.post(create_url, json=payload, headers=headers)
-            resp.raise_for_status()
-            data = resp.json()
-            output = data.get("output") or {}
-            task_id = output.get("task_id") or data.get("task_id")
-            if not task_id:
-                raise RuntimeError(f"Bailian Image2Image: no task_id: {data}")
+            logger.info(
+                f"Bailian Image2Image (legacy ref_img): model={model_id}, size={size!r}"
+            )
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(create_url, json=payload, headers=headers)
+                if resp.status_code >= 400:
+                    try:
+                        err_body = resp.text
+                    except Exception:
+                        err_body = ""
+                    logger.error(
+                        f"Bailian Image2Image HTTP {resp.status_code}: {err_body[:800]}"
+                    )
+                    resp.raise_for_status()
+                data = resp.json()
+                output = data.get("output") or {}
+                task_id = output.get("task_id") or data.get("task_id")
+                if not task_id:
+                    raise RuntimeError(f"Bailian Image2Image: no task_id: {data}")
+                return await self._poll_image_task(
+                    client,
+                    http_base=http_base,
+                    api_key=api_key,
+                    task_id=task_id,
+                    timeout=timeout,
+                    label="Image2Image",
+                )
 
-            task_url = f"{http_base}/tasks/{task_id}"
-            poll_headers = {"Authorization": f"Bearer {api_key}"}
-            start = time.time()
-            while time.time() - start < timeout:
-                tr = await client.get(task_url, headers=poll_headers)
-                tr.raise_for_status()
-                tdata = tr.json()
-                output = (tdata.get("output") or {}) if isinstance(tdata, dict) else {}
-                status = (output.get("task_status") or "").upper()
-                if status == "SUCCEEDED":
-                    url = self._extract_image_url(output, tdata)
-                    if not url:
-                        raise RuntimeError(f"Bailian Image2Image empty url: {tdata}")
-                    return Image(image=url)
-                if status in ("FAILED", "CANCELED", "UNKNOWN"):
-                    raise RuntimeError(f"Bailian Image2Image failed: {output.get('message') or status}")
-                await asyncio.sleep(2)
-
-        raise TimeoutError(f"Bailian Image2Image timed out after {timeout}s")
+        # Should be unreachable: unsupported models raise earlier
+        raise RuntimeError(
+            f"Bailian Image2Image: no protocol handler for model {model_id!r}"
+        )
 
 
 # ───────────────────────────── STT ─────────────────────────────
@@ -1537,24 +1901,31 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
         )
 
         try:
+            # Run synthesis on a dedicated executor so asyncio timeout can abandon
+            # the wait without leaving the process-wide DashScope lock held by
+            # an abandoned default worker forever in a queue.
+            loop = asyncio.get_running_loop()
             audio_bytes = await asyncio.wait_for(
-                asyncio.to_thread(
-                    self._synth_sync,
-                    text=text,
-                    api_key=api_key,
-                    model_id=model_id,
-                    voice=voice,
-                    region=region,
-                    workspace_id=workspace_id,
-                    volume=volume,
-                    speech_rate=speech_rate,
-                    pitch_rate=pitch_rate,
-                    audio_format=audio_format,
-                    language_hints=language_hints,
-                    instruction=instruction,
-                    enable_markdown_filter=enable_markdown_filter,
+                loop.run_in_executor(
+                    None,
+                    lambda: self._synth_sync(
+                        text=text,
+                        api_key=api_key,
+                        model_id=model_id,
+                        voice=voice,
+                        region=region,
+                        workspace_id=workspace_id,
+                        volume=volume,
+                        speech_rate=speech_rate,
+                        pitch_rate=pitch_rate,
+                        audio_format=audio_format,
+                        language_hints=language_hints,
+                        instruction=instruction,
+                        enable_markdown_filter=enable_markdown_filter,
+                        timeout_sec=timeout,
+                    ),
                 ),
-                timeout=timeout,
+                timeout=timeout + 5,
             )
         except asyncio.TimeoutError:
             logger.error(f"Bailian CosyVoice TTS timed out after {timeout}s (model={model_id})")
@@ -1585,8 +1956,15 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
         language_hints: list[str],
         instruction: str,
         enable_markdown_filter: bool,
+        timeout_sec: int = 60,
     ) -> bytes:
-        """Synchronous CosyVoice synthesis via DashScope SDK (run in thread)."""
+        """Synchronous CosyVoice synthesis via DashScope SDK (run in thread).
+
+        Mutates process-global dashscope.api_key under `_DASHSCOPE_LOCK` for the
+        whole call, and enforces a hard timeout (SDK timeout_millis when
+        available + ThreadPoolExecutor future timeout) so the lock is always
+        released even if the worker cannot be cancelled.
+        """
         from dashscope.audio.tts_v2 import SpeechSynthesizer
 
         fmt = _resolve_audio_format(audio_format)
@@ -1612,8 +1990,22 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
         if additional_params:
             kwargs["additional_params"] = additional_params
 
-        with _DASHSCOPE_LOCK:
+        # Prefer SDK-native timeout_millis when available (DashScope CosyVoice call).
+        # Hold process-global api_key mutation under lock for the whole call
+        # (dashscope.api_key is process-global), but enforce a hard timeout so
+        # the lock is always released.
+        call_timeout = max(1, int(timeout_sec or 60))
+        timeout_ms = call_timeout * 1000
+        synthesizer = None
+        audio = None
+        acquired = _DASHSCOPE_LOCK.acquire(timeout=call_timeout)
+        if not acquired:
+            raise TimeoutError(
+                f"CosyVoice waiting for DashScope lock timed out after {call_timeout}s"
+            )
+        try:
             import dashscope
+            import inspect
 
             dashscope.api_key = api_key
             synthesizer = SpeechSynthesizer(
@@ -1622,12 +2014,45 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
                 url=_resolve_ws_url(region, workspace_id),
             )
 
-        audio = synthesizer.call(text)
+            def _do_call() -> object:
+                # Newer SDKs: call(text, timeout_millis=...)
+                try:
+                    sig = inspect.signature(synthesizer.call)
+                    if "timeout_millis" in sig.parameters:
+                        return synthesizer.call(text, timeout_millis=timeout_ms)
+                except (TypeError, ValueError):
+                    pass
+                return synthesizer.call(text)
+
+            pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            try:
+                future = pool.submit(_do_call)
+                try:
+                    audio = future.result(timeout=call_timeout)
+                except concurrent.futures.TimeoutError:
+                    for closer in ("close", "shutdown", "cancel"):
+                        try:
+                            fn = getattr(synthesizer, closer, None)
+                            if callable(fn):
+                                fn()
+                        except Exception:
+                            pass
+                    raise TimeoutError(
+                        f"CosyVoice SpeechSynthesizer.call timed out after {call_timeout}s"
+                    )
+            finally:
+                try:
+                    pool.shutdown(wait=False, cancel_futures=True)
+                except TypeError:
+                    pool.shutdown(wait=False)
+        finally:
+            _DASHSCOPE_LOCK.release()
 
         if audio is None:
             try:
-                resp = synthesizer.get_response()
-                logger.error(f"Bailian CosyVoice empty audio, response={resp}")
+                if synthesizer is not None:
+                    resp = synthesizer.get_response()
+                    logger.error(f"Bailian CosyVoice empty audio, response={resp}")
             except Exception:
                 pass
             raise RuntimeError("CosyVoice returned empty audio")

--- a/core/provider/src/aliyun_bailian/model_clients.py
+++ b/core/provider/src/aliyun_bailian/model_clients.py
@@ -378,6 +378,26 @@ def _image_size_limits(
             allow_k_tokens=("1K",),
         )
 
+    # Preserve legacy edit limits for wanx-v1 / older wanx & wan2.2 paths BEFORE
+    # the generic modern edit profile (which allows up to 2K). Otherwise
+    # image_to_image() with editing=True would send oversized sizes to wanx-v1.
+    if editing and (
+        mid in ("wanx-v1", "wanx.v1")
+        or mid.startswith("wan2.2")
+        or mid.startswith("wanx")
+        or mid.startswith("wan2.1")
+    ):
+        return _ImageSizeLimits(
+            min_total=512 * 512,
+            max_total=1440 * 1440,
+            min_side=512,
+            max_side=1440,
+            min_aspect=1 / 4,
+            max_aspect=4 / 1,
+            multiple=8,
+            allow_k_tokens=(),
+        )
+
     # Reference-image / edit mode never accepts 4K (including wan2.7-image-pro).
     if editing:
         return _ImageSizeLimits(
@@ -911,8 +931,9 @@ class BailianImageClient(ImageModelClient):
     @staticmethod
     def _supports_legacy_ref_img(model_id: str) -> bool:
         """Older models that accept input.ref_img on text2image endpoint."""
+        # Underscores are normalized to dots first, so wanx_v1 -> wanx.v1
         mid = (model_id or "").lower().replace("_", ".")
-        return mid in ("wanx-v1", "wanx_v1")
+        return mid in ("wanx-v1", "wanx.v1")
 
     @staticmethod
     def _supports_messages_img2img(model_id: str) -> bool:
@@ -957,6 +978,28 @@ class BailianImageClient(ImageModelClient):
             return "wan2.6-t2i"
         return model_id
 
+    @staticmethod
+    def _normalize_ref_uri(value: str | None) -> str | None:
+        """Normalize a candidate reference URI; reject empty/malformed data URLs."""
+        if not value:
+            return None
+        val = str(value).strip()
+        if not val:
+            return None
+        if val.startswith(("http://", "https://")):
+            return val
+        if val.startswith("data:"):
+            header, separator, payload = val.partition(",")
+            # Require a non-empty payload after the comma. Also require a base64
+            # marker in the header for DashScope data-url acceptance; bare
+            # data:image/png, / data:image/png;base64 (no payload) are invalid.
+            if not separator or not payload.strip():
+                return None
+            if ";base64" not in header.lower():
+                return None
+            return val
+        return None
+
     async def _image_to_ref_uri(self, image: Image) -> str | None:
         """Convert KiraAI Image to a DashScope-accepted image URI (url or data-url)."""
         if image is None:
@@ -964,33 +1007,25 @@ class BailianImageClient(ImageModelClient):
         file_type = getattr(image, "file_type", None) or getattr(image, "image_type", None)
         file_val = getattr(image, "file", None) or getattr(image, "image", None)
         if file_type == "url" and file_val:
-            return str(file_val)
+            return self._normalize_ref_uri(str(file_val))
         # Prefer data URL for local/base64 images
         if hasattr(image, "to_data_url"):
             try:
                 data_url = await image.to_data_url()
-                # Reject empty/invalid data URIs (e.g. "data:image/png;base64,")
-                if data_url and "base64," in str(data_url):
-                    b64_part = str(data_url).split("base64,", 1)[-1].strip()
-                    if b64_part:
-                        return str(data_url)
-                elif data_url and str(data_url).startswith(("http://", "https://")):
-                    return str(data_url)
+                normalized = self._normalize_ref_uri(str(data_url) if data_url else None)
+                if normalized:
+                    return normalized
             except Exception as e:
                 logger.warning(f"Bailian Image: to_data_url failed: {e}")
         if file_val and str(file_val).startswith(("http://", "https://", "data:")):
-            val = str(file_val)
-            if val.startswith("data:") and "base64," in val:
-                if not val.split("base64,", 1)[-1].strip():
-                    return None
-            return val
+            return self._normalize_ref_uri(str(file_val))
         if hasattr(image, "to_base64"):
             try:
                 b64 = await image.to_base64()
                 if not b64:
                     return None
                 mime = getattr(image, "mime", None) or "image/png"
-                return f"data:{mime};base64,{b64}"
+                return self._normalize_ref_uri(f"data:{mime};base64,{b64}")
             except Exception as e:
                 logger.warning(f"Bailian Image: to_base64 failed: {e}")
         return None
@@ -1008,8 +1043,18 @@ class BailianImageClient(ImageModelClient):
         task_url = f"{http_base}/tasks/{task_id}"
         poll_headers = {"Authorization": f"Bearer {api_key}"}
         start = time.time()
-        while time.time() - start < timeout:
-            tr = await client.get(task_url, headers=poll_headers)
+        total_timeout = max(1, int(timeout or 1))
+        while True:
+            remaining = total_timeout - (time.time() - start)
+            if remaining <= 0:
+                break
+            # Bound each poll HTTP request to the remaining overall deadline so a
+            # short configured timeout cannot be exceeded by the client default.
+            tr = await client.get(
+                task_url,
+                headers=poll_headers,
+                timeout=max(0.1, remaining),
+            )
             tr.raise_for_status()
             tdata = tr.json()
             output = (tdata.get("output") or {}) if isinstance(tdata, dict) else {}
@@ -1023,8 +1068,11 @@ class BailianImageClient(ImageModelClient):
                 msg = output.get("message") or tdata.get("message") or status
                 code = output.get("code") or tdata.get("code") or ""
                 raise RuntimeError(f"Bailian {label} failed: {code} {msg}".strip())
-            await asyncio.sleep(2)
-        raise TimeoutError(f"Bailian {label} timed out after {timeout}s")
+            remaining_after = total_timeout - (time.time() - start)
+            if remaining_after <= 0:
+                break
+            await asyncio.sleep(min(2.0, remaining_after))
+        raise TimeoutError(f"Bailian {label} timed out after {total_timeout}s")
 
     @staticmethod
     def _extract_image_url(output: dict, tdata: dict | None = None) -> str | None:
@@ -1155,9 +1203,9 @@ class BailianImageClient(ImageModelClient):
                 payload["parameters"]["seed"] = int(seed)
             except (TypeError, ValueError):
                 pass
-        # style only for wanx-v1
+        # style only for wanx-v1 (underscore already normalized to dot)
         style = (mc.get("style") or "").strip()
-        if style and mid in ("wanx-v1", "wanx_v1"):
+        if style and mid in ("wanx-v1", "wanx.v1"):
             payload["parameters"]["style"] = style
         if "prompt_extend" in mc:
             payload["parameters"]["prompt_extend"] = bool(prompt_extend)
@@ -1901,9 +1949,7 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
         )
 
         try:
-            # Run synthesis on a dedicated executor so asyncio timeout can abandon
-            # the wait without leaving the process-wide DashScope lock held by
-            # an abandoned default worker forever in a queue.
+            # Single overall deadline for lock wait + synthesis (not additive).
             loop = asyncio.get_running_loop()
             audio_bytes = await asyncio.wait_for(
                 loop.run_in_executor(
@@ -1925,7 +1971,7 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
                         timeout_sec=timeout,
                     ),
                 ),
-                timeout=timeout + 5,
+                timeout=max(1, int(timeout or 60)) + 1,
             )
         except asyncio.TimeoutError:
             logger.error(f"Bailian CosyVoice TTS timed out after {timeout}s (model={model_id})")
@@ -1960,10 +2006,9 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
     ) -> bytes:
         """Synchronous CosyVoice synthesis via DashScope SDK (run in thread).
 
-        Mutates process-global dashscope.api_key under `_DASHSCOPE_LOCK` for the
-        whole call, and enforces a hard timeout (SDK timeout_millis when
-        available + ThreadPoolExecutor future timeout) so the lock is always
-        released even if the worker cannot be cancelled.
+        Mutates process-global dashscope.api_key under `_DASHSCOPE_LOCK`.
+        Uses ONE shared deadline for lock acquisition + synthesis wait so total
+        wait cannot exceed the configured timeout (lock budget is not additive).
         """
         from dashscope.audio.tts_v2 import SpeechSynthesizer
 
@@ -1990,20 +2035,26 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
         if additional_params:
             kwargs["additional_params"] = additional_params
 
-        # Prefer SDK-native timeout_millis when available (DashScope CosyVoice call).
-        # Hold process-global api_key mutation under lock for the whole call
-        # (dashscope.api_key is process-global), but enforce a hard timeout so
-        # the lock is always released.
+        # Single overall deadline shared by lock acquisition and synthesis call.
         call_timeout = max(1, int(timeout_sec or 60))
-        timeout_ms = call_timeout * 1000
+        deadline = time.monotonic() + call_timeout
         synthesizer = None
         audio = None
-        acquired = _DASHSCOPE_LOCK.acquire(timeout=call_timeout)
+
+        lock_budget = max(0.01, deadline - time.monotonic())
+        acquired = _DASHSCOPE_LOCK.acquire(timeout=lock_budget)
         if not acquired:
             raise TimeoutError(
                 f"CosyVoice waiting for DashScope lock timed out after {call_timeout}s"
             )
         try:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"CosyVoice overall deadline exceeded after waiting for lock "
+                    f"({call_timeout}s)"
+                )
+
             import dashscope
             import inspect
 
@@ -2013,6 +2064,14 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
                 workspace=workspace_id or None,
                 url=_resolve_ws_url(region, workspace_id),
             )
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"CosyVoice overall deadline exceeded before synthesis "
+                    f"({call_timeout}s)"
+                )
+            timeout_ms = max(1, int(remaining * 1000))
 
             def _do_call() -> object:
                 # Newer SDKs: call(text, timeout_millis=...)
@@ -2028,7 +2087,7 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
             try:
                 future = pool.submit(_do_call)
                 try:
-                    audio = future.result(timeout=call_timeout)
+                    audio = future.result(timeout=max(0.01, remaining))
                 except concurrent.futures.TimeoutError:
                     for closer in ("close", "shutdown", "cancel"):
                         try:

--- a/core/provider/src/aliyun_bailian/provider.py
+++ b/core/provider/src/aliyun_bailian/provider.py
@@ -1,7 +1,6 @@
 import httpx
 
 from core.provider import ModelType, BaseProvider
-from core.logging_manager import get_logger
 
 from .model_clients import (
     BailianLLMClient,
@@ -12,8 +11,6 @@ from .model_clients import (
     BailianRerankClient,
     resolve_compatible_base_url,
 )
-
-logger = get_logger("provider", "purple")
 
 
 def _tag(model_type: str, text: str = "") -> str:
@@ -29,8 +26,8 @@ def _tag(model_type: str, text: str = "") -> str:
 
 def _infer_type(model_id: str) -> str:
     """
-    Best-effort type inference from model id.
-    Used only for display tags; never blocks listing unknown remote models.
+    Best-effort type inference from remote model id.
+    Used only for display tags on truly returned models.
     Order matters: video/tts/stt before broad wan/image prefixes.
     """
     mid = (model_id or "").lower().strip()
@@ -82,160 +79,15 @@ def _infer_type(model_id: str) -> str:
     return "llm"
 
 
-def _annotate(item: dict, forced_type: str | None = None) -> dict:
-    """Return a shallow-copied model dict with type-tagged description."""
+def _annotate(item: dict) -> dict:
+    """Return a shallow-copied remote model dict with type-tagged description."""
     out = dict(item)
     mid = out.get("id") or ""
-    mtype = forced_type or _infer_type(mid)
+    mtype = _infer_type(mid)
     out["description"] = _tag(mtype, out.get("description") or "")
     # Keep raw type for potential future UI use (harmless extra field)
     out.setdefault("type", mtype)
     return out
-
-
-# CosyVoice 全系列（远端 /models 通常不含语音模型，静态补充）
-COSYVOICE_MODELS = [
-    {
-        "id": "cosyvoice-v3.5-plus",
-        "name": "CosyVoice v3.5 Plus",
-        "description": "超高表现力，声音复刻与声音设计效果升级，推荐",
-    },
-    {
-        "id": "cosyvoice-v3.5-flash",
-        "name": "CosyVoice v3.5 Flash",
-        "description": "v3.5 轻量版，低延迟，支持复刻音色",
-    },
-    {
-        "id": "cosyvoice-v3-plus",
-        "name": "CosyVoice v3 Plus",
-        "description": "合成效果佳，支持声音复刻与指令控制",
-    },
-    {
-        "id": "cosyvoice-v3-flash",
-        "name": "CosyVoice v3 Flash",
-        "description": "常用 Flash 版本，低延迟，支持复刻音色",
-    },
-    {
-        "id": "cosyvoice-v2",
-        "name": "CosyVoice v2",
-        "description": "v2 大模型，多音色与多语言支持",
-    },
-    {
-        "id": "cosyvoice-v1",
-        "name": "CosyVoice v1",
-        "description": "旧版 v1，功能有限，不推荐新项目使用",
-    },
-]
-
-# 语音识别常用模型（远端列表通常不含）
-STT_MODELS = [
-    {
-        "id": "paraformer-realtime-v2",
-        "name": "Paraformer Realtime v2",
-        "description": "实时/本地文件语音识别，推荐",
-    },
-    {
-        "id": "paraformer-realtime-8k-v2",
-        "name": "Paraformer Realtime 8k v2",
-        "description": "8kHz 电话场景语音识别",
-    },
-    {
-        "id": "paraformer-realtime-v1",
-        "name": "Paraformer Realtime v1",
-        "description": "实时识别 v1",
-    },
-    {
-        "id": "fun-asr-realtime",
-        "name": "Fun-ASR Realtime",
-        "description": "Fun-ASR 实时语音识别",
-    },
-]
-
-# 文生图常用模型
-IMAGE_MODELS = [
-    {
-        "id": "wan2.7-image-pro",
-        "name": "Wan 2.7 Image Pro",
-        "description": "万相 2.7 专业版（文生图/编辑，最高 4K）",
-    },
-    {
-        "id": "wan2.7-image",
-        "name": "Wan 2.7 Image",
-        "description": "万相 2.7 标准版（更快）",
-    },
-    {
-        "id": "wan2.6-image",
-        "name": "Wan 2.6 Image",
-        "description": "万相 2.6 图像生成与编辑（支持参考图/图生图）",
-    },
-    {
-        "id": "wan2.6-t2i",
-        "name": "Wan 2.6 T2I",
-        "description": "万相 2.6 纯文生图（不支持参考图；selfie 请用 wan2.6-image，或开启 auto_route）",
-    },
-    {
-        "id": "wan2.5-t2i-preview",
-        "name": "Wan 2.5 T2I Preview",
-        "description": "万相 2.5 文生图 preview",
-    },
-    {
-        "id": "wan2.2-t2i-flash",
-        "name": "Wan 2.2 T2I Flash",
-        "description": "万相 2.2 极速版",
-    },
-    {
-        "id": "wan2.2-t2i-plus",
-        "name": "Wan 2.2 T2I Plus",
-        "description": "万相 2.2 专业版",
-    },
-    {
-        "id": "wanx2.1-t2i-turbo",
-        "name": "Wanx 2.1 T2I Turbo",
-        "description": "万相 2.1 极速版",
-    },
-    {
-        "id": "wanx2.1-t2i-plus",
-        "name": "Wanx 2.1 T2I Plus",
-        "description": "万相 2.1 专业版",
-    },
-    {
-        "id": "wanx-v1",
-        "name": "Wanx v1",
-        "description": "万相 v1 文生图（旧版）",
-    },
-]
-
-# Embedding / Rerank 常用模型（远端可能已包含，静态作兜底）
-EMBEDDING_MODELS = [
-    {
-        "id": "text-embedding-v4",
-        "name": "Text Embedding v4",
-        "description": "通用文本向量 v4（推荐）",
-    },
-    {
-        "id": "text-embedding-v3",
-        "name": "Text Embedding v3",
-        "description": "通用文本向量 v3",
-    },
-    {
-        "id": "text-embedding-v2",
-        "name": "Text Embedding v2",
-        "description": "通用文本向量 v2",
-    },
-]
-
-RERANK_MODELS = [
-    {
-        "id": "qwen3-rerank",
-        "name": "Qwen3 Rerank",
-        "description": "文本重排序（推荐）",
-    },
-    {
-        "id": "gte-rerank-v2",
-        "name": "GTE Rerank v2",
-        "description": "GTE 文本重排序 v2",
-    },
-]
 
 
 class BailianProvider(BaseProvider):
@@ -247,6 +99,9 @@ class BailianProvider(BaseProvider):
     - STT: Paraformer / Fun-ASR realtime recognition (local files)
     - Image: Wanxiang async image generation / editing
     - Rerank: text ranking
+
+    Model listing is always remote-only (GET /models), same as other providers.
+    On failure the error is propagated; no static fallback list is injected.
     """
 
     models = {
@@ -263,66 +118,23 @@ class BailianProvider(BaseProvider):
 
     async def get_llm_list(self) -> list[dict]:
         """
-        优先从百炼 OpenAI 兼容 /models 远端拉取；
-        失败时回退静态列表，并始终补充 TTS/STT/Image 等远端通常不返回的模型。
+        Fetch available models from Bailian OpenAI-compatible API (GET /models).
 
-        容错策略（官网调整模型列表时不会“出错”）：
-        1. 远端成功：原样收录所有 id（含新增未知模型），仅加类型备注
-        2. 远端失败/空 Key：静态兜底，不抛异常给 WebUI
-        3. 静态列表只做“缺失 id 补充”，绝不覆盖远端同名项
-        4. 类型标签仅用于展示，不影响实际调用
+        Same behavior as OpenAI / SiliconFlow / ModelScope / DeepSeek / Volcengine:
+        - success: return remote models only (optionally type-tagged for display)
+        - failure / empty key / HTTP error: raise and let ProviderManager report it
+        - never inject static/fallback model ids
         """
-        remote: list[dict] = []
-        try:
-            remote = await self._fetch_remote_models()
-        except Exception as e:
-            logger.warning(f"Bailian remote model list failed, using static fallback: {e}")
-
-        # 合并：远端优先，静态补充缺失 id
-        by_id: dict[str, dict] = {}
-        for item in remote:
-            mid = item.get("id")
-            if not mid:
-                continue
-            # 远端模型：推断类型并打标签；未知 id 默认 [LLM]，仍完整保留
-            by_id[mid] = _annotate(item)
-
-        static_groups = (
-            (COSYVOICE_MODELS, "tts"),
-            (STT_MODELS, "stt"),
-            (IMAGE_MODELS, "image"),
-            (EMBEDDING_MODELS, "embedding"),
-            (RERANK_MODELS, "rerank"),
-        )
-        for static_list, mtype in static_groups:
-            for item in static_list:
-                mid = item["id"]
-                if mid not in by_id:
-                    by_id[mid] = _annotate(item, forced_type=mtype)
-
-        # 若远端完全失败，至少给一些常用 LLM 兜底
-        if not remote:
-            for item in self._static_llm_fallback():
-                mid = item["id"]
-                if mid not in by_id:
-                    by_id[mid] = _annotate(item, forced_type="llm")
-
-        return list(by_id.values())
-
-    async def _fetch_remote_models(self) -> list[dict]:
         base_url = resolve_compatible_base_url(self.provider_config).rstrip("/")
         api_key = (self.provider_config.get("api_key") or "").strip()
-        if not api_key:
-            raise ValueError("api_key is empty")
-
         headers = {"Authorization": f"Bearer {api_key}"}
         async with httpx.AsyncClient(timeout=15) as client:
             resp = await client.get(f"{base_url}/models", headers=headers)
             resp.raise_for_status()
             data = resp.json()
 
-        models = []
-        # 兼容多种返回形态，避免官网字段微调导致整表失败
+        models: list[dict] = []
+        # Accept common response shapes, but only keep ids that the API actually returned.
         raw_list = []
         if isinstance(data, dict):
             raw_list = data.get("data") or data.get("models") or []
@@ -331,29 +143,29 @@ class BailianProvider(BaseProvider):
 
         for item in raw_list:
             if not isinstance(item, dict):
-                # 偶发纯字符串 id
                 if isinstance(item, str) and item.strip():
-                    models.append({"id": item.strip(), "name": item.strip(), "description": ""})
+                    models.append(
+                        _annotate(
+                            {
+                                "id": item.strip(),
+                                "name": item.strip(),
+                                "description": "",
+                            }
+                        )
+                    )
                 continue
             model_id = item.get("id") or item.get("model") or item.get("model_id") or ""
             if not model_id:
                 continue
-            models.append({
-                "id": model_id,
-                "name": item.get("name") or model_id,
-                "description": item.get("description") or item.get("owned_by") or "",
-            })
+            models.append(
+                _annotate(
+                    {
+                        "id": model_id,
+                        "name": item.get("name") or model_id,
+                        "description": item.get("description")
+                        or item.get("owned_by")
+                        or "",
+                    }
+                )
+            )
         return models
-
-    @staticmethod
-    def _static_llm_fallback() -> list[dict]:
-        return [
-            {"id": "qwen-plus", "name": "Qwen Plus", "description": "通义千问 Plus"},
-            {"id": "qwen-turbo", "name": "Qwen Turbo", "description": "通义千问 Turbo"},
-            {"id": "qwen-max", "name": "Qwen Max", "description": "通义千问 Max"},
-            {"id": "qwen-long", "name": "Qwen Long", "description": "通义千问 Long"},
-            {"id": "qwen-vl-plus", "name": "Qwen VL Plus", "description": "通义千问视觉 Plus"},
-            {"id": "qwen-vl-max", "name": "Qwen VL Max", "description": "通义千问视觉 Max"},
-            {"id": "deepseek-v3", "name": "DeepSeek V3", "description": "DeepSeek V3（百炼）"},
-            {"id": "deepseek-r1", "name": "DeepSeek R1", "description": "DeepSeek R1（百炼）"},
-        ]

--- a/core/provider/src/aliyun_bailian/provider.py
+++ b/core/provider/src/aliyun_bailian/provider.py
@@ -31,6 +31,7 @@ def _infer_type(model_id: str) -> str:
     """
     Best-effort type inference from model id.
     Used only for display tags; never blocks listing unknown remote models.
+    Order matters: video/tts/stt before broad wan/image prefixes.
     """
     mid = (model_id or "").lower().strip()
     if not mid:
@@ -45,20 +46,39 @@ def _infer_type(model_id: str) -> str:
         or mid.startswith("sensevoice")
     ):
         return "stt"
+    # Video before image: wan2.x-i2v / t2v / r2v / s2v / kf2v / *-video*
+    # must not be tagged as image.
     if (
-        mid.startswith("wan")
-        or mid.startswith("wanx")
-        or "t2i" in mid
-        or "image" in mid
-        or mid.startswith("flux")
+        "video" in mid
+        or "i2v" in mid
+        or "t2v" in mid
+        or "r2v" in mid
+        or "s2v" in mid
+        or "kf2v" in mid
+        or (("i2i" in mid) and ("video" in mid))
+        or mid.endswith("-vace")
     ):
-        return "image"
+        return "video"
     if "embedding" in mid or mid.startswith("text-embedding"):
         return "embedding"
     if "rerank" in mid:
         return "rerank"
-    if "video" in mid or mid.startswith("wan2") and "i2v" in mid:
-        return "video"
+    if (
+        mid.startswith("wanx")
+        or "t2i" in mid
+        or mid.startswith("flux")
+        or ("image" in mid and "video" not in mid)
+        or (
+            mid.startswith("wan")
+            and "i2v" not in mid
+            and "t2v" not in mid
+            and "r2v" not in mid
+            and "s2v" not in mid
+            and "kf2v" not in mid
+            and "video" not in mid
+        )
+    ):
+        return "image"
     return "llm"
 
 
@@ -144,9 +164,14 @@ IMAGE_MODELS = [
         "description": "万相 2.7 标准版（更快）",
     },
     {
+        "id": "wan2.6-image",
+        "name": "Wan 2.6 Image",
+        "description": "万相 2.6 图像生成与编辑（支持参考图/图生图）",
+    },
+    {
         "id": "wan2.6-t2i",
         "name": "Wan 2.6 T2I",
-        "description": "万相 2.6 文生图（推荐）",
+        "description": "万相 2.6 纯文生图（不支持参考图；selfie 请用 wan2.6-image，或开启 auto_route）",
     },
     {
         "id": "wan2.5-t2i-preview",
@@ -215,13 +240,13 @@ RERANK_MODELS = [
 
 class BailianProvider(BaseProvider):
     """
-    阿里云百炼完整提供商。
+    Alibaba Cloud Bailian (DashScope) full provider.
 
-    - LLM / Embedding：OpenAI 兼容接口
-    - TTS：CosyVoice（DashScope SDK）
-    - STT：Paraformer / Fun-ASR 实时识别（本地文件）
-    - Image：万相文生图异步任务
-    - Rerank：文本排序
+    - LLM / Embedding: OpenAI-compatible API
+    - TTS: CosyVoice (DashScope SDK)
+    - STT: Paraformer / Fun-ASR realtime recognition (local files)
+    - Image: Wanxiang async image generation / editing
+    - Rerank: text ranking
     """
 
     models = {

--- a/core/provider/src/aliyun_bailian/schema.json
+++ b/core/provider/src/aliyun_bailian/schema.json
@@ -348,11 +348,23 @@
         "name": "图片尺寸",
         "type": "string",
         "default": "auto",
-        "hint": "默认 auto：不强制比例。可固定 1280*1280 / 2K / 16:9。auto 时从提示词识别（竖图/4k横屏/1920x1080）；1K-8K 按真实分辨率意图换算，并自动钳到当前模型上限",
+        "hint": "默认 auto：不强制比例。可固定 1280*1280 / 2K / 16:9。auto 时从提示词识别（竖图/4k横屏/1920x1080）；1K-8K 按真实分辨率意图换算。自动钳制：图编辑最高 2K；wan2.6-image 纯文本/混排约 1280^2；文生图 pro 最高 4K",
         "locales": {
           "en": {
             "name": "Image Size",
-            "hint": "Default auto. Or fix 1280*1280 / 2K / 16:9. Auto parses prompt (portrait/4k landscape/1920x1080); N K maps to real pixels and clamps to model max"
+            "hint": "Default auto. Or fix 1280*1280 / 2K / 16:9. Auto parses prompt; clamps to edit<=2K, wan2.6-image interleave~1280^2, pro t2i up to 4K"
+          }
+        }
+      },
+      "auto_route": {
+        "name": "自动切换图像模型",
+        "type": "switch",
+        "default": false,
+        "hint": "默认关闭。开启后：纯文生图时 wan2.6-image→wan2.6-t2i；带参考图/selfie 时 wan2.6-t2i 等纯 t2i→wan2.6-image。关闭则始终使用你配置的模型（t2i 不支持参考图会报错）",
+        "locales": {
+          "en": {
+            "name": "Auto-route Image Model",
+            "hint": "Default off. When on: pure t2i may map edit models to t2i, and ref-image may map pure t2i to wan2.6-image. When off, always use the configured model id"
           }
         }
       },


### PR DESCRIPTION
fix(provider): address CodeRabbit review and DashScope constraints for AliyunBailian

- Validate empty base64 / data-url refs before image-to-image
- Pass embedding dimensions only for text-embedding-v3/v4
- Clamp edit sizes to 2K; interleave wan2.6-image to ~1280^2
- Classify r2v/s2v/kf2v as video before wan image fallback
- Enable interleave for text-only wan2.6-image (n=1, max_images=1)
- Enforce CosyVoice timeout via timeout_millis + lock release
- Remove static model-list fallback; remote /models only (fail like other providers)
- Set author to znq19, bump version to 2.4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional automatic routing setting for image generation and editing models.
  * Improved automatic image-size detection and limits across text-to-image and image-editing workflows.
  * Added support for more image reference formats and editing protocols.
  * Improved model classification when retrieving available models.

* **Bug Fixes**
  * Improved image-task polling, timeout handling, and failure reporting.
  * Improved embedding compatibility with custom model identifiers.
  * Increased reliability of speech synthesis requests and timeout handling.

* **Documentation**
  * Updated image-size guidance and provider metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->