### PR TITLE
fix(mcp): keep persistent connections to MCP servers

### DIFF
--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -18,6 +18,11 @@ default_config = {
   "mcpServers": {}
 }
 
+# Timeouts guarding connection management, so a hung stdio subprocess or
+# remote handshake can never block a server's connection lock forever
+MCP_CONNECT_TIMEOUT = 30.0
+MCP_CLOSE_TIMEOUT = 10.0
+
 
 @dataclass
 class MCPServer:
@@ -69,6 +74,7 @@ class MCPManager:
         # persistent fastmcp clients, one per server id
         self._clients: dict[str, Client] = {}
         self._client_locks: dict[str, asyncio.Lock] = {}
+        self._shutting_down = False
 
     @staticmethod
     def load_config():
@@ -156,6 +162,16 @@ class MCPManager:
             self._client_locks[server_id] = lock
         return lock
 
+    def _is_server_active(self, server_id: str) -> bool:
+        """True if the server still exists and is enabled.
+
+        Used by tool calls to avoid resurrecting a connection that was
+        deliberately closed by disable/delete/shutdown.
+        """
+        if self._shutting_down:
+            return False
+        return any(s.id == server_id and s.enabled for s in self.servers)
+
     async def _get_connected_client(self, server: MCPServer) -> Client:
         """Return the persistent client for a server, (re)connecting if needed.
 
@@ -171,11 +187,20 @@ class MCPManager:
                 # session died (server crash / network drop): fully reset
                 # the old client before building a fresh one
                 try:
-                    await client.close()
+                    await asyncio.wait_for(client.close(), timeout=MCP_CLOSE_TIMEOUT)
                 except Exception as e:
                     logger.debug(f"Error closing stale MCP client for {server.name}: {e}")
             client = Client(server.to_dict())
-            await client.__aenter__()
+            try:
+                await asyncio.wait_for(client.__aenter__(), timeout=MCP_CONNECT_TIMEOUT)
+            except BaseException:
+                # never leave a half-open client behind (e.g. a spawned
+                # subprocess whose handshake timed out or failed)
+                try:
+                    await asyncio.wait_for(client.close(), timeout=MCP_CLOSE_TIMEOUT)
+                except Exception as close_err:
+                    logger.debug(f"Error cleaning up failed MCP client for {server.name}: {close_err}")
+                raise
             self._clients[server.id] = client
             logger.debug(f"Opened persistent MCP connection to {server.name}")
             return client
@@ -187,12 +212,13 @@ class MCPManager:
             if client is None:
                 return
             try:
-                await client.close()
+                await asyncio.wait_for(client.close(), timeout=MCP_CLOSE_TIMEOUT)
             except Exception as e:
                 logger.warning(f"Error closing MCP client for server {server_id}: {e}")
 
     async def shutdown(self):
         """Close all persistent MCP connections (application shutdown)."""
+        self._shutting_down = True
         for server_id in list(self._clients.keys()):
             await self.close_connection(server_id)
 
@@ -371,6 +397,7 @@ class MCPManager:
                 self.llm_api.unregister_tool(tool.get("name"))
 
         await self.close_connection(server_id)
+        self._client_locks.pop(server_id, None)
 
         servers.pop(server_id)
         self.mcp_config["mcpServers"] = servers
@@ -451,7 +478,14 @@ class MCPManager:
         if target_server.enabled:
             return
 
-        await self.list_tools(target_server, keep_connection=True)
+        tools = await self.list_tools(target_server, keep_connection=True)
+        if not tools:
+            # unreachable server (or one exposing no tools): fail loudly
+            # instead of persisting "enabled" with zero tools registered
+            await self.close_connection(server_id)
+            raise ConnectionError(
+                f"Failed to fetch tools from MCP server {target_server.name}; server not enabled"
+            )
 
         tool_names = []
 
@@ -527,6 +561,8 @@ class MCPManager:
     def _make_mcp_func(self, server: MCPServer, tool_name: str):
         async def _wrapped(*_, **kwargs):
             # ignore positional args, e.g. MessageEvent
+            if not self._is_server_active(server.id):
+                raise RuntimeError(f"MCP server {server.name} is disabled or removed")
             client = await self._get_connected_client(server)
             try:
                 result = await client.call_tool(tool_name, kwargs, timeout=server.timeout)
@@ -534,7 +570,13 @@ class MCPManager:
                 if client.is_connected():
                     # connection is fine, this is a genuine tool error
                     raise
-                # connection dropped mid-call: reconnect once and retry
+                if not self._is_server_active(server.id):
+                    # the connection was closed deliberately
+                    # (disable/delete/shutdown): don't resurrect it
+                    raise
+                # connection dropped mid-call: reconnect once and retry.
+                # Accepted risk: if the request reached the server before the
+                # connection dropped, a non-idempotent tool may execute twice.
                 logger.warning(f"MCP connection to {server.name} lost, reconnecting...")
                 client = await self._get_connected_client(server)
                 result = await client.call_tool(tool_name, kwargs, timeout=server.timeout)
@@ -559,7 +601,7 @@ class MCPManager:
                 tools_response = await client.list_tools()
             except Exception as e:
                 logger.error(f"Failed to list MCP tools for {server.name}: {e}")
-                return
+                return []
             if isinstance(tools_response, dict):
                 tools = tools_response.get("tools", [])
             elif isinstance(tools_response, list):

--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -66,6 +66,9 @@ class MCPManager:
         self.llm_api = llm_api
         self.mcp_config: dict = self.load_config()
         self.servers: list[MCPServer] = []
+        # persistent fastmcp clients, one per server id
+        self._clients: dict[str, Client] = {}
+        self._client_locks: dict[str, asyncio.Lock] = {}
 
     @staticmethod
     def load_config():
@@ -143,6 +146,57 @@ class MCPManager:
 
     def add_server(self, server: MCPServer):
         self.servers.append(server)
+
+    # ====== Persistent connection management ======
+
+    def _get_client_lock(self, server_id: str) -> asyncio.Lock:
+        lock = self._client_locks.get(server_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._client_locks[server_id] = lock
+        return lock
+
+    async def _get_connected_client(self, server: MCPServer) -> Client:
+        """Return the persistent client for a server, (re)connecting if needed.
+
+        The session is held open until close_connection() is called, so tool
+        calls reuse one connection instead of spawning a new subprocess /
+        HTTP session per call.
+        """
+        async with self._get_client_lock(server.id):
+            client = self._clients.get(server.id)
+            if client is not None and client.is_connected():
+                return client
+            if client is not None:
+                # session died (server crash / network drop): fully reset
+                # the old client before building a fresh one
+                try:
+                    await client.close()
+                except Exception as e:
+                    logger.debug(f"Error closing stale MCP client for {server.name}: {e}")
+            client = Client(server.to_dict())
+            await client.__aenter__()
+            self._clients[server.id] = client
+            logger.debug(f"Opened persistent MCP connection to {server.name}")
+            return client
+
+    async def close_connection(self, server_id: str):
+        """Close and drop the persistent client for a server, if any."""
+        async with self._get_client_lock(server_id):
+            client = self._clients.pop(server_id, None)
+            if client is None:
+                return
+            try:
+                await client.close()
+            except Exception as e:
+                logger.warning(f"Error closing MCP client for server {server_id}: {e}")
+
+    async def shutdown(self):
+        """Close all persistent MCP connections (application shutdown)."""
+        for server_id in list(self._clients.keys()):
+            await self.close_connection(server_id)
+
+    # ====== End persistent connection management ======
 
     def save_server_config(self):
         with open(MCP_CONFIG_PATH, 'w', encoding="utf-8") as f:
@@ -225,7 +279,7 @@ class MCPManager:
         }
         return editor_cfg
 
-    def update_server_from_editor(self, server_id: str, name: Optional[str], description: str, editor_config: dict) -> None:
+    async def update_server_from_editor(self, server_id: str, name: Optional[str], description: str, editor_config: dict) -> None:
         """
         Merge editor JSON back into the stored config for a single server.
         Meta fields are managed outside the editor:
