### PR TITLE
feat(webui): add session ID copy button

### DIFF
--- a/webui/frontend/src/assets/main.css
+++ b/webui/frontend/src/assets/main.css
@@ -734,6 +734,9 @@ textarea:focus:hover,
 .dark .text-yellow-600 { color: #fbbf24 !important; }
 .dark .text-red-600 { color: #f87171 !important; }
 
+/* Keep session ID copy feedback visible despite the global dark-mode color overrides. */
+.dark .session-copy-button:hover { color: #93c5fd !important; }
+
 /* Borders / dividers — must hit 3:1 non-text contrast (WCAG 1.4.11) */
 .dark .border-gray-100,
 .dark .border-gray-200 { border-color: rgba(148, 163, 184, 0.24) !important; }

--- a/webui/frontend/src/components/icons.ts
+++ b/webui/frontend/src/components/icons.ts
@@ -78,6 +78,10 @@ export const IconDownload = svgIcon(
   '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />',
 )
 
+export const IconCopy = svgIcon(
+  '<rect x="9" y="9" width="13" height="13" rx="2" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />',
+)
+
 export const IconUpload = svgIcon(
   '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />',
 )

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -675,6 +675,9 @@ export default {
     },
   },
   sessions: {
+    copy_session_id: 'Copy session ID',
+    copy_success: 'Session ID copied',
+    copy_failed: 'Failed to copy session ID',
     title: 'Sessions',
     new: 'New Session',
     no_sessions: 'No active sessions',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -676,6 +676,9 @@ export default {
     },
   },
   sessions: {
+    copy_session_id: '复制会话 ID',
+    copy_success: '会话 ID 已复制',
+    copy_failed: '复制会话 ID 失败',
     title: '会话管理',
     new: '新建会话',
     no_sessions: '无活跃会话',

--- a/webui/frontend/src/views/SessionView.vue
+++ b/webui/frontend/src/views/SessionView.vue
@@ -41,7 +41,18 @@
               </span>
             </td>
             <td class="px-6 py-4">
-              <div class="text-sm text-gray-500 dark:text-gray-400 font-mono break-all max-w-xs">{{ session.session_id || session.id }}</div>
+              <div class="flex items-center gap-2 max-w-xs">
+                <div class="text-sm text-gray-500 dark:text-gray-400 font-mono break-all">{{ session.session_id || session.id }}</div>
+                <button
+                  type="button"
+                  class="shrink-0 text-gray-400 hover:text-blue-600 dark:hover:text-blue-300 transition-colors"
+                  :title="$t('sessions.copy_session_id')"
+                  :aria-label="$t('sessions.copy_session_id')"
+                  @click="copySessionId(session)"
+                >
+                  <IconCopy class="w-4 h-4" />
+                </button>
+              </div>
             </td>
             <td class="px-6 py-4 whitespace-nowrap">
               <div class="text-sm text-gray-500 dark:text-gray-400">{{ session.message_count }}</div>
@@ -125,7 +136,7 @@ import { getSessions, getSession, updateSession, deleteSession } from '@/api/ses
 import MonacoEditor from '@/components/common/MonacoEditor.vue'
 import Modal from '@/components/common/Modal.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
-import { IconPlus, IconClose } from '@/components/icons'
+import { IconPlus, IconClose, IconCopy } from '@/components/icons'
 import type { SessionItem } from '@/types'
 
 const { t } = useI18n()
@@ -154,6 +165,25 @@ async function loadSessions() {
 
 function resolveSessionId(session: SessionItem): string {
   return session.id || session.session_id || ''
+}
+
+function getSessionIdentifier(session: SessionItem): string {
+  return session.id || [session.adapter_name, session.session_type, session.session_id].filter(Boolean).join(':')
+}
+
+async function copySessionId(session: SessionItem) {
+  const sessionIdentifier = getSessionIdentifier(session)
+  if (!sessionIdentifier) {
+    notify(t('sessions.copy_failed'), 'error')
+    return
+  }
+
+  try {
+    await navigator.clipboard.writeText(sessionIdentifier)
+    notify(t('sessions.copy_success'), 'success')
+  } catch {
+    notify(t('sessions.copy_failed'), 'error')
+  }
 }
 
 function getDisplayTitleSource(session: SessionItem): string {

--- a/webui/frontend/src/views/SessionView.vue
+++ b/webui/frontend/src/views/SessionView.vue
@@ -45,7 +45,7 @@
                 <div class="text-sm text-gray-500 dark:text-gray-400 font-mono break-all">{{ session.session_id || session.id }}</div>
                 <button
                   type="button"
-                  class="shrink-0 text-gray-400 hover:text-blue-600 dark:hover:text-blue-300 transition-colors"
+                  class="session-copy-button shrink-0 text-gray-400 hover:text-blue-600 dark:hover:text-blue-300 transition-colors"
                   :title="$t('sessions.copy_session_id')"
                   :aria-label="$t('sessions.copy_session_id')"
                   @click="copySessionId(session)"


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Add a copy button to the sessions page so users can quickly copy the complete session identifier, such as `qq:dm:123456`. Also fix the dark-mode hover feedback that was overridden by the global dark-mode color rules.

## Type of change

- [x] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Add a copy icon beside each session ID on the sessions page.
- Copy the full session identifier through the browser clipboard API.
- Add localized copy tooltip and success/failure notifications in Chinese and English.
- Add a dark-mode hover override for the copy button so the visual feedback is not masked by the global `!important` color rules.

## Screenshots / Logs

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

Validation: `npm run build` passed successfully. Vite emitted only the existing large-chunk warning.
