### PR TITLE
fix: restore plugin widgets after re-enable

### DIFF
--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -1466,9 +1466,9 @@ class PluginManager:
         for tag in comp.tags:
             tag_registry.unregister(tag.get("name"))
 
-        # clean up widget registration
-        comp.widgets.clear()
-        comp.widget_funcs.clear()
+        # Widget declarations are module-level metadata, just like API and page
+        # declarations.  Keep them across disable/enable so init_plugin() can
+        # make them available again without re-importing the plugin module.
 
         # clean up FastAPI routes (API routes, page routes, static mounts)
         self._remove_plugin_routes(plugin_id)

--- a/tests/test_plugin_widget_lifecycle.py
+++ b/tests/test_plugin_widget_lifecycle.py
@@ -1,0 +1,27 @@
+from core.plugin import plugin_registry
+
+
+def test_cleanup_preserves_widget_declarations(monkeypatch):
+    """Widgets must remain declared so a disabled plugin can be re-enabled."""
+    plugin_id = "widget_lifecycle_test"
+    components = plugin_registry.PluginComponents()
+
+    def status_widget():
+        return "ready"
+
+    components.register_widget(
+        widget_id=f"{plugin_id}:status_widget",
+        label="Status",
+        icon="Box",
+        color="blue",
+        order=0,
+        size="small",
+        func=status_widget,
+    )
+    monkeypatch.setitem(plugin_registry._plugin_components, plugin_id, components)
+
+    manager = plugin_registry.PluginManager(ctx=None)
+    manager._cleanup_plugin_registration(plugin_id)
+
+    assert components.widgets[0]["widget_id"] == f"{plugin_id}:status_widget"
+    assert components.widget_funcs[f"{plugin_id}:status_widget"] is status_widget


### PR DESCRIPTION
## Summary

Fix plugin overview Widgets disappearing after a plugin is disabled and then re-enabled. Widget declarations now follow the same lifecycle as API and page declarations.

## Type of change

- [x] fix: Bug fix
- [x] test: Adding or updating tests

## Changes

- Preserve Widget metadata during plugin cleanup so it can be reused on enable.
- Add a regression test covering the Widget declaration lifecycle.

## Screenshots / Logs

`uv run pytest tests/test_plugin_widget_lifecycle.py -v` — 1 passed.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes
