### PR TITLE
fix: avoid recreating default persona

### DIFF
--- a/core/persona/persona_manager.py
+++ b/core/persona/persona_manager.py
@@ -53,8 +53,8 @@ class PersonaManager:
         return success
 
     async def init_persona(self):
-        persona_dict = await self.db.get_persona(persona_id="default")
-        if not persona_dict:
+        personas = await self.db.list_personas()
+        if not personas:
             import time
             await self.db.add_persona(
                 persona_id="default",

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -250,6 +250,18 @@ async def test_init_persona(persona_manager):
 
 
 @pytest.mark.anyio
+async def test_init_persona_does_not_seed_default_when_persona_exists(persona_manager):
+    """Test that initialization does not create a default alongside an existing persona."""
+    persona = PersonaInfo(id="custom", name="Custom", content="Custom content")
+    await persona_manager.create_persona(persona)
+
+    await persona_manager.init_persona()
+
+    personas = await persona_manager.list_personas()
+    assert [item.id for item in personas] == ["custom"]
+
+
+@pytest.mark.anyio
 async def test_get_persona_returns_none_when_no_active(persona_manager):
     """Test that get_persona returns None when no persona is active."""
     # Create default persona but do not activate it


### PR DESCRIPTION
## Summary

Prevent the default persona from being recreated on restart after a user deletes it. The initializer now seeds the default persona only when no personas exist.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [x] test: Adding or updating tests

## Changes

- Check the full persona list during startup initialization.
- Create default only when the persona table is empty.
- Add a regression test covering an existing custom persona.

## Screenshots / Logs

- python -m py_compile core/persona/persona_manager.py tests/test_persona_manager.py passed.
- git diff --check passed.
- python -m pytest tests/test_persona_manager.py -v could not run because pytest is not installed in the environment.

## Checklist

- [ ] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to equirements.txt (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic creation of a default persona when any persona already exists.
  * Preserved existing custom personas during persona initialization.

* **Tests**
  * Added coverage verifying that an existing persona does not trigger default persona creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->