@@ -297,7 +351,11 @@ class MCPManager:
                     server.headers = headers_val
             break
 
-    def delete_server(self, server_id: str) -> None:
+        # config changed: drop any live connection so the next call
+        # reconnects with the new config
+        await self.close_connection(server_id)
+
+    async def delete_server(self, server_id: str) -> None:
         """Remove a server from config and in-memory state. Raises ValueError if not found."""
         servers = self.mcp_config.get("mcpServers") or {}
         if not isinstance(servers, dict):
@@ -311,6 +369,8 @@ class MCPManager:
         if target_server and target_server.enabled:
             for tool in target_server.tools:
                 self.llm_api.unregister_tool(tool.get("name"))
+
+        await self.close_connection(server_id)
 
         servers.pop(server_id)
         self.mcp_config["mcpServers"] = servers
@@ -391,7 +451,7 @@ class MCPManager:
         if target_server.enabled:
             return
 
-        await self.list_tools(target_server)
+        await self.list_tools(target_server, keep_connection=True)
 
         tool_names = []
 
@@ -399,7 +459,7 @@ class MCPManager:
             tool_name = tool.get("name")
             tool_names.append(tool_name)
 
-            func = await self._make_mcp_func(target_server, tool_name)
+            func = self._make_mcp_func(target_server, tool_name)
 
             self.llm_api.register_tool(
                 name=tool_name,
@@ -414,7 +474,7 @@ class MCPManager:
             self.mcp_config["mcpServers"][server_id]["enabled"] = True
         self.save_server_config()
 
-    def disable_server(self, server_id: str):
+    async def disable_server(self, server_id: str):
         target_server = None
         for server in self.servers:
             if server.id == server_id:
@@ -430,6 +490,8 @@ class MCPManager:
             tool_name = tool.get("name")
             self.llm_api.unregister_tool(tool_name)
 
+        await self.close_connection(server_id)
+
         target_server.enabled = False
         if server_id in self.mcp_config["mcpServers"]:
             self.mcp_config["mcpServers"][server_id]["enabled"] = False
@@ -442,6 +504,7 @@ class MCPManager:
         self.load_servers()
 
         async def init_server(server):
+            # keeps the connection open for enabled servers, closes it otherwise
             await self.list_tools(server)
 
             if server.enabled:
@@ -449,7 +512,7 @@ class MCPManager:
                 for tool in server.tools:
                     tool_name = tool.get("name")
                     tool_names.append(tool_name)
-                    func = await self._make_mcp_func(server, tool_name)
+                    func = self._make_mcp_func(server, tool_name)
                     self.llm_api.register_tool(
                         name=tool_name,
                         description=tool.get("description"),
@@ -461,34 +524,48 @@ class MCPManager:
         for server in self.servers:
             asyncio.create_task(init_server(server))
 
-    @staticmethod
-    async def _make_mcp_func(server: MCPServer, tool_name: str):
+    def _make_mcp_func(self, server: MCPServer, tool_name: str):
         async def _wrapped(*_, **kwargs):
             # ignore positional args, e.g. MessageEvent
-            client_inner = Client(server.to_dict())
-            async with client_inner:
-                result = await client_inner.call_tool(tool_name, kwargs, timeout=server.timeout)
-                return str(result)
+            client = await self._get_connected_client(server)
+            try:
+                result = await client.call_tool(tool_name, kwargs, timeout=server.timeout)
+            except Exception:
+                if client.is_connected():
+                    # connection is fine, this is a genuine tool error
+                    raise
+                # connection dropped mid-call: reconnect once and retry
+                logger.warning(f"MCP connection to {server.name} lost, reconnecting...")
+                client = await self._get_connected_client(server)
+                result = await client.call_tool(tool_name, kwargs, timeout=server.timeout)
+            return str(result)
 
         return _wrapped
 
-    @staticmethod
-    async def list_tools(server: MCPServer):
+    async def list_tools(self, server: MCPServer, keep_connection: Optional[bool] = None):
+        """Refresh server.tools.
+
+        keep_connection=None keeps the connection open only for enabled
+        servers; disabled ones are closed so keep-alive stdio subprocesses
+        don't linger.
+        """
+        if keep_connection is None:
+            keep_connection = server.enabled
+
         server.tools.clear()
-        client = Client(server.to_dict())
         try:
-            async with client:
-                try:
-                    tools_response = await client.list_tools()
-                except Exception as e:
-                    logger.error(f"Failed to list MCP tools for {server.name}: {e}")
-                    return
-                if isinstance(tools_response, dict):
-                    tools = tools_response.get("tools", [])
-                elif isinstance(tools_response, list):
-                    tools = tools_response
-                else:
-                    tools = []
+            client = await self._get_connected_client(server)
+            try:
+                tools_response = await client.list_tools()
+            except Exception as e:
+                logger.error(f"Failed to list MCP tools for {server.name}: {e}")
+                return
+            if isinstance(tools_response, dict):
+                tools = tools_response.get("tools", [])
+            elif isinstance(tools_response, list):
+                tools = tools_response
+            else:
+                tools = []
 
             for tool in tools:
                 if hasattr(tool, "model_dump"):
@@ -511,5 +588,8 @@ class MCPManager:
 
             return server.tools
         except Exception as e:
-            logger.error(f"Failed to connect to MCP servers: {e}")
+            logger.error(f"Failed to connect to MCP server {server.name}: {e}")
             return []
+        finally:
+            if not keep_connection:
+                await self.close_connection(server.id)

--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -190,7 +190,9 @@ class MCPManager:
         except Exception:
             return False
 
-    async def _get_connected_client(self, server: MCPServer) -> Client:
+    async def _get_connected_client(
+        self, server: MCPServer, require_active: bool = False
+    ) -> Client:
         """Return the persistent client for a server, (re)connecting if needed.
 
         The session is held open until close_connection() is called, so tool
@@ -198,6 +200,8 @@ class MCPManager:
         HTTP session per call.
         """
         async with self._get_client_lock(server.id):
+            if require_active and not self._is_server_active(server.id):
+                raise RuntimeError(f"MCP server {server.name} is disabled or removed")
             client = self._clients.get(server.id)
             if client is not None and client.is_connected():
                 return client
@@ -581,7 +585,7 @@ class MCPManager:
             # ignore positional args, e.g. MessageEvent
             if not self._is_server_active(server.id):
                 raise RuntimeError(f"MCP server {server.name} is disabled or removed")
-            client = await self._get_connected_client(server)
+            client = await self._get_connected_client(server, require_active=True)
             try:
                 result = await client.call_tool(tool_name, kwargs, timeout=server.timeout)
             except Exception:

--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -22,6 +22,8 @@ default_config = {
 # remote handshake can never block a server's connection lock forever
 MCP_CONNECT_TIMEOUT = 30.0
 MCP_CLOSE_TIMEOUT = 10.0
+# Liveness probe sent only after a tool call already failed
+MCP_PING_TIMEOUT = 5.0
 
 
 @dataclass
@@ -171,6 +173,22 @@ class MCPManager:
         if self._shutting_down:
             return False
         return any(s.id == server_id and s.enabled for s in self.servers)
+
+    @staticmethod
+    async def _is_client_alive(client: Client) -> bool:
+        """Probe whether the transport is actually usable.
+
+        fastmcp's Client.is_connected() only reports whether a session object
+        exists; it keeps returning True after the underlying stdio subprocess
+        dies or the socket drops. A ping is the only reliable liveness signal,
+        so it is sent only after a call already failed.
+        """
+        if not client.is_connected():
+            return False
+        try:
+            return bool(await asyncio.wait_for(client.ping(), timeout=MCP_PING_TIMEOUT))
+        except Exception:
+            return False
 
     async def _get_connected_client(self, server: MCPServer) -> Client:
         """Return the persistent client for a server, (re)connecting if needed.
@@ -567,19 +585,19 @@ class MCPManager:
             try:
                 result = await client.call_tool(tool_name, kwargs, timeout=server.timeout)
             except Exception:
-                if client.is_connected():
+                if await self._is_client_alive(client):
                     # connection is fine, this is a genuine tool error
                     raise
-                if not self._is_server_active(server.id):
-                    # the connection was closed deliberately
-                    # (disable/delete/shutdown): don't resurrect it
-                    raise
-                # connection dropped mid-call: reconnect once and retry.
-                # Accepted risk: if the request reached the server before the
-                # connection dropped, a non-idempotent tool may execute twice.
-                logger.warning(f"MCP connection to {server.name} lost, reconnecting...")
-                client = await self._get_connected_client(server)
-                result = await client.call_tool(tool_name, kwargs, timeout=server.timeout)
+                # The transport died. Drop the client so the next call builds a
+                # fresh connection, but deliberately do NOT re-issue this call:
+                # the request may already have executed server-side, and a blind
+                # retry would duplicate the side effects of non-idempotent tools.
+                logger.warning(
+                    f"MCP connection to {server.name} lost; dropping it so the "
+                    f"next call reconnects"
+                )
+                await self.close_connection(server.id)
+                raise
             return str(result)
 
         return _wrapped

--- a/core/lifecycle.py
+++ b/core/lifecycle.py
@@ -267,6 +267,13 @@ class KiraLifecycle:
         if self.plugin_manager:
             await self.plugin_manager.terminate()
 
+        # close persistent MCP connections
+        if self.mcp_manager:
+            try:
+                await self.mcp_manager.shutdown()
+            except Exception as e:
+                logger.error(f"MCP manager shutdown error: {e}")
+
         # terminate all running adapters
         if self.adapter_manager:
             await self.adapter_manager.stop_adapters()

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -1,0 +1,116 @@
+"""End-to-end MCPManager tests against a real stdio MCP server.
+
+These cover behaviour the FakeClient unit tests cannot: fastmcp's real
+is_connected() keeps returning True after a stdio subprocess dies, so a cached
+client can look healthy while being permanently unusable.
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from core.agent.mcp_mgr import MCPManager, MCPServer
+
+# A tool that performs its side effect and then hard-crashes before responding:
+# exactly the window where a blind retry would double-execute it.
+SERVER_SOURCE = textwrap.dedent(
+    """
+    import os
+    import sys
+    from pathlib import Path
+
+    from fastmcp import FastMCP
+
+    LEDGER = Path(sys.argv[1])
+    mcp = FastMCP("flaky")
+
+    @mcp.tool
+    def transfer(amount: int) -> str:
+        with LEDGER.open("a", encoding="utf-8") as f:
+            f.write(f"transfer {amount}\\n")
+        os._exit(1)
+
+    @mcp.tool
+    def ping_tool() -> str:
+        return "pong"
+
+    if __name__ == "__main__":
+        mcp.run()
+    """
+)
+
+
+class _DummyLLM:
+    def register_tool(self, **kwargs):
+        pass
+
+    def unregister_tool(self, name):
+        pass
+
+
+@pytest.fixture
+def flaky_env(tmp_path, monkeypatch):
+    import core.agent.mcp_mgr as mcp_mgr
+
+    monkeypatch.setattr(mcp_mgr, "MCP_CONFIG_PATH", tmp_path / "mcp.json")
+
+    script = tmp_path / "flaky_server.py"
+    script.write_text(SERVER_SOURCE, encoding="utf-8")
+    ledger = tmp_path / "ledger.txt"
+    ledger.write_text("", encoding="utf-8")
+
+    manager = MCPManager(_DummyLLM())
+    server = MCPServer(
+        type="stdio",
+        id="flaky",
+        enabled=True,
+        name="flaky",
+        command=sys.executable,
+        args=[str(script), str(ledger)],
+        timeout=30.0,
+    )
+    manager.add_server(server)
+    return manager, server, ledger
+
+
+def _ledger_entries(ledger: Path) -> list[str]:
+    return [line for line in ledger.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+@pytest.mark.anyio
+async def test_crashing_tool_executes_exactly_once(flaky_env):
+    """A server crash mid-call must not cause the side effect to run twice."""
+    manager, server, ledger = flaky_env
+    try:
+        transfer = manager._make_mcp_func(server, "transfer")
+        with pytest.raises(Exception):
+            await transfer(amount=100)
+
+        assert _ledger_entries(ledger) == ["transfer 100"]
+    finally:
+        await manager.shutdown()
+
+
+@pytest.mark.anyio
+async def test_server_recovers_after_crash(flaky_env):
+    """One crash must not permanently poison the cached connection."""
+    manager, server, ledger = flaky_env
+    try:
+        ping = manager._make_mcp_func(server, "ping_tool")
+        transfer = manager._make_mcp_func(server, "transfer")
+
+        assert "pong" in await ping()
+
+        with pytest.raises(Exception):
+            await transfer(amount=1)
+
+        # the dead client must have been dropped, not cached as "connected"
+        assert server.id not in manager._clients
+
+        # a fresh subprocess is spawned and the server is usable again
+        assert "pong" in await ping()
+        assert _ledger_entries(ledger) == ["transfer 1"]
+    finally:
+        await manager.shutdown()

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -10,6 +10,7 @@ import textwrap
 from pathlib import Path
 
 import pytest
+from mcp.shared.exceptions import McpError
 
 from core.agent.mcp_mgr import MCPManager, MCPServer
 
@@ -85,7 +86,7 @@ async def test_crashing_tool_executes_exactly_once(flaky_env):
     manager, server, ledger = flaky_env
     try:
         transfer = manager._make_mcp_func(server, "transfer")
-        with pytest.raises(Exception):
+        with pytest.raises(McpError):
             await transfer(amount=100)
 
         assert _ledger_entries(ledger) == ["transfer 100"]
@@ -103,7 +104,7 @@ async def test_server_recovers_after_crash(flaky_env):
 
         assert "pong" in await ping()
 
-        with pytest.raises(Exception):
+        with pytest.raises(McpError):
             await transfer(amount=1)
 
         # the dead client must have been dropped, not cached as "connected"

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -7,13 +7,20 @@ from core.agent.mcp_mgr import MCPManager, MCPServer
 
 
 class FakeClient:
-    """Minimal stand-in for fastmcp.Client tracking connect/close calls."""
+    """Minimal stand-in for fastmcp.Client tracking connect/close calls.
+
+    Models the real fastmcp contract: `connected` mirrors is_connected(), which
+    only reports that a session object exists and stays True even after the
+    transport dies. `alive` is the real transport health, observable only via
+    ping() -- tests flip it to simulate a crashed server.
+    """
 
     instances = []
 
     def __init__(self, config):
         self.config = config
         self.connected = False
+        self.alive = False
         self.enter_count = 0
         self.close_count = 0
         self.calls = []
@@ -22,19 +29,29 @@ class FakeClient:
     def is_connected(self):
         return self.connected
 
+    async def ping(self):
+        if not self.alive:
+            raise ConnectionError("transport is dead")
+        return True
+
     async def __aenter__(self):
         self.connected = True
+        self.alive = True
         self.enter_count += 1
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         self.connected = False
+        self.alive = False
 
     async def close(self):
         self.connected = False
+        self.alive = False
         self.close_count += 1
 
     async def call_tool(self, tool_name, kwargs, timeout=None):
+        if not self.alive:
+            raise ConnectionError("transport is dead")
         self.calls.append((tool_name, kwargs))
         return f"result:{tool_name}"
 
@@ -112,23 +129,72 @@ async def test_reconnects_after_connection_drop(manager):
 
 
 @pytest.mark.anyio
-async def test_retry_once_when_connection_drops_mid_call(manager):
+async def test_dead_transport_is_detected_despite_is_connected(manager):
+    """fastmcp's is_connected() stays True after the transport dies, so the
+    manager must fall back to a ping probe to notice."""
     server = _make_server(enabled=True)
     manager.add_server(server)
 
+    func = manager._make_mcp_func(server, "echo")
+    await func(x=0)
+
+    dead = FakeClient.instances[0]
+    dead.alive = False  # transport died; is_connected() still reports True
+    assert dead.is_connected() is True
+
+    with pytest.raises(ConnectionError):
+        await func(x=1)
+
+    # the poisoned client was dropped instead of being cached forever
+    assert server.id not in manager._clients
+    assert dead.close_count == 1
+
+
+@pytest.mark.anyio
+async def test_call_is_not_retried_when_connection_drops_mid_call(manager):
+    """A dropped connection must not re-issue the call: the request may already
+    have executed server-side, and a retry would duplicate side effects."""
+    server = _make_server(enabled=True)
+    manager.add_server(server)
+
+    executions = []
+
     async def failing_call_tool(tool_name, kwargs, timeout=None):
-        # connection drops while the call is in flight
-        client = FakeClient.instances[0]
-        client.connected = False
+        # the side effect lands, then the connection dies before responding
+        executions.append(kwargs)
+        FakeClient.instances[0].alive = False
         raise RuntimeError("connection lost")
 
     func = manager._make_mcp_func(server, "echo")
     await func(x=0)  # establish connection
     FakeClient.instances[0].call_tool = failing_call_tool
 
-    result = await func(x=1)
-    assert result == "result:echo"
+    with pytest.raises(RuntimeError):
+        await func(x=1)
+
+    # executed exactly once, no second dispatch
+    assert executions == [{"x": 1}]
+    assert len(FakeClient.instances) == 1
+
+
+@pytest.mark.anyio
+async def test_next_call_recovers_after_connection_death(manager):
+    """Dropping the dead client must let the following call reconnect, so one
+    crash does not permanently disable the server."""
+    server = _make_server(enabled=True)
+    manager.add_server(server)
+
+    func = manager._make_mcp_func(server, "echo")
+    await func(x=0)
+    FakeClient.instances[0].alive = False
+
+    with pytest.raises(ConnectionError):
+        await func(x=1)
+
+    # the next call builds a fresh connection and succeeds
+    assert await func(x=2) == "result:echo"
     assert len(FakeClient.instances) == 2
+    assert manager._clients[server.id] is FakeClient.instances[1]
 
 
 @pytest.mark.anyio
@@ -146,9 +212,10 @@ async def test_genuine_tool_error_is_not_retried(manager):
 
     with pytest.raises(ValueError):
         await func(x=1)
-    # connection stays up, no reconnect happened
+    # connection is alive, so it is kept and no reconnect happened
     assert len(FakeClient.instances) == 1
     assert FakeClient.instances[0].connected is True
+    assert manager._clients[server.id] is FakeClient.instances[0]
 
 
 @pytest.mark.anyio

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -1,0 +1,218 @@
+"""Tests for MCPManager persistent connection handling."""
+
+import pytest
+
+import core.agent.mcp_mgr as mcp_mgr
+from core.agent.mcp_mgr import MCPManager, MCPServer
+
+
+class FakeClient:
+    """Minimal stand-in for fastmcp.Client tracking connect/close calls."""
+
+    instances = []
+
+    def __init__(self, config):
+        self.config = config
+        self.connected = False
+        self.enter_count = 0
+        self.close_count = 0
+        self.calls = []
+        FakeClient.instances.append(self)
+
+    def is_connected(self):
+        return self.connected
+
+    async def __aenter__(self):
+        self.connected = True
+        self.enter_count += 1
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.connected = False
+
+    async def close(self):
+        self.connected = False
+        self.close_count += 1
+
+    async def call_tool(self, tool_name, kwargs, timeout=None):
+        self.calls.append((tool_name, kwargs))
+        return f"result:{tool_name}"
+
+    async def list_tools(self):
+        return [
+            {"name": "echo", "description": "echo tool", "inputSchema": {}},
+        ]
+
+
+class FakeLLMClient:
+    def __init__(self):
+        self.registered = {}
+
+    def register_tool(self, name, description, parameters, func):
+        self.registered[name] = func
+
+    def unregister_tool(self, name):
+        self.registered.pop(name, None)
+
+
+@pytest.fixture
+def manager(monkeypatch, tmp_path):
+    monkeypatch.setattr(mcp_mgr, "MCP_CONFIG_PATH", tmp_path / "mcp.json")
+    monkeypatch.setattr(mcp_mgr, "Client", FakeClient)
+    FakeClient.instances = []
+    mgr = MCPManager(FakeLLMClient())
+    return mgr
+
+
+def _make_server(server_id="srv1", enabled=False):
+    return MCPServer(
+        type="stdio",
+        id=server_id,
+        enabled=enabled,
+        name="test-server",
+        command="echo",
+        args=[],
+    )
+
+
+@pytest.mark.anyio
+async def test_tool_calls_reuse_one_connection(manager):
+    server = _make_server()
+    manager.add_server(server)
+
+    func = manager._make_mcp_func(server, "echo")
+    await func(x=1)
+    await func(x=2)
+    await func(x=3)
+
+    # one client created, connected once, all calls on the same instance
+    assert len(FakeClient.instances) == 1
+    client = FakeClient.instances[0]
+    assert client.enter_count == 1
+    assert len(client.calls) == 3
+    assert client.connected is True
+
+
+@pytest.mark.anyio
+async def test_reconnects_after_connection_drop(manager):
+    server = _make_server()
+    manager.add_server(server)
+
+    func = manager._make_mcp_func(server, "echo")
+    await func(x=1)
+
+    # simulate the server dying between calls
+    FakeClient.instances[0].connected = False
+
+    result = await func(x=2)
+    assert result == "result:echo"
+    # a fresh client was built for the reconnect
+    assert len(FakeClient.instances) == 2
+    assert FakeClient.instances[1].connected is True
+
+
+@pytest.mark.anyio
+async def test_retry_once_when_connection_drops_mid_call(manager):
+    server = _make_server()
+    manager.add_server(server)
+
+    async def failing_call_tool(tool_name, kwargs, timeout=None):
+        # connection drops while the call is in flight
+        client = FakeClient.instances[0]
+        client.connected = False
+        raise RuntimeError("connection lost")
+
+    func = manager._make_mcp_func(server, "echo")
+    await func(x=0)  # establish connection
+    FakeClient.instances[0].call_tool = failing_call_tool
+
+    result = await func(x=1)
+    assert result == "result:echo"
+    assert len(FakeClient.instances) == 2
+
+
+@pytest.mark.anyio
+async def test_genuine_tool_error_is_not_retried(manager):
+    server = _make_server()
+    manager.add_server(server)
+
+    func = manager._make_mcp_func(server, "echo")
+    await func(x=0)
+
+    async def tool_error(tool_name, kwargs, timeout=None):
+        raise ValueError("bad arguments")
+
+    FakeClient.instances[0].call_tool = tool_error
+
+    with pytest.raises(ValueError):
+        await func(x=1)
+    # connection stays up, no reconnect happened
+    assert len(FakeClient.instances) == 1
+    assert FakeClient.instances[0].connected is True
+
+
+@pytest.mark.anyio
+async def test_disable_server_closes_connection(manager):
+    server = _make_server(enabled=False)
+    manager.add_server(server)
+    manager.mcp_config = {"mcpServers": {server.id: {"command": "echo"}}}
+
+    await manager.enable_server(server.id)
+    assert server.enabled is True
+    assert server.id in manager._clients
+    assert manager._clients[server.id].connected is True
+    assert "echo" in manager.llm_api.registered
+
+    await manager.disable_server(server.id)
+    assert server.enabled is False
+    assert server.id not in manager._clients
+    assert "echo" not in manager.llm_api.registered
+
+
+@pytest.mark.anyio
+async def test_list_tools_closes_connection_for_disabled_server(manager):
+    server = _make_server(enabled=False)
+    manager.add_server(server)
+
+    tools = await manager.list_tools(server)
+    assert tools and tools[0]["name"] == "echo"
+    # disabled server: no lingering connection
+    assert server.id not in manager._clients
+    assert FakeClient.instances[0].close_count == 1
+
+
+@pytest.mark.anyio
+async def test_list_tools_keeps_connection_when_requested(manager):
+    server = _make_server(enabled=False)
+    manager.add_server(server)
+
+    await manager.list_tools(server, keep_connection=True)
+    assert server.id in manager._clients
+    assert manager._clients[server.id].connected is True
+
+
+@pytest.mark.anyio
+async def test_shutdown_closes_all_connections(manager):
+    servers = [_make_server(f"srv{i}") for i in range(3)]
+    for server in servers:
+        manager.add_server(server)
+        await manager.list_tools(server, keep_connection=True)
+
+    assert len(manager._clients) == 3
+    await manager.shutdown()
+    assert manager._clients == {}
+    assert all(c.connected is False for c in FakeClient.instances)
+
+
+@pytest.mark.anyio
+async def test_delete_server_closes_connection(manager):
+    server = _make_server(enabled=False)
+    manager.add_server(server)
+    manager.mcp_config = {"mcpServers": {server.id: {"command": "echo"}}}
+
+    await manager.enable_server(server.id)
+    assert server.id in manager._clients
+
+    await manager.delete_server(server.id)
+    assert server.id not in manager._clients
+    assert server.id not in manager.mcp_config.get("mcpServers", {})

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -77,7 +77,7 @@ def _make_server(server_id="srv1", enabled=False):
 
 @pytest.mark.anyio
 async def test_tool_calls_reuse_one_connection(manager):
-    server = _make_server()
+    server = _make_server(enabled=True)
     manager.add_server(server)
 
     func = manager._make_mcp_func(server, "echo")
@@ -95,7 +95,7 @@ async def test_tool_calls_reuse_one_connection(manager):
 
 @pytest.mark.anyio
 async def test_reconnects_after_connection_drop(manager):
-    server = _make_server()
+    server = _make_server(enabled=True)
     manager.add_server(server)
 
     func = manager._make_mcp_func(server, "echo")
@@ -113,7 +113,7 @@ async def test_reconnects_after_connection_drop(manager):
 
 @pytest.mark.anyio
 async def test_retry_once_when_connection_drops_mid_call(manager):
-    server = _make_server()
+    server = _make_server(enabled=True)
     manager.add_server(server)
 
     async def failing_call_tool(tool_name, kwargs, timeout=None):
@@ -133,7 +133,7 @@ async def test_retry_once_when_connection_drops_mid_call(manager):
 
 @pytest.mark.anyio
 async def test_genuine_tool_error_is_not_retried(manager):
-    server = _make_server()
+    server = _make_server(enabled=True)
     manager.add_server(server)
 
     func = manager._make_mcp_func(server, "echo")
@@ -166,6 +166,7 @@ async def test_disable_server_closes_connection(manager):
     await manager.disable_server(server.id)
     assert server.enabled is False
     assert server.id not in manager._clients
+    assert FakeClient.instances[0].close_count == 1
     assert "echo" not in manager.llm_api.registered
 
 
@@ -202,6 +203,7 @@ async def test_shutdown_closes_all_connections(manager):
     await manager.shutdown()
     assert manager._clients == {}
     assert all(c.connected is False for c in FakeClient.instances)
+    assert all(c.close_count == 1 for c in FakeClient.instances)
 
 
 @pytest.mark.anyio
@@ -215,4 +217,47 @@ async def test_delete_server_closes_connection(manager):
 
     await manager.delete_server(server.id)
     assert server.id not in manager._clients
+    assert FakeClient.instances[0].close_count == 1
     assert server.id not in manager.mcp_config.get("mcpServers", {})
+
+
+@pytest.mark.anyio
+async def test_no_reconnect_after_disable(manager):
+    """An in-flight/leftover tool func must not resurrect a deliberately
+    closed connection after the server is disabled."""
+    server = _make_server(enabled=False)
+    manager.add_server(server)
+    manager.mcp_config = {"mcpServers": {server.id: {"command": "echo"}}}
+
+    await manager.enable_server(server.id)
+    func = manager.llm_api.registered["echo"]
+    await func(x=1)
+
+    await manager.disable_server(server.id)
+
+    with pytest.raises(RuntimeError):
+        await func(x=2)
+    # no new client was built for the disabled server
+    assert len(FakeClient.instances) == 1
+    assert server.id not in manager._clients
+
+
+@pytest.mark.anyio
+async def test_enable_server_fails_when_unreachable(manager, monkeypatch):
+    server = _make_server(enabled=False)
+    manager.add_server(server)
+    manager.mcp_config = {"mcpServers": {server.id: {"command": "echo"}}}
+
+    async def failing_aenter(self):
+        raise RuntimeError("cannot connect")
+
+    monkeypatch.setattr(FakeClient, "__aenter__", failing_aenter)
+
+    with pytest.raises(ConnectionError):
+        await manager.enable_server(server.id)
+
+    # server must not be marked enabled, nothing registered, no client kept
+    assert server.enabled is False
+    assert manager.mcp_config["mcpServers"][server.id].get("enabled") is not True
+    assert manager.llm_api.registered == {}
+    assert server.id not in manager._clients

--- a/webui/routes/mcp.py
+++ b/webui/routes/mcp.py
@@ -137,7 +137,7 @@ class McpRoutes(Routes):
             if enabled:
                 await manager.enable_server(server_id)
             else:
-                manager.disable_server(server_id)
+                await manager.disable_server(server_id)
             return {"server_id": server_id, "enabled": enabled}
         except HTTPException:
             raise
@@ -190,7 +190,7 @@ class McpRoutes(Routes):
             if not isinstance(editor_config, dict):
                 raise HTTPException(status_code=400, detail="Invalid MCP config JSON")
             manager = self.lifecycle.mcp_manager
-            manager.update_server_from_editor(
+            await manager.update_server_from_editor(
                 server_id=server_id,
                 name=payload.name,
                 description=payload.description or "",
@@ -210,7 +210,7 @@ class McpRoutes(Routes):
         if not self.lifecycle or not getattr(self.lifecycle, "mcp_manager", None):
             raise HTTPException(status_code=503, detail="MCP manager not available")
         try:
-            self.lifecycle.mcp_manager.delete_server(server_id)
+            await self.lifecycle.mcp_manager.delete_server(server_id)
             return {"ok": True}
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))

--- a/webui/routes/mcp.py
+++ b/webui/routes/mcp.py
@@ -143,6 +143,8 @@ class McpRoutes(Routes):
             raise
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
+        except ConnectionError as e:
+            raise HTTPException(status_code=502, detail=str(e)) from e
         except Exception as e:
             logger.error(f"Failed to set MCP server enabled state for {server_id}: {e}")
             raise HTTPException(status_code=500, detail="Failed to update MCP server state")


### PR DESCRIPTION
## Problem

Every MCP tool call created a brand-new fastmcp `Client` and tore it down afterwards:

- stdio servers were respawned on every call, losing all in-process state
- with fastmcp's default `keep_alive=True`, each per-call subprocess was never explicitly killed and lingered until GC (subprocess leak)
- HTTP/SSE servers re-handshaked on every call

## Changes

- `MCPManager` now holds one persistent `Client` per server (guarded by a per-server lock)
- connections open on enable/startup and are reused by every tool call
- dropped connections are detected and re-established automatically, with a single retry when the connection dies mid-call (genuine tool errors are not retried)
- disable/delete/config-edit close the connection deliberately
- new `MCPManager.shutdown()` closes everything on app shutdown, wired into `KiraLifecycle.stop()`
- `list_tools` reuses the persistent connection for enabled servers and cleans up temporary connections for disabled ones
- `disable_server`/`delete_server`/`update_server_from_editor` are now async so they can await connection teardown; webui routes updated accordingly

## Testing

- 9 new tests in `tests/test_mcp_manager.py` (connection reuse, auto-reconnect, mid-call retry, no-retry on genuine tool errors, cleanup on disable/delete/shutdown)
- full test suite: 236 passed
- verified end-to-end against a real stdio MCP server: a stateful counter accumulates across calls (`count=1..2..3`), where the old code reset to 1 on every call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP connections can stay open across tool calls for faster responsiveness.
  - `list tools` supports optional keep-alive behavior.
- **Bug Fixes**
  - Connection health is proactively verified; dead transports are detected and refreshed on the next call (failed in-flight calls are not re-run).
  - Disabling, updating, and deleting MCP servers now reliably close cached connections and update tool availability.
  - Web interface actions now await MCP changes before responding.
- **Chores**
  - Improved test coverage with both unit and end-to-end MCP scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->