### PR TITLE
feat: localize adapter and provider type names

### DIFF
--- a/core/adapter/src/bilibili/manifest.json
+++ b/core/adapter/src/bilibili/manifest.json
@@ -1,12 +1,13 @@
 {
     "name": "BiliBili",
+    "display_name": "BiliBili",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "BiliBili Adapter",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "BiliBili 适配器",
+            "display_name": "BiliBili",
             "description": "BiliBili 平台适配器"
         }
     }

--- a/core/adapter/src/discord/manifest.json
+++ b/core/adapter/src/discord/manifest.json
@@ -1,12 +1,13 @@
 {
     "name": "Discord",
+    "display_name": "Discord",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "Discord Adapter",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "Discord 适配器",
+            "display_name": "Discord",
             "description": "Discord 平台适配器"
         }
     }

--- a/core/adapter/src/qq/manifest.json
+++ b/core/adapter/src/qq/manifest.json
@@ -1,12 +1,13 @@
 {
     "name": "QQ",
+    "display_name": "QQ",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "QQ Adapter",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "QQ 适配器",
+            "display_name": "QQ",
             "description": "QQ 平台适配器"
         }
     }

--- a/core/adapter/src/telegram/manifest.json
+++ b/core/adapter/src/telegram/manifest.json
@@ -1,12 +1,13 @@
 {
     "name": "Telegram",
+    "display_name": "Telegram",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "Telegram Adapter",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "Telegram 适配器",
+            "display_name": "Telegram",
             "description": "Telegram 平台适配器"
         }
     }

--- a/core/adapter/src/weixin_oc/manifest.json
+++ b/core/adapter/src/weixin_oc/manifest.json
@@ -1,12 +1,17 @@
 {
     "name": "WeixinOC",
+    "display_name": "微信个人号",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "个人微信适配器 (OpenClaw)",
     "repo": null,
     "locales": {
+        "zh": {
+            "display_name": "个人微信",
+            "description": "个人微信适配器 (OpenClaw)"
+        },
         "en": {
-            "name": "Weixin OC",
+            "display_name": "WeChat Personal",
             "description": "Personal WeChat Adapter (OpenClaw)"
         }
     }

--- a/core/provider/src/aliyun_bailian/manifest.json
+++ b/core/provider/src/aliyun_bailian/manifest.json
@@ -1,16 +1,17 @@
 {
     "name": "AliyunBailian",
+    "display_name": "Aliyun Bailian",
     "version": "2.4.0",
     "author": "znq19",
     "description": "AliyunBailian (DashScope) full provider: LLM, CosyVoice TTS, STT, Image, Embedding, Rerank.",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "阿里云百炼",
+            "display_name": "阿里云百炼",
             "description": "阿里云百炼完整提供商：大模型 / CosyVoice 语音合成 / 语音识别 / 文生图 / 向量 / 重排序"
         },
         "en": {
-            "name": "AliyunBailian",
+            "display_name": "Aliyun Bailian",
             "description": "AliyunBailian full provider: LLM, CosyVoice TTS, STT, Image, Embedding, Rerank"
         }
     }

--- a/core/provider/src/deepseek/manifest.json
+++ b/core/provider/src/deepseek/manifest.json
@@ -1,12 +1,13 @@
 {
     "name": "DeepSeek",
+    "display_name": "DeepSeek",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "DeepSeek Provider with thinking mode support",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "DeepSeek 提供商",
+            "display_name": "DeepSeek",
             "description": "支持思考模式的 DeepSeek 提供商"
         }
     }

--- a/core/provider/src/gptsovits/manifest.json
+++ b/core/provider/src/gptsovits/manifest.json
@@ -1,12 +1,13 @@
 {
     "name": "GPT-Sovits",
+    "display_name": "GPT-SoVITS",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "GPT-Sovits TTS Provider",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "GPT-Sovits",
+            "display_name": "GPT-SoVITS",
             "description": "GPT-Sovits 文本转语音提供商"
         }
     }

