### PR TITLE
fix: add fallback for session ID copy

### DIFF
--- a/webui/frontend/src/views/SessionView.vue
+++ b/webui/frontend/src/views/SessionView.vue
@@ -173,6 +173,31 @@ function getSessionIdentifier(session: SessionItem): string {
   return session.id || [session.adapter_name, session.session_type, session.session_id].filter(Boolean).join(':')
 }
 
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // Fall back for browsers or embedded contexts that deny Clipboard API access.
+    }
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+
+  try {
+    return document.execCommand('copy')
+  } finally {
+    textarea.remove()
+  }
+}
+
 async function copySessionId(session: SessionItem) {
   const sessionIdentifier = getSessionIdentifier(session)
   if (!sessionIdentifier) {
@@ -180,10 +205,9 @@ async function copySessionId(session: SessionItem) {
     return
   }
 
-  try {
-    await navigator.clipboard.writeText(sessionIdentifier)
+  if (await copyTextToClipboard(sessionIdentifier)) {
     notify(t('sessions.copy_success'), 'success')
-  } catch {
+  } else {
     notify(t('sessions.copy_failed'), 'error')
   }
 }


### PR DESCRIPTION
## Summary

Fixes session ID copying in environments where the modern Clipboard API is unavailable or denied, such as restricted WebViews.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Prefer the Clipboard API and fall back to `document.execCommand('copy')` when it fails.
- Keep existing success and failure notifications when both copy mechanisms are unavailable.

## Screenshots / Logs

Not applicable; the production build completed successfully.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copying session IDs to the clipboard.
  * Added a fallback method for browsers or environments where the standard clipboard function is unavailable or blocked.
  * Copy success is now reported more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->