### PR TITLE
fix(webui): reduce session editor whitespace

### DIFF
--- a/webui/frontend/src/components/common/MonacoEditor.vue
+++ b/webui/frontend/src/components/common/MonacoEditor.vue
@@ -13,11 +13,15 @@ const props = withDefaults(
     language?: string
     height?: number | string
     readOnly?: boolean
+    folding?: boolean
+    stickyScroll?: boolean
   }>(),
   {
     language: 'json',
     height: 500,
     readOnly: false,
+    folding: true,
+    stickyScroll: true,
   },
 )
 
@@ -43,6 +47,9 @@ onMounted(() => {
     theme: appStore.isDark ? 'vs-dark' : 'vs',
     automaticLayout: true,
     readOnly: props.readOnly,
+    folding: props.folding,
+    showFoldingControls: props.folding ? 'mouseover' : 'never',
+    stickyScroll: { enabled: props.stickyScroll },
     minimap: { enabled: false },
     scrollBeyondLastLine: false,
     wordWrap: 'on',

--- a/webui/frontend/src/views/SessionView.vue
+++ b/webui/frontend/src/views/SessionView.vue
@@ -98,6 +98,8 @@
             v-model="editorContent"
             language="json"
             :height="350"
+            :folding="false"
+            :sticky-scroll="false"
             class="border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden"
           />
         </div>


### PR DESCRIPTION
## Summary

修复会话管理页面查看较长会话内容时，Monaco 编辑器因结构化 JSON 导航功能造成额外空白占位的问题。

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- 为通用 Monaco 编辑器增加可选的折叠和粘滞滚动配置。
- 会话管理页面关闭 JSON 折叠解析和粘滞结构导航，保留编辑与滚动能力。

## Screenshots / Logs

未添加截图。已运行 `npm run build`，前端类型检查和生产构建通过。

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to control code folding and sticky scrolling in the code editor.
  - These features remain enabled by default where supported.

- **Improvements**
  - Session editing now provides a simpler editor view by disabling code folding and sticky scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->