### PR TITLE
refactor: decouple event bus from message manager

### DIFF
--- a/core/chat/session_manager.py
+++ b/core/chat/session_manager.py
@@ -28,6 +28,7 @@ class SessionManager:
         self.chat_memory_path = CHAT_MEMORY_PATH
 
         self.memory_lock = Lock()
+        self._background_tasks: set[asyncio.Task] = set()
 
         # === Session history ===
         self.chat_memory = self._load_memory(self.chat_memory_path)
@@ -203,7 +204,9 @@ class SessionManager:
             )
             publish_task = self.event_bus.publish(event)
             try:
-                asyncio.create_task(publish_task, name="session_deleted_event")
+                task = asyncio.create_task(publish_task, name="session_deleted_event")
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
             except RuntimeError:
                 publish_task.close()
                 logger.warning("Unable to publish session deletion event outside a running event loop")

--- a/core/chat/session_manager.py
+++ b/core/chat/session_manager.py
@@ -186,7 +186,24 @@ class SessionManager:
         logger.info(f"Memory updated for {session}")
 
     def delete_session(self, session: str):
+        deleted = False
         with self.memory_lock:
+            deleted = session in self.chat_memory
             self.chat_memory.pop(session, None)
             self._save_memory(self.chat_memory, self.chat_memory_path)
         logger.info(f"Memory deleted for {session}")
+
+        if deleted and getattr(self, "event_bus", None):
+            from core.event_bus import SystemEvent
+
+            event = SystemEvent(
+                event_type="session_deleted",
+                payload={"session": session},
+                source="session_manager",
+            )
+            publish_task = self.event_bus.publish(event)
+            try:
+                asyncio.create_task(publish_task, name="session_deleted_event")
+            except RuntimeError:
+                publish_task.close()
+                logger.warning("Unable to publish session deletion event outside a running event loop")

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
-from enum import Enum, auto
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING, Type
 from dataclasses import dataclass, field
 from datetime import datetime
 import uuid
@@ -15,57 +14,42 @@ from core.chat import KiraMessageEvent, KiraCommentEvent
 from core.chat.message_utils import KiraMessageBatchEvent, KiraCustomEvent
 
 
-class EventType(Enum):
-    """事件类型枚举"""
-    KiraAILoaded = auto()
-
-    """When a message arrives, could be KiraMessageEvent, KiraCommentEvent, etc..."""
-    MsgRecv = auto()
-
-    """THe message has been processed and has a result"""
-    MsgResult = auto()
-
-    """The message has been sent to adapter"""
-    MsgSent = auto()
-
-
-# @dataclass
-# class Event:
-#     """统一事件对象"""
-#     event_type: EventType
-#     payload: Any
-#     source: str
-#     timestamp: datetime = field(default_factory=datetime.now)
-#     event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-#     priority: int = 0  # 0 = normal, 1 = high, 2 = critical
-#     metadata: Dict[str, Any] = field(default_factory=dict)
+@dataclass
+class SystemEvent:
+    """统一事件对象"""
+    event_type: str
+    payload: Any
+    source: str
+    timestamp: datetime = field(default_factory=datetime.now)
+    event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    priority: int = 0  # 0 = normal, 1 = high, 2 = critical
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 if TYPE_CHECKING:
-    from core.message_manager import MessageProcessor
     from core.db.service import DatabaseService
 
 
 class EventBus:
     """事件总线"""
 
-    def __init__(self, stats: Statistics, event_queue: asyncio.Queue, message_processor: MessageProcessor,
+    def __init__(self, stats: Statistics, event_queue: asyncio.Queue,
                  db: DatabaseService = None):
         self.stats = stats
         self.db = db
 
         self.event_queue: asyncio.Queue = event_queue
 
-        self.message_processor = message_processor
-
-        # TODO make max concurrent messages as a config
-        self.message_processing_semaphore = asyncio.Semaphore(3)
-
         # subscribers dict：{event_type: [handlers]}
-        self.subscribers: Dict[EventType, List[Callable]] = {}
+        self.subscribers: Dict[Union[str, Type], List[Callable]] = {}
 
-        # event handlers
-        self.event_handlers: Dict[Union[KiraMessageEvent, KiraCommentEvent], Callable]
+        # Built-in events have one fixed owner. Later registrations cannot
+        # replace it, while application-specific events remain multicast.
+        self._single_handler_event_types = {
+            KiraMessageEvent,
+            KiraMessageBatchEvent,
+            KiraCustomEvent,
+        }
 
         # middleware list
         self.middlewares: List[Callable] = []
@@ -88,30 +72,35 @@ class EventBus:
         self._running_event = asyncio.Event()
         self.logger = get_logger("event_bus", "blue")
 
-    async def _dispatch_event(self, event):
-        if isinstance(event, KiraMessageBatchEvent):
-            await self.message_processor.handle_im_batch_message(event)
-            return
-        if isinstance(event, KiraCustomEvent):
-            from core.plugin.plugin_handlers import event_handler_reg, EventType as PluginEventType
-            for handler in event_handler_reg.get_handlers(PluginEventType.ON_CUSTOM_EVENT):
-                filter_name = getattr(handler.handler, '_custom_event_name', None)
-                if filter_name is None or filter_name == event.event_name:
-                    await handler.exec_handler(event)
-            return
-        async with self.message_processing_semaphore:
-            if isinstance(event, KiraMessageEvent):
-                await self.message_processor.handle_im_message(event)
-            elif isinstance(event, KiraCommentEvent):
-                await self.message_processor.handle_cmt_message(event)
+        self.subscribe(KiraCustomEvent, self._dispatch_custom_event)
 
-    def subscribe(self, event_type: EventType, handler: Callable):
+    async def _dispatch_event(self, event):
+        await self._process_event(event)
+
+    async def _dispatch_custom_event(self, event: KiraCustomEvent):
+        from core.plugin.plugin_handlers import event_handler_reg, EventType as PluginEventType
+
+        for handler in event_handler_reg.get_handlers(PluginEventType.ON_CUSTOM_EVENT):
+            filter_name = getattr(handler.handler, '_custom_event_name', None)
+            if filter_name is None or filter_name == event.event_name:
+                await handler.exec_handler(event)
+
+    def subscribe(self, event_type: Union[str, Type], handler: Callable):
         """subscribe event"""
+        if event_type in self._single_handler_event_types:
+            if event_type in self.subscribers:
+                self.logger.warning(
+                    "Handler for built-in event %s is already registered; ignoring replacement",
+                    event_type.__name__,
+                )
+                return
+            self.subscribers[event_type] = [handler]
+            return
         if event_type not in self.subscribers:
             self.subscribers[event_type] = []
         self.subscribers[event_type].append(handler)
 
-    def unsubscribe(self, event_type: EventType, handler: Callable):
+    def unsubscribe(self, event_type: Union[str, Type], handler: Callable):
         """unsubscribe event"""
         if event_type in self.subscribers:
             self.subscribers[event_type].remove(handler)
@@ -162,11 +151,14 @@ class EventBus:
 
     async def _process_event(self, event):
         """处理单个事件"""
-        event_type = event.event_type
+        if isinstance(event, (KiraMessageEvent, KiraMessageBatchEvent, KiraCustomEvent, KiraCommentEvent)):
+            event_type = type(event)
+        else:
+            event_type = getattr(event, "event_type", None)
 
         # 处理所有订阅者
         if event_type in self.subscribers:
-            for handler in self.subscribers[event_type]:
+            for handler in tuple(self.subscribers[event_type]):
                 try:
                     await handler(event)
                 except Exception as e:

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -49,6 +49,7 @@ class EventBus:
             KiraMessageEvent,
             KiraMessageBatchEvent,
             KiraCustomEvent,
+            KiraCommentEvent,
         }
 
         # middleware list
