### PR TITLE
fix(provider): preserve model type during lookup

### DIFF
--- a/core/provider/provider_manager.py
+++ b/core/provider/provider_manager.py
@@ -73,9 +73,14 @@ class ProviderManager:
         manifest = cls._manifests.get(name, {})
         return copy.deepcopy(manifest) if manifest else {}
 
-    def get_model_client(self, provider_id: str, model_id: str) -> Optional[BaseModelClient]:
+    def get_model_client(
+        self,
+        provider_id: str,
+        model_id: str,
+        model_type: Optional[ModelType | str] = None,
+    ) -> Optional[BaseModelClient]:
         provider = self.get_provider(provider_id)
-        model_info = self.get_model_info(provider_id, model_id)
+        model_info = self.get_model_info(provider_id, model_id, model_type)
         if not model_info:
             return
         model_type_enum = model_info.model_type
@@ -89,7 +94,9 @@ class ProviderManager:
 
     def get_default_llm(self) -> LLMModelClient:
         model_info = self.get_default_model_info("default_llm")
-        model_client = self.get_model_client(model_info.provider_id, model_info.model_id)
+        model_client = self.get_model_client(
+            model_info.provider_id, model_info.model_id, model_info.model_type
+        )
         if not isinstance(model_client, LLMModelClient):
             raise TypeError(
                 f"Expected LLMModelClient, got {type(model_client).__name__}"
@@ -98,7 +105,9 @@ class ProviderManager:
 
     def get_default_fast_llm(self) -> LLMModelClient:
         model_info = self.get_default_model_info("default_fast_llm")
-        model_client = self.get_model_client(model_info.provider_id, model_info.model_id)
+        model_client = self.get_model_client(
+            model_info.provider_id, model_info.model_id, model_info.model_type
+        )
         if not isinstance(model_client, LLMModelClient):
             raise TypeError(
                 f"Expected LLMModelClient, got {type(model_client).__name__}"
@@ -107,7 +116,9 @@ class ProviderManager:
 
     def get_default_vlm(self) -> LLMModelClient:
         model_info = self.get_default_model_info("default_vlm")
-        model_client = self.get_model_client(model_info.provider_id, model_info.model_id)
+        model_client = self.get_model_client(
+            model_info.provider_id, model_info.model_id, model_info.model_type
+        )
         if not isinstance(model_client, LLMModelClient):
             raise TypeError(
                 f"Expected LLMModelClient, got {type(model_client).__name__}"
@@ -116,7 +127,9 @@ class ProviderManager:
 
     def get_default_tts(self) -> TTSModelClient:
         model_info = self.get_default_model_info("default_tts")
-        model_client = self.get_model_client(model_info.provider_id, model_info.model_id)
+        model_client = self.get_model_client(
+            model_info.provider_id, model_info.model_id, model_info.model_type
+        )
         if not isinstance(model_client, TTSModelClient):
             raise TypeError(
                 f"Expected TTSModelClient, got {type(model_client).__name__}"
@@ -129,7 +142,9 @@ class ProviderManager:
         except ValueError:
             logger.error("default_stt not configured, please configure it in Configuration")
             raise
-        model_client = self.get_model_client(model_info.provider_id, model_info.model_id)
+        model_client = self.get_model_client(
+            model_info.provider_id, model_info.model_id, model_info.model_type
+        )
         if not isinstance(model_client, STTModelClient):
             raise TypeError(
                 f"Expected STTModelClient, got {type(model_client).__name__}"
@@ -138,7 +153,9 @@ class ProviderManager:
 
     def get_default_image(self) -> ImageModelClient:
         model_info = self.get_default_model_info("default_image")
-        model_client = self.get_model_client(model_info.provider_id, model_info.model_id)
+        model_client = self.get_model_client(
+            model_info.provider_id, model_info.model_id, model_info.model_type
+        )
         if not isinstance(model_client, ImageModelClient):
             raise TypeError(
                 f"Expected ImageModelClient, got {type(model_client).__name__}"
@@ -147,7 +164,9 @@ class ProviderManager:
 
     def get_default_video(self) -> VideoModelClient:
         model_info = self.get_default_model_info("default_video")
-        model_client = self.get_model_client(model_info.provider_id, model_info.model_id)
+        model_client = self.get_model_client(
+            model_info.provider_id, model_info.model_id, model_info.model_type
+        )
         if not isinstance(model_client, VideoModelClient):
             raise TypeError(
                 f"Expected VideoModelClient, got {type(model_client).__name__}"
@@ -156,7 +175,9 @@ class ProviderManager:
 
     def get_default_embedding(self) -> EmbeddingModelClient:
         model_info = self.get_default_model_info("default_embedding")
-        model_client = self.get_model_client(model_info.provider_id, model_info.model_id)
+        model_client = self.get_model_client(
+            model_info.provider_id, model_info.model_id, model_info.model_type
+        )
         if not isinstance(model_client, EmbeddingModelClient):
             raise TypeError(
                 f"Expected EmbeddingModelClient, got {type(model_client).__name__}"
@@ -165,7 +186,9 @@ class ProviderManager:
 
     def get_default_rerank(self) -> RerankModelClient:
         model_info = self.get_default_model_info("default_rerank")
-        model_client = self.get_model_client(model_info.provider_id, model_info.model_id)
+        model_client = self.get_model_client(
+            model_info.provider_id, model_info.model_id, model_info.model_type
+        )
         if not isinstance(model_client, RerankModelClient):
             raise TypeError(
                 f"Expected RerankModelClient, got {type(model_client).__name__}"
@@ -298,14 +321,23 @@ class ProviderManager:
             type_dict[info.model_id] = info.model_config
         return models
 
-    def get_model_info(self, provider_id: str, model_id: str) -> Optional[ModelInfo]:
+    def get_model_info(
+        self,
+        provider_id: str,
+        model_id: str,
+        model_type: Optional[ModelType | str] = None,
+    ) -> Optional[ModelInfo]:
         providers_config = self.kira_config.get("providers", {})
         provider_config = providers_config.get(provider_id) or {}
         provider_instance_config = provider_config.get("provider_config", {}) or {}
         provider_name = provider_config.get("name", provider_id)
         model_config_root = provider_config.get("model_config") or {}
+        if isinstance(model_type, str):
+            model_type = ModelType(model_type)
         for model_type_key, type_models in model_config_root.items():
             if not isinstance(type_models, dict):
+                continue
+            if model_type is not None and model_type_key != model_type.value:
                 continue
             if model_id in type_models:
                 model_cfg = type_models[model_id]
@@ -477,7 +509,7 @@ class ProviderManager:
         :return: {"success": bool, "latency": int (ms), "error": str | None}
         """
         try:
-            model_client = self.get_model_client(provider_id, model_id)
+            model_client = self.get_model_client(provider_id, model_id, model_type)
         except Exception as e:
             return {"success": False, "latency": None, "error": str(e)}
         if not model_client:

--- a/tests/test_provider_manager.py
+++ b/tests/test_provider_manager.py
@@ -1,0 +1,47 @@
+from core.provider import ModelType, ProviderManager
+
+
+class StubConfig(dict):
+    def get_config(self, key: str):
+        value = self
+        for part in key.split("."):
+            value = value[part]
+        return value
+
+
+def build_provider_manager() -> ProviderManager:
+    manager = object.__new__(ProviderManager)
+    manager.kira_config = StubConfig(
+        {
+            "providers": {
+                "provider": {
+                    "name": "Test Provider",
+                    "provider_config": {},
+                    "model_config": {
+                        "image": {"duplicate-model": {"group": "image"}},
+                        "llm": {"duplicate-model": {"group": "llm"}},
+                    },
+                }
+            }
+        }
+    )
+    return manager
+
+
+def test_get_model_info_filters_duplicate_model_ids_by_model_type():
+    manager = build_provider_manager()
+
+    image_info = manager.get_model_info(
+        "provider", "duplicate-model", ModelType.IMAGE
+    )
+    string_image_info = manager.get_model_info(
+        "provider", "duplicate-model", "image"
+    )
+    legacy_info = manager.get_model_info("provider", "duplicate-model")
+
+    assert image_info.model_type is ModelType.IMAGE
+    assert image_info.model_config["group"] == "image"
+    assert string_image_info.model_type is ModelType.IMAGE
+    assert string_image_info.model_config["group"] == "image"
+    assert legacy_info.model_type is ModelType.IMAGE
+    assert legacy_info.model_config["group"] == "image"


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

修复同一提供商下 LLM、图像等不同模型组使用相同模型 ID 时，默认模型可能被错误解析的问题。

## Type of change

<!-- Check the one that applies. -->

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- 为 `get_model_client()` 和 `get_model_info()` 增加可选的 `model_type` 参数。
- 默认模型入口和健康检查显式传递模型类型。
- 保留原有不传 `model_type` 的调用方式，避免影响现有调用方。

## Screenshots / Logs

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes