### PR TITLE
fix(webui): serve root static files through SPA fallback

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -140,14 +140,6 @@ class KiraWebUI:
 
         self.app.add_middleware(PluginBridgeInjectionMiddleware)
 
-        # Serve the plugin bridge SDK directly so it works before frontend is built
-        bridge_js_path = self.webui_dir / 'frontend' / 'public' / 'plugin-bridge.js'
-        if bridge_js_path.exists():
-            from fastapi.responses import FileResponse as _FileResponse
-            @self.app.get('/plugin-bridge.js', include_in_schema=False)
-            async def serve_bridge_js():
-                return _FileResponse(bridge_js_path, media_type='application/javascript')
-
         # Mount user sticker library
         if self.sticker_dir.exists():
             self.app.mount(

--- a/webui/routes/auth.py
+++ b/webui/routes/auth.py
@@ -178,8 +178,6 @@ class AuthRoutes(Routes):
                     return response
                 if request.method != "GET":
                     return response
-                if "text/html" not in request.headers.get("accept", ""):
-                    return response
                 full_path = request.url.path.lstrip("/")
                 if full_path.startswith(("api/", "assets/", "monacoeditorwork/", "page/")):
                     return response
@@ -200,6 +198,12 @@ class AuthRoutes(Routes):
                             return FileResponse(resolved)
                     except (OSError, ValueError):
                         pass
+                # Only browser navigations should fall back to the SPA shell.
+                # Root-level files must be served regardless of the request's
+                # Accept header, since image and other asset requests do not
+                # include text/html.
+                if "text/html" not in request.headers.get("accept", ""):
+                    return response
                 no_cache_headers = {
                     "Cache-Control": "no-cache, no-store, must-revalidate",
                     "Pragma": "no-cache",


### PR DESCRIPTION
## Summary
Fix root-level WebUI static file delivery on the FastAPI port so files such as `icon.png` and `plugin-bridge.js` are served without individual routes.

## Type of change

- [x] fix: Bug fix
- [ ] feat: New feature
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Serve existing root-level files from the configured frontend `dist` directory regardless of the request `Accept` header.
- Keep SPA fallback limited to HTML navigation requests.
- Remove the dedicated `plugin-bridge.js` route so root static files use one shared path.

## Screenshots / Logs

- `npm run build` passed.
- `python -m compileall -q webui/app.py webui/routes/auth.py` passed.
- Verified `GET /icon.png` on port 5267 returns `200 OK`.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of requests to missing paths so valid files and mounted resources continue to be resolved correctly.
  * Refined SPA fallback behavior to serve the application shell only for browser requests expecting HTML.
  * Removed a redundant direct route for serving the plugin bridge script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->