### PR TITLE
feat(webui): follow browser theme on first visit

### DIFF
--- a/webui/frontend/src/stores/app.ts
+++ b/webui/frontend/src/stores/app.ts
@@ -11,6 +11,15 @@ function sanitizeTheme(value: string | null): Theme {
   return (ALLOWED_THEMES as readonly string[]).includes(value ?? '') ? (value as Theme) : 'light'
 }
 
+function getInitialTheme(): Theme {
+  const storedTheme = localStorage.getItem('theme')
+  if ((ALLOWED_THEMES as readonly string[]).includes(storedTheme ?? '')) {
+    return storedTheme as Theme
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
 function sanitizeLanguage(value: string | null): Language {
   return (ALLOWED_LANGUAGES as readonly string[]).includes(value ?? '')
     ? (value as Language)
@@ -18,7 +27,7 @@ function sanitizeLanguage(value: string | null): Language {
 }
 
 export const useAppStore = defineStore('app', () => {
-  const theme = ref<Theme>(sanitizeTheme(localStorage.getItem('theme')))
+  const theme = ref<Theme>(getInitialTheme())
   const language = ref<Language>(sanitizeLanguage(localStorage.getItem('language')))
 
   const isDark = ref(theme.value === 'dark')

--- a/webui/frontend/src/stores/app.ts
+++ b/webui/frontend/src/stores/app.ts
@@ -17,7 +17,7 @@ function getInitialTheme(): Theme {
     return storedTheme as Theme
   }
 
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  return window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ? 'dark' : 'light'
 }
 
 function sanitizeLanguage(value: string | null): Language {


### PR DESCRIPTION
## Summary

Make the WebUI use the browser's color-scheme preference when a visitor has not previously selected a theme. Existing saved theme choices continue to take precedence.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Initialize the theme from `prefers-color-scheme` when local storage has no valid theme value.
- Preserve persisted and manually selected themes unchanged.

## Screenshots / Logs

`npm run build` completed successfully.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial theme selection by honoring valid saved preferences and falling back to the device’s system color scheme when needed.
  * Ensured invalid or unavailable saved theme settings no longer cause incorrect initial display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->