### PR TITLE
feat(webui): show live character count in persona editor (#75)

### DIFF
--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -252,6 +252,7 @@ export default {
     modal_title: 'Add Persona',
     modal_name_label: 'Persona Name',
     modal_content_label: 'Persona Content',
+    char_count: '{count} characters',
     modal_cancel: 'Cancel',
     modal_save: 'Save',
     format_json: 'JSON',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -252,6 +252,7 @@ export default {
     modal_title: '添加人设',
     modal_name_label: '人设名称',
     modal_content_label: '人设内容',
+    char_count: '{count} 字符',
     modal_cancel: '取消',
     modal_save: '保存',
     format_json: 'JSON',

--- a/webui/frontend/src/views/PersonaView.vue
+++ b/webui/frontend/src/views/PersonaView.vue
@@ -109,9 +109,14 @@
             />
           </div>
           <div class="mb-4">
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              {{ $t('persona.modal_content_label') }}
-            </label>
+            <div class="flex justify-between items-center mb-2">
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                {{ $t('persona.modal_content_label') }}
+              </label>
+              <span class="text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+                {{ t('persona.char_count', { count: charCount }) }}
+              </span>
+            </div>
             <MonacoEditor
               v-model="form.content"
               :language="monacoLanguage"
@@ -210,6 +215,8 @@ const monacoLanguage = computed(() => {
   }
   return map[form.value.format] || 'plaintext'
 })
+
+const charCount = computed(() => form.value.content?.length ?? 0)
 
 function formatLabel(fmt: string) {
   const map: Record<string, string> = {

--- a/webui/frontend/src/views/PersonaView.vue
+++ b/webui/frontend/src/views/PersonaView.vue
@@ -216,7 +216,9 @@ const monacoLanguage = computed(() => {
   return map[form.value.format] || 'plaintext'
 })
 
-const charCount = computed(() => form.value.content?.length ?? 0)
+// Count Unicode code points so that emoji and other non-BMP characters
+// count as one instead of two (UTF-16 surrogate pairs).
+const charCount = computed(() => (form.value.content ? [...form.value.content].length : 0))
 
 function formatLabel(fmt: string) {
   const map: Record<string, string> = {


### PR DESCRIPTION
## Summary

Adds a live character counter next to the "Persona Content" label in the persona create/edit dialog. The count updates in real time as the user types, making it easy to gauge persona length (useful for reasoning about token usage and model behavior). This addresses the gap left by the deprecated `personal.txt` file, which previously gave users an at-a-glance length reference.

Closes #75

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Added a `charCount` computed property in `PersonaView.vue` that derives from `form.content.length`.
- Rendered the count inline to the right of the content label using small muted text with `tabular-nums` so digits align as the count grows.
- Added i18n strings `persona.char_count` for both English (`{count} characters`) and Chinese (`{count} 字符`), using vue-i18n named interpolation.

## Screenshots / Logs

The counter appears in the top-right of the content editor header row and updates live as the user edits the persona text in the Monaco editor.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed (n/a — i18n updated for both EN and ZH per AGENTS.md)
- [x] New dependencies have been added to `requirements.txt` (if applicable) — n/a, no new dependencies
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer — feature is requested in issue #75
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a live character counter next to the persona content field in the create and edit dialog.
  * Introduced new English and Chinese translations for the character count label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->