--- a/core/provider/src/modelscope/manifest.json
+++ b/core/provider/src/modelscope/manifest.json
@@ -1,12 +1,13 @@
 {
     "name": "ModelScope",
+    "display_name": "ModelScope",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "ModelScope Provider",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "ModelScope 提供商",
+            "display_name": "ModelScope（魔搭）",
             "description": "ModelScope 提供商"
         }
     }

--- a/core/provider/src/openai/manifest.json
+++ b/core/provider/src/openai/manifest.json
@@ -1,12 +1,13 @@
 {
     "name": "OpenAI",
+    "display_name": "OpenAI",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "OpenAI Provider",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "OpenAI 提供商",
+            "display_name": "OpenAI",
             "description": "OpenAI 提供商"
         }
     }

--- a/core/provider/src/siliconflow_cn/manifest.json
+++ b/core/provider/src/siliconflow_cn/manifest.json
@@ -1,16 +1,17 @@
 {
     "name": "SiliconflowCN",
+    "display_name": "SiliconFlow CN",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "硅基流动CN提供商",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "硅基流动 CN",
+            "display_name": "硅基流动 CN",
             "description": "硅基流动 CN 提供商"
         },
         "en": {
-            "name": "SiliconFlow CN",
+            "display_name": "SiliconFlow CN",
             "description": "SiliconFlow CN Provider"
         }
     }