@@ -104,6 +105,8 @@ class EventBus:
         """unsubscribe event"""
         if event_type in self.subscribers:
             self.subscribers[event_type].remove(handler)
+            if not self.subscribers[event_type]:
+                del self.subscribers[event_type]
 
     def add_middleware(self, middleware: Callable):
         """add a middleware"""

--- a/core/lifecycle.py
+++ b/core/lifecycle.py
@@ -13,6 +13,7 @@ from .adapter import AdapterManager
 from .statistics import Statistics
 from .llm_client import LLMClient
 from .event_bus import EventBus
+from core.chat.message_utils import KiraMessageEvent, KiraMessageBatchEvent, KiraCommentEvent
 from .persona import PersonaManager
 from .provider import ProviderManager
 from .plugin import PluginContext, PluginManager
@@ -197,8 +198,12 @@ class KiraLifecycle:
             )
         )
 
-        self.event_bus = EventBus(self.stats, event_queue, self.message_processor, db=self.db_service)
+        self.event_bus = EventBus(self.stats, event_queue, db=self.db_service)
+        self.session_manager.event_bus = self.event_bus
         self.message_processor.event_bus = self.event_bus
+        self.event_bus.subscribe(KiraMessageEvent, self.message_processor.handle_event)
+        self.event_bus.subscribe(KiraMessageBatchEvent, self.message_processor.handle_event)
+        self.event_bus.subscribe(KiraCommentEvent, self.message_processor.handle_event)
 
         # ====== init plugin system ======
         self.plugin_context = PluginContext(

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -188,6 +188,18 @@ class MessageProcessor:
 
         logger.info("MessageProcessor initialized")
 
+    async def handle_event(self, event):
+        """Handle events received from the event bus."""
+        if isinstance(event, KiraMessageBatchEvent):
+            await self.handle_im_batch_message(event)
+            return
+
+        async with self.message_processing_semaphore:
+            if isinstance(event, KiraMessageEvent):
+                await self.handle_im_message(event)
+            elif isinstance(event, KiraCommentEvent):
+                await self.handle_cmt_message(event)
+
     def get_session_lock(self, sid: str) -> Lock:
         """get session lock to avoid sending message simultaneously"""
         if sid not in self.session_locks:


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Decouple the event bus from `MessageProcessor` and introduce `SystemEvent` support for system-level notifications such as session deletion.

## Type of change

<!-- Check the one that applies. -->

- [ ] feat: New feature
- [ ] fix: Bug fix
- [x] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Route built-in message events through class-based `subscribe()` handlers.
- Keep exactly one non-overridable handler for `KiraMessageEvent`, `KiraMessageBatchEvent`, and `KiraCustomEvent`; allow multiple handlers for other event keys.
- Remove the event-bus `EventType` enum and support string event types for generic system events.
- Add `SystemEvent` and publish a `session_deleted` event asynchronously after a session is deleted.
- Move message concurrency control into `MessageProcessor`.

## Screenshots / Logs

Not applicable.

## Checklist

- [ ] I have tested these changes locally (full tests unavailable because `pytest` and `colorlog` are not installed; Python compilation and `git diff --check` passed)
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (not applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [ ] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system events for tracking session deletions.
  * Expanded event handling to support system, message, batch, and comment events.
  * Improved event subscriptions with support for custom event types.

* **Bug Fixes**
  * Session deletion now consistently removes both active and persisted session data.
  * Message and comment events are routed and processed more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->