### PR TITLE
feat(config): add forward message parsing switch

### DIFF
--- a/core/config/default.py
+++ b/core/config/default.py
@@ -38,6 +38,9 @@ DEFAULT_CONFIG = {
             },
             "video_generation": {
                 "enabled": False
+            },
+            "forward_parsing": {
+                "enabled": True
             }
         }
     },

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -350,7 +350,10 @@ class MessageProcessor:
                 else:
                     message_str += f"[Reply ID: {ele.message_id}]"
             elif isinstance(ele, Forward):
-                if ele.chains:
+                caps = self.kira_config.get_config("bot_config.capabilities.forward_parsing", {})
+                if not caps.get("enabled", True):
+                    message_str += "[Forward message]"
+                elif ele.chains:
                     forward_contents = ""
                     for i, chain in enumerate(ele.chains):
                         ele.chains[i].message_list = [x for x in chain if not isinstance(x, Forward)]

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -608,6 +608,7 @@ export default {
       tts_enabled: 'Allow sending voice messages in reply',
       image_generation_enabled: 'Allow generating images via text-to-image and image-to-image',
       video_generation_enabled: 'Allow generating videos via text-to-video',
+      forward_parsing_enabled: 'Parse the content of forwarded messages. When disabled, only a placeholder is kept',
     },
     validation: {
       required: 'This field is required',
@@ -636,6 +637,7 @@ export default {
       tts_enabled: 'Voice Synthesis',
       image_generation_enabled: 'Image Generation',
       video_generation_enabled: 'Video Generation',
+      forward_parsing_enabled: 'Forward Message Parsing',
       max_size_mb: 'Max Storage (MB)',
       max_files: 'Max Files',
       max_age_hours: 'Max Cache Age (hours)',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -609,6 +609,7 @@ export default {
       tts_enabled: '允许在回复中发送语音消息',
       image_generation_enabled: '允许通过文生图和图生图生成图片',
       video_generation_enabled: '允许通过文生视频生成视频',
+      forward_parsing_enabled: '解析转发消息的内容，关闭后仅保留占位符',
     },
     validation: {
       required: '此字段为必填项',
@@ -637,6 +638,7 @@ export default {
       tts_enabled: '语音合成',
       image_generation_enabled: '图片生成',
       video_generation_enabled: '视频生成',
+      forward_parsing_enabled: '解析转发消息',
       max_size_mb: '最大存储（MB）',
       max_files: '最大文件数',
       max_age_hours: '最大缓存时间（小时）',

--- a/webui/frontend/src/views/ConfigView.vue
+++ b/webui/frontend/src/views/ConfigView.vue
@@ -452,6 +452,7 @@ const allGroups: ConfigGroup[] = [
       { key: 'bot_config.capabilities.tts.enabled', labelKey: 'configuration.message.tts_enabled', labelFallback: 'Voice Synthesis', hintKey: 'configuration.hints.tts_enabled', hintFallback: 'Allow sending voice messages in reply', type: 'boolean', default: true },
       { key: 'bot_config.capabilities.image_generation.enabled', labelKey: 'configuration.message.image_generation_enabled', labelFallback: 'Image Generation', hintKey: 'configuration.hints.image_generation_enabled', hintFallback: 'Allow generating images via text-to-image and image-to-image', type: 'boolean', default: true },
       { key: 'bot_config.capabilities.video_generation.enabled', labelKey: 'configuration.message.video_generation_enabled', labelFallback: 'Video Generation', hintKey: 'configuration.hints.video_generation_enabled', hintFallback: 'Allow generating videos via text-to-video', type: 'boolean', default: false },
+      { key: 'bot_config.capabilities.forward_parsing.enabled', labelKey: 'configuration.message.forward_parsing_enabled', labelFallback: 'Forward Message Parsing', hintKey: 'configuration.hints.forward_parsing_enabled', hintFallback: 'Parse the content of forwarded messages. When disabled, only a placeholder is kept', type: 'boolean', default: true },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Adds a `forward_parsing` capability switch that controls whether the content of `Forward` message elements is parsed. Some platforms deliver large forwarded chat logs; expanding them can flood the context window, so users can now turn the expansion off while still letting the model know a forwarded message arrived.

Default is `true`, so existing behavior is unchanged.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- `core/config/default.py`: add `bot_config.capabilities.forward_parsing.enabled` (default `True`).
- `core/message_manager.py`: gate the `Forward` branch of `message_format_to_text`. When disabled, emit a `[Forward message]` placeholder instead of recursively rendering `ele.chains` — mirroring how the existing STT switch degrades to `[Speech recognition disabled]`.
- `webui/frontend/src/views/ConfigView.vue`: new boolean field in the Capabilities group.
- `webui/frontend/src/i18n/{zh,en}.ts`: label and hint for the new field in both locales.

## Screenshots / Logs

Verification so far: `npm run build` (vue-tsc type-check + vite build) passes. The backend switch has not been exercised against a live forwarded message yet.

Note on scope: this gates parsing/rendering, not fetching. Adapters still call the platform API to retrieve forward content before the element reaches `MessageManager` (e.g. `get_forward_msg` in `core/adapter/src/qq/qq.py`). Skipping that round-trip would require each adapter to read the config at parse time — happy to follow up if that's wanted.

## Checklist

- [ ] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