--- a/core/provider/src/volcengine/manifest.json
+++ b/core/provider/src/volcengine/manifest.json
@@ -1,12 +1,13 @@
 {
     "name": "Volcengine",
+    "display_name": "Volcengine",
     "version": "1.0.0",
     "author": "KiraAI",
     "description": "Volcengine Provider",
     "repo": null,
     "locales": {
         "zh": {
-            "name": "火山引擎",
+            "display_name": "火山引擎",
             "description": "火山引擎提供商"
         }
     }

--- a/webui/frontend/src/api/adapter.ts
+++ b/webui/frontend/src/api/adapter.ts
@@ -1,9 +1,15 @@
 import apiClient from './client'
-import type { AdapterBase, AdapterResponse } from '@/types'
+import type { AdapterBase, AdapterPlatform, AdapterResponse } from '@/types'
+import type { AxiosPromise } from 'axios'
 
-export function getAdapterPlatforms() {
-  return apiClient.get<string[]>('/adapter-platforms')
+export function getAdapterPlatforms(details: true): AxiosPromise<AdapterPlatform[]>
+export function getAdapterPlatforms(details?: false): AxiosPromise<string[]>
+export function getAdapterPlatforms(details = false) {
+  return apiClient.get<string[] | AdapterPlatform[]>('/adapter-platforms', {
+    params: details ? { details: true } : undefined,
+  })
 }
+
 
 export function getAdapterSchema(platform: string) {
   return apiClient.get<any>(`/adapters/schema/${encodeURIComponent(platform)}`)

--- a/webui/frontend/src/api/provider.ts
+++ b/webui/frontend/src/api/provider.ts
@@ -1,8 +1,13 @@
 import apiClient from './client'
-import type { ProviderBase, ProviderResponse, ModelCreateRequest, ModelUpdateRequest } from '@/types'
+import type { ProviderBase, ProviderResponse, ProviderType, ModelCreateRequest, ModelUpdateRequest } from '@/types'
+import type { AxiosPromise } from 'axios'
 
-export function getProviderTypes() {
-  return apiClient.get<string[]>('/provider-types')
+export function getProviderTypes(details: true): AxiosPromise<ProviderType[]>
+export function getProviderTypes(details?: false): AxiosPromise<string[]>
+export function getProviderTypes(details = false) {
+  return apiClient.get<string[] | ProviderType[]>('/provider-types', {
+    params: details ? { details: true } : undefined,
+  })
 }
 
 export function getProviderSchema(providerType: string) {

--- a/webui/frontend/src/types/models.ts
+++ b/webui/frontend/src/types/models.ts
@@ -93,12 +93,22 @@ export interface ProviderBase {
   type: string
   status: string
   config: Record<string, any>
+  locales?: Record<string, Record<string, string>>
+}
+
+export interface ProviderType {
+  id: string
+  display_name: string
+  description: string
+  locales: Record<string, Record<string, string>>
 }
 
 export interface ProviderResponse extends ProviderBase {
   id: string
   model_config: Record<string, any>
   supported_model_types: string[]
+  type_display_name: string
+  type_locales: Record<string, Record<string, string>>
 }
 
 export interface ModelCreateRequest {
@@ -119,8 +129,17 @@ export interface AdapterBase {
   config: Record<string, any>
 }
 
+export interface AdapterPlatform {
+  id: string
+  display_name: string
+  description: string
+  locales: Record<string, Record<string, string>>
+}
+
 export interface AdapterResponse extends AdapterBase {
   id: string
+  platform_display_name: string
+  platform_locales: Record<string, Record<string, string>>
 }
 
 export interface PersonaBase {

--- a/webui/frontend/src/views/AdapterView.vue
+++ b/webui/frontend/src/views/AdapterView.vue
@@ -42,7 +42,7 @@
                 {{ adapter.status }}
               </span>
             </div>
-            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 truncate">{{ adapter.platform }}</p>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 truncate">{{ localizePlatform(adapter.platform_display_name, adapter.platform_locales, adapter.platform) }}</p>
           </div>
           <ToggleSwitch
             :model-value="adapter.status === 'active'"
@@ -172,7 +172,7 @@ import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import Modal from '@/components/common/Modal.vue'
 import ToggleSwitch from '@/components/common/ToggleSwitch.vue'
 import { IconPlus, IconTerminal, IconClose } from '@/components/icons'
-import type { AdapterResponse } from '@/types'
+import type { AdapterPlatform, AdapterResponse } from '@/types'
 
 const { t } = useI18n()
 const { localize } = useLocalized()
@@ -182,6 +182,7 @@ const confirmModalRef = ref<InstanceType<typeof ConfirmModal>>()
 
 const adapters = ref<AdapterResponse[]>([])
 const platforms = ref<string[]>([])
+const platformDetails = ref<AdapterPlatform[]>([])
 const dialogVisible = ref(false)
 const editMode = ref(false)
 const editId = ref<string | null>(null)
@@ -196,7 +197,15 @@ const confirmMessage = ref('')
 let deleteTargetId: string | null = null
 
 const platformOptions = computed(() =>
-  platforms.value.map(p => ({ value: p, label: p }))
+  platforms.value.map(id => {
+    const platform = platformDetails.value.find(item => item.id === id)
+    return {
+      value: id,
+      label: platform
+        ? localize(platform, 'display_name', id)
+        : id,
+    }
+  })
 )
 
 const form = ref({
@@ -218,12 +227,24 @@ async function loadAdapters() {
 
 async function loadPlatforms() {
   try {
-    const res = await getAdapterPlatforms()
-    platforms.value = Array.isArray(res.data) ? res.data : []
+    const [idsRes, detailsRes] = await Promise.all([
+      getAdapterPlatforms(),
+      getAdapterPlatforms(true),
+    ])
+    platforms.value = Array.isArray(idsRes.data) ? idsRes.data : []
+    platformDetails.value = Array.isArray(detailsRes.data) ? detailsRes.data : []
   } catch (e) {
     notify(t('adapter.platform_load_failed'), 'error')
     console.error('Failed to load platforms:', e)
   }
+}
+
+function localizePlatform(
+  displayName: string,
+  locales: Record<string, Record<string, string>>,
+  fallback: string,
+) {
+  return localize({ display_name: displayName, locales }, 'display_name', fallback)
 }
 
 function openCreateDialog() {

--- a/webui/frontend/src/views/ProviderView.vue
+++ b/webui/frontend/src/views/ProviderView.vue
@@ -32,7 +32,7 @@
             </div>
             <div class="flex-1 min-w-0">
               <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ provider.name }}</div>
-              <div class="text-xs text-gray-500">{{ provider.type }}</div>
+              <div class="text-xs text-gray-500">{{ localizeProviderType(provider) }}</div>
             </div>
             <span class="px-2 py-1 text-xs rounded-full" :class="provider.status === 'active' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'">
               {{ provider.status }}
@@ -59,7 +59,7 @@
       <div v-else class="flex flex-col flex-1 overflow-y-auto pr-2">
         <div class="border-b border-gray-200 dark:border-gray-700 pb-4 mb-6">
           <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-100 truncate">{{ selectedProvider?.name }}</h3>
-          <p class="text-sm text-gray-500 mt-1 truncate">{{ selectedProvider?.type }}</p>
+          <p class="text-sm text-gray-500 mt-1 truncate">{{ selectedProvider && localizeProviderType(selectedProvider) }}</p>
         </div>
 
         <!-- Provider Config Fields -->
@@ -176,7 +176,7 @@
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{ $t('provider.type') }}</label>
             <CustomSelect
               v-model="createForm.type"
-              :options="providerTypes.map(t => ({ value: t, label: t }))"
+              :options="providerTypes.map(type => ({ value: type.id, label: localize(type, 'display_name', type.id) }))"
               :placeholder="$t('provider.select_type') || 'Select provider type...'"
               @update:modelValue="onCreateTypeChange"
             />
@@ -354,7 +354,7 @@ import CustomSelect from '@/components/common/CustomSelect.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import Modal from '@/components/common/Modal.vue'
 import { IconClose, IconPlus, IconCpu, IconChevronDown, IconRefresh, IconSpinner, IconPulse, IconSliders, IconInfo } from '@/components/icons'
-import type { ProviderResponse } from '@/types'
+import type { ProviderResponse, ProviderType } from '@/types'
 
 const router = useRouter()
 const { t } = useI18n()
@@ -391,7 +391,7 @@ function onConfirmAction() {
 
 const providers = ref<ProviderResponse[]>([])
 const selectedId = ref<string | null>(null)
-const providerTypes = ref<string[]>([])
+const providerTypes = ref<ProviderType[]>([])
 const providerSchema = ref<any>(null)
 const providerConfigValues = ref<Record<string, any>>({})
 const providerModels = ref<Record<string, any>>({})
@@ -454,6 +454,14 @@ function deepClone<T>(obj: T): T {
   } catch {
     return JSON.parse(JSON.stringify(obj))
   }
+}
+
+function localizeProviderType(provider: ProviderResponse) {
+  return localize(
+    { display_name: provider.type_display_name, locales: provider.type_locales },
+    'display_name',
+    provider.type,
+  )
 }
 
 function toggleModelGroup(modelType: string) {
@@ -540,7 +548,7 @@ function openCreateDialog() {
   createSchema.value = null
   createDialogVisible.value = true
   if (providerTypes.value.length === 0) {
-    getProviderTypes().then(res => { providerTypes.value = res.data }).catch(() => {
+    getProviderTypes(true).then(res => { providerTypes.value = res.data }).catch(() => {
       notify(t('provider.load_types_failed'), 'error')
     })
   }

--- a/webui/models.py
+++ b/webui/models.py
@@ -93,6 +93,8 @@ class ProviderResponse(ProviderBase):
     id: str
     model_config_data: Dict = Field(default_factory=dict, alias="model_config")
     supported_model_types: List[str] = Field(default_factory=list)
+    type_display_name: str = ""
+    type_locales: Dict[str, Dict[str, str]] = Field(default_factory=dict)
 
 
 class ModelCreateRequest(BaseModel):
@@ -136,6 +138,8 @@ class AdapterBase(BaseModel):
 
 class AdapterResponse(AdapterBase):
     id: str
+    platform_display_name: str = ""
+    platform_locales: Dict[str, Dict[str, str]] = Field(default_factory=dict)
 
 
 class PersonaBase(BaseModel):

--- a/webui/routes/adapters.py
+++ b/webui/routes/adapters.py
@@ -76,12 +76,25 @@ class AdaptersRoutes(Routes):
             ),
         ]
 
-    async def get_adapter_platforms(self):
+    async def get_adapter_platforms(self, details: bool = False):
+        """Return stable platform IDs for backwards compatibility."""
         try:
             if not self.lifecycle or not getattr(self.lifecycle, "adapter_manager", None):
                 logger.warning("Adapter manager not available for get_adapter_platforms")
                 return []
-            return self.lifecycle.adapter_manager.get_adapter_types()
+            adapter_manager = self.lifecycle.adapter_manager
+            if not details:
+                return adapter_manager.get_adapter_types()
+            return [
+                {
+                    "id": adapter_id,
+                    "display_name": manifest.get("display_name") or adapter_id,
+                    "description": manifest.get("description") or "",
+                    "locales": manifest.get("locales") or {},
+                }
+                for adapter_id in adapter_manager.get_adapter_types()
+                for manifest in [adapter_manager.get_manifest(adapter_id)]
+            ]
         except Exception as e:
             logger.error(f"Error getting adapter platforms: {e}")
             return []
@@ -104,6 +117,26 @@ class AdaptersRoutes(Routes):
             return manifest.get("locales") or {}
         return {}
 
+    def _get_adapter_platform_display(self, platform: str) -> tuple[str, Dict[str, Dict[str, str]]]:
+        if self.lifecycle and getattr(self.lifecycle, "adapter_manager", None):
+            manifest = self.lifecycle.adapter_manager.get_manifest(platform)
+            return manifest.get("display_name") or platform, manifest.get("locales") or {}
+        return platform, {}
+
+    def _adapter_response(self, info, status_value: str) -> AdapterResponse:
+        platform_display_name, platform_locales = self._get_adapter_platform_display(info.platform)
+        return AdapterResponse(
+            id=info.adapter_id,
+            name=info.name,
+            platform=info.platform,
+            status=status_value,
+            description=info.description,
+            config=info.config,
+            locales=self._get_adapter_locales(info.platform),
+            platform_display_name=platform_display_name,
+            platform_locales=platform_locales,
+        )
+
     async def list_adapters(self):
         if self.lifecycle and getattr(self.lifecycle, "adapter_manager", None):
             try:
@@ -115,18 +148,7 @@ class AdaptersRoutes(Routes):
                     adapter_status = (
                         "active" if info.enabled and info.name in running_adapters else "inactive"
                     )
-                    locales = self._get_adapter_locales(info.platform)
-                    adapters.append(
-                        AdapterResponse(
-                            id=info.adapter_id,
-                            name=info.name,
-                            platform=info.platform,
-                            status=adapter_status,
-                            description=info.description,
-                            config=info.config,
-                            locales=locales,
-                        )
-                    )
+                    adapters.append(self._adapter_response(info, adapter_status))
                 return adapters
             except Exception as e:
                 logger.error(f"Error listing adapters from lifecycle: {e}")
@@ -151,16 +173,7 @@ class AdaptersRoutes(Routes):
                     raise HTTPException(status_code=500, detail="Failed to create adapter")
                 running_adapters = set(adapter_mgr.get_adapters().keys())
                 status_value = "active" if info.enabled and info.name in running_adapters else "inactive"
-                locales = self._get_adapter_locales(info.platform)
-                return AdapterResponse(
-                    id=info.adapter_id,
-                    name=info.name,
-                    platform=info.platform,
-                    status=status_value,
-                    description=info.description,
-                    config=info.config,
-                    locales=locales,
-                )
+                return self._adapter_response(info, status_value)
             except HTTPException:
                 raise
             except Exception as e:
@@ -180,16 +193,7 @@ class AdaptersRoutes(Routes):
                     raise HTTPException(status_code=404, detail="Adapter not found")
                 running_adapters = set(adapter_mgr.get_adapters().keys())
                 adapter_status = "active" if info.enabled and info.name in running_adapters else "inactive"
-                locales = self._get_adapter_locales(info.platform)
-                return AdapterResponse(
-                    id=adapter_id,
-                    name=info.name,
-                    platform=info.platform,
-                    status=adapter_status,
-                    description=info.description,
-                    config=info.config,
-                    locales=locales,
-                )
+                return self._adapter_response(info, adapter_status)
             except HTTPException:
                 raise
             except Exception as e:
@@ -215,16 +219,7 @@ class AdaptersRoutes(Routes):
                     raise HTTPException(status_code=404, detail="Adapter not found")
                 running_adapters = set(adapter_mgr.get_adapters().keys())
                 status_value = "active" if info.enabled and info.name in running_adapters else "inactive"
-                locales = self._get_adapter_locales(info.platform)
-                return AdapterResponse(
-                    id=info.adapter_id,
-                    name=info.name,
-                    platform=info.platform,
-                    status=status_value,
-                    description=info.description,
-                    config=info.config,
-                    locales=locales,
-                )
+                return self._adapter_response(info, status_value)
             except HTTPException:
                 raise
             except Exception as e:

--- a/webui/routes/providers.py
+++ b/webui/routes/providers.py
@@ -30,7 +30,6 @@ class ProvidersRoutes(Routes):
                 path="/api/provider-types",
                 methods=["GET"],
                 endpoint=self.get_provider_types,
-                response_model=List[str],
                 tags=["providers"],
                 dependencies=[Depends(require_auth)],
             ),
@@ -134,12 +133,26 @@ class ProvidersRoutes(Routes):
             ),
         ]
 
-    def _get_provider_locales(self, provider_type: str) -> Dict[str, Dict[str, str]]:
-        """Get locales dict from provider manifest for the given provider type."""
+    def _get_provider_type_display(self, provider_type: str) -> tuple[str, Dict[str, Dict[str, str]]]:
         if self.lifecycle and self.lifecycle.provider_manager:
             manifest = self.lifecycle.provider_manager.get_manifest(provider_type)
-            return manifest.get("locales") or {}
-        return {}
+            return manifest.get("display_name") or provider_type, manifest.get("locales") or {}
+        return provider_type, {}
+
+    def _provider_response(self, provider_info, status_value: str, model_config: dict) -> ProviderResponse:
+        type_display_name, type_locales = self._get_provider_type_display(provider_info.provider_type)
+        return ProviderResponse(
+            id=provider_info.provider_id,
+            name=provider_info.provider_name,
+            type=provider_info.provider_type,
+            status=status_value,
+            config=provider_info.provider_config,
+            model_config_data=model_config,
+            supported_model_types=self._get_supported_model_types(provider_info.provider_id),
+            locales=type_locales,
+            type_display_name=type_display_name,
+            type_locales=type_locales,
+        )
 
     def _get_supported_model_types(self, provider_id: str) -> List[str]:
         if not self.lifecycle or not self.lifecycle.provider_manager:
@@ -168,12 +181,24 @@ class ProvidersRoutes(Routes):
             logger.error(f"Failed to get supported model types for provider {provider_id}: {e}")
             return []
 
-    async def get_provider_types(self):
+    async def get_provider_types(self, details: bool = False):
         try:
             if not self.lifecycle or not self.lifecycle.provider_manager:
                 logger.warning("Provider manager not available for get_provider_types")
                 return []
-            return self.lifecycle.provider_manager.get_provider_types()
+            provider_manager = self.lifecycle.provider_manager
+            if not details:
+                return provider_manager.get_provider_types()
+            return [
+                {
+                    "id": provider_type,
+                    "display_name": manifest.get("display_name") or provider_type,
+                    "description": manifest.get("description") or "",
+                    "locales": manifest.get("locales") or {},
+                }
+                for provider_type in provider_manager.get_provider_types()
+                for manifest in [provider_manager.get_manifest(provider_type)]
+            ]
         except Exception as e:
             logger.error(f"Error getting provider types: {e}")
             return []
@@ -217,20 +242,11 @@ class ProvidersRoutes(Routes):
                 continue
             is_active = provider_id in active_providers
             config = self.lifecycle.kira_config.get("providers", {}).get(provider_id, {})
-            supported_model_types = self._get_supported_model_types(provider_id)
-            locales = self._get_provider_locales(provider_info.provider_type)
-            providers.append(
-                ProviderResponse(
-                    id=provider_info.provider_id,
-                    name=provider_info.provider_name,
-                    type=provider_info.provider_type,
-                    status="active" if is_active else "inactive",
-                    config=provider_info.provider_config,
-                    model_config_data=config.get("model_config", {}),
-                    supported_model_types=supported_model_types,
-                    locales=locales,
-                )
-            )
+            providers.append(self._provider_response(
+                provider_info,
+                "active" if is_active else "inactive",
+                config.get("model_config", {}),
+            ))
         return providers
 
     async def create_provider(self, payload: ProviderBase):
@@ -262,16 +278,11 @@ class ProvidersRoutes(Routes):
             self.lifecycle.kira_config.save_config()
             config_for_instantiation = generated_config.copy()
             self.lifecycle.provider_manager.set_provider(provider_id, config_for_instantiation)
-            locales = self._get_provider_locales(provider_type)
-            return ProviderResponse(
-                id=provider_id,
-                name=payload.name or provider_id,
-                type=provider_type,
-                status="active",
-                config=generated_config["provider_config"],
-                model_config_data=generated_config.get("model_config", {}),
-                supported_model_types=self._get_supported_model_types(provider_id),
-                locales=locales,
+            provider_info = self.lifecycle.provider_manager.get_provider_info(provider_id)
+            if not provider_info:
+                raise HTTPException(status_code=500, detail="Failed to read created provider")
+            return self._provider_response(
+                provider_info, "active", generated_config.get("model_config", {})
             )
         except Exception as e:
             logger.error(f"Error creating provider: {e}")
@@ -284,16 +295,8 @@ class ProvidersRoutes(Routes):
             if not provider_info:
                 raise HTTPException(status_code=404, detail="Provider not found")
             config = self.lifecycle.kira_config.get("providers", {}).get(provider_id, {})
-            locales = self._get_provider_locales(provider_info.provider_type)
-            return ProviderResponse(
-                id=provider_info.provider_id,
-                name=provider_info.provider_name,
-                type=provider_info.provider_type,
-                status="active" if provider_inst else "inactive",
-                config=provider_info.provider_config,
-                model_config_data=config.get("model_config", {}),
-                supported_model_types=self._get_supported_model_types(provider_id),
-                locales=locales,
+            return self._provider_response(
+                provider_info, "active" if provider_inst else "inactive", config.get("model_config", {})
             )
         provider = self._providers.get(provider_id)
         if not provider:
@@ -313,16 +316,11 @@ class ProvidersRoutes(Routes):
             self.lifecycle.kira_config.save_config()
             config_for_instantiation = config.copy()
             self.lifecycle.provider_manager.set_provider(provider_id, config_for_instantiation)
-            locales = self._get_provider_locales(config.get("format", "unknown"))
-            return ProviderResponse(
-                id=provider_id,
-                name=config.get("name", provider_id),
-                type=config.get("format", "unknown"),
-                status="active",
-                config=config["provider_config"],
-                model_config_data=config.get("model_config", {}),
-                supported_model_types=self._get_supported_model_types(provider_id),
-                locales=locales,
+            provider_info = self.lifecycle.provider_manager.get_provider_info(provider_id)
+            if not provider_info:
+                raise HTTPException(status_code=500, detail="Failed to read updated provider")
+            return self._provider_response(
+                provider_info, "active", config.get("model_config", {})
             )
         provider = self._providers.get(provider_id)
         if not provider:


### PR DESCRIPTION
## Summary

Adds localized display names for adapter and provider types while preserving their existing stable internal IDs for plugin compatibility.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Added `display_name` and localized `display_name` fields to built-in adapter and provider manifests.
- Kept the existing adapter/provider type APIs backward compatible by returning internal IDs by default; WebUI requests optional display metadata from the same endpoints.
- Updated WebUI adapter and provider type labels to use localized display names while continuing to submit internal IDs.

## Screenshots / Logs

No screenshots captured. `npm run build`, Python compilation, manifest validation, and `git diff --check` passed locally.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized display names and descriptions for provider types and adapter platforms.
  * Provider and adapter lists, headers, and selection menus now show localized labels instead of internal identifiers.
  * Added optional detailed metadata to provider-type and adapter-platform API responses.
  * Improved WeChat Personal adapter naming across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->