### PR TITLE
docs: fix README wording/structure, unify Docker commands, add CLI & telemetry docs (Closes #214, #215)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ npm run build    # Type-check (vue-tsc) + build → webui/static/dist/
 ### Docker
 
 ```bash
-docker-compose up
+docker compose up -d
 ```
 
 ## Rules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 
 ### Reporting Bugs
 
-Before opening a new issue, please **[search existing issues](https://github.com/xxynet/KiraAI/issues)** to check if the same bug has already been reported. If you find an existing issue that matches yours, add your information as a comment instead of creating a duplicate.
+Before opening a new issue, please **[search existing issues](https://github.com/xxynet/KiraAI/issues)** to check if the same bug has already been reported. If you find an existing issue that matches yours, add your comment instead of creating a duplicate.
 
 If no existing issue covers your bug, [open a new issue](https://github.com/xxynet/KiraAI/issues/new) with:
 
@@ -114,8 +114,11 @@ The Vite dev server starts on `:3000` and proxies API requests to the Python bac
 ### Docker (optional)
 
 ```bash
-docker compose up --build
+# Pull the prebuilt image (xxynet/kira-ai:latest) and start in the background
+docker compose up -d
 ```
+
+> `docker-compose.yml` references the prebuilt image and has no `build` section, so `--build` is not needed. Stop the container with `docker compose down`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ KiraAI, a modular, multi-platform AI digital life that connects various AI model
 - Easy-to-use WebUI
 - Customizable LLM providers and models
 - Flexible message sending mechanism, various message elements
-- Add-ons, expand the boundarieds of AI digital life
+- Plugins, expand the boundaries of AI digital life
 
 ## 📷 ScreenShots
 
@@ -58,6 +58,24 @@ Go to [Releases](https://github.com/xxynet/KiraAI/releases) and download `Source
 (zip)` from the release tagged latest
 
 Extract zip and run `scripts/run.bat` on Windows or run `scripts/run.sh` on Linux or Mac
+
+### 🐳 Docker (alternative)
+
+Prefer containers? Make sure [Docker](https://docs.docker.com/get-docker/) is installed, then:
+
+```bash
+# Pull the prebuilt image and start in the background
+docker compose up -d
+```
+
+KiraAI will be served at `http://localhost:5267`. Runtime data is persisted under `./data` (mounted to `/app/data` inside the container).
+
+```bash
+docker compose logs -f    # follow logs
+docker compose down       # stop the container
+```
+
+> `docker-compose.yml` pulls `xxynet/kira-ai:latest` from Docker Hub by default and contains no `build` section.
 
 ## 🧪 Development Guide
 
@@ -114,6 +132,61 @@ Run the project & enter webui to configure:
 - Persona
 ...
 
+## 🛠️ CLI Parameters
+
+KiraAI can be launched from the command line. All parameters are optional; sensible defaults are used when omitted.
+
+| Parameter | Description | Default | Example |
+| --- | --- | --- | --- |
+| `--data-dir <path>` | Directory where KiraAI stores runtime data (databases, logs, cache, session files). | `./data` | `kiraai --data-dir /var/lib/kiraai` |
+| `--env <dev\|prod>` | Runtime environment. `dev` enables debug logging, hot reload, and verbose errors; `prod` enables optimized behavior and production-grade logging. Can also be set via the `KIRA_ENV` environment variable. | `prod` | `kiraai --env dev` |
+| `--disable-webui-auth` | Disables authentication for the WebUI. Only recommended on trusted local networks. | Off (auth enabled) | `kiraai --disable-webui-auth` |
+| `--telemetry-server <url>` | Overrides the endpoint that telemetry data is reported to. Can also be set via the `KIRA_TELEMETRY_SERVER` environment variable. | Default KiraAI telemetry endpoint | `kiraai --telemetry-server https://telemetry.example.com` |
+| `--webui-dir <path>` | Path to a custom WebUI static directory (frontend build) to serve instead of the bundled one. | Bundled WebUI | `kiraai --webui-dir ./webui/dist` |
+| `--ignore-webui-version-check` | Skips the WebUI ↔ backend version compatibility check. Useful when running a custom-built or mismatched WebUI version. | Off (version check enabled) | `kiraai --ignore-webui-version-check` |
+
+### Environment variables
+
+| Variable | Description |
+| --- | --- |
+| `KIRA_ENV` | Equivalent to `--env`. Accepted values: `dev`, `prod`. |
+| `KIRA_TELEMETRY_SERVER` | Equivalent to `--telemetry-server`. |
+
+## 📡 Telemetry
+
+KiraAI collects anonymous telemetry data to understand how the project is used, prioritize development efforts, and improve stability. Telemetry is **enabled by default**.
+
+### What is collected
+
+- **Anonymous usage data** — aggregate statistics: message counts per platform, LLM call counts and token usage, average response time.
+- **Runtime environment** — KiraAI version, Python version, OS platform.
+- **Client identifier** — a randomly generated, anonymous installation ID.
+- **Country code** — resolved once at startup via a third-party service (`ip-api.com`, plain HTTP) based on your public IP address.
+
+No chat content, message history, personal information, or file/configuration contents are collected or transmitted.
+
+### Disabling telemetry
+
+Telemetry is on by default. Disable it in either of the following ways:
+
+**Via environment variable** (recommended):
+
+```bash
+KIRA_TELEMETRY_ENABLED=0 python main.py
+```
+
+**Via `system_config.json`** — set `telemetry.enabled` to `false` and restart KiraAI:
+
+```json
+{
+  "telemetry": {
+    "enabled": false
+  }
+}
+```
+
+> Note: there is currently no WebUI switch for telemetry.
+
 ## 🗂️ Project Structure
 
 <details>
@@ -122,6 +195,12 @@ Run the project & enter webui to configure:
 ```
 KiraAI/
   core/               # Core modules
+    event_bus.py        # EventBus: async pub/sub bus for internal & platform events
+    launcher.py         # KiraLauncher: boots the WebUI & lifecycle
+    lifecycle.py        # KiraLifecycle: central manager of all modules & background tasks
+    llm_client.py       # LLMClient: unified LLM client with tool-calling support
+    logging_manager.py  # Colored console logging + rotating file handler
+    temp_monitor.py     # AsyncTempMonitor: async cleanup of temp/cache folders
     adapter/           # Chat platform adapters
     agent/             # Agent executor, MCP & skill management
     chat/              # Session management & message handling

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -19,7 +19,7 @@ KiraAI，一个模块化、跨平台的 AI 数字生命项目，以数字生命�
 - 易于使用的 WebUI
 - 可自定义的 LLM 提供商与模型
 - 灵活的消息发送机制，丰富的消息元素支持
-- 附加功能，可自行拓展数字生命能力边界
+- 插件（Plugin），可自行拓展数字生命能力边界
 
 ## 📷 截图
 
@@ -57,6 +57,24 @@ KiraAI，一个模块化、跨平台的 AI 数字生命项目，以数字生命�
 前往 [Releases](https://github.com/xxynet/KiraAI/releases) 下载标记为 `latest` 的 Release 中的 `Source code
 (zip)`
 解压并执行 `scripts/run.bat` （Windows 用户） 或执行 `scripts/run.sh` （Linux、Mac 用户）
+
+### 🐳 Docker（可选）
+
+更倾向容器部署？请先安装 [Docker](https://docs.docker.com/get-docker/)，然后：
+
+```bash
+# 拉取预构建镜像并后台启动
+docker compose up -d
+```
+
+KiraAI 将运行在 `http://localhost:5267`，运行时数据持久化在 `./data`（容器内挂载至 `/app/data`）。
+
+```bash
+docker compose logs -f    # 查看日志
+docker compose down       # 停止容器
+```
+
+> 默认从 Docker Hub 拉取 `xxynet/kira-ai:latest`，`docker-compose.yml` 中不包含 `build` 段。
 
 ## 🧪 开发指南
 
@@ -113,6 +131,61 @@ scripts/run.sh
 - 人设
 ...
 
+## 🛠️ CLI 参数
+
+KiraAI 支持通过命令行启动，所有参数均为可选，省略时使用合理的默认值。
+
+| 参数 | 说明 | 默认值 | 示例 |
+| --- | --- | --- | --- |
+| `--data-dir <path>` | 指定 KiraAI 存放运行时数据的目录（数据库、日志、缓存、会话文件等）。 | `./data` | `kiraai --data-dir /var/lib/kiraai` |
+| `--env <dev\|prod>` | 指定运行环境。`dev` 开启调试日志、热重载与详细报错；`prod` 使用优化行为与生产级日志。也可通过环境变量 `KIRA_ENV` 设置。 | `prod` | `kiraai --env dev` |
+| `--disable-webui-auth` | 关闭 WebUI 的登录鉴权。仅建议在可信的本地网络中使用。 | 关闭（默认启用鉴权） | `kiraai --disable-webui-auth` |
+| `--telemetry-server <url>` | 覆盖遥测数据上报的服务端地址。也可通过环境变量 `KIRA_TELEMETRY_SERVER` 设置。 | 默认的 KiraAI 遥测服务地址 | `kiraai --telemetry-server https://telemetry.example.com` |
+| `--webui-dir <path>` | 指定自定义 WebUI 静态文件目录（前端构建产物），用于替代内置的 WebUI。 | 内置 WebUI | `kiraai --webui-dir ./webui/dist` |
+| `--ignore-webui-version-check` | 跳过 WebUI 与后端之间的版本兼容性检查。适用于运行自定义构建或版本不匹配的 WebUI 时。 | 关闭（默认检查版本） | `kiraai --ignore-webui-version-check` |
+
+### 环境变量
+
+| 变量 | 说明 |
+| --- | --- |
+| `KIRA_ENV` | 等价于 `--env`，取值 `dev` / `prod`。 |
+| `KIRA_TELEMETRY_SERVER` | 等价于 `--telemetry-server`。 |
+
+## 📡 遥测
+
+KiraAI 会收集匿名遥测数据，用于了解项目使用情况、确定开发优先级并改善稳定性。遥测**默认开启**。
+
+### 收集内容
+
+- **匿名使用数据** —— 汇总统计：各平台消息数、LLM 调用次数与 token 用量、平均响应时间。
+- **运行环境信息** —— KiraAI 版本、Python 版本、操作系统平台。
+- **客户端标识** —— 随机生成的匿名安装 ID。
+- **国家代码** —— 启动时通过第三方服务（`ip-api.com`，明文 HTTP）根据公网 IP 解析一次。
+
+**不会收集**聊天内容、消息记录、个人信息或文件/配置内容。
+
+### 关闭遥测
+
+遥测默认开启，可通过以下任一方式关闭：
+
+**方式一：环境变量（推荐）**
+
+```bash
+KIRA_TELEMETRY_ENABLED=0 python main.py
+```
+
+**方式二：修改 `system_config.json`**，将 `telemetry.enabled` 设为 `false` 并重启 KiraAI：
+
+```json
+{
+  "telemetry": {
+    "enabled": false
+  }
+}
+```
+
+> 注：目前 WebUI 中没有遥测开关。
+
 ## 🗂️ 项目结构
 
 <details>
@@ -121,6 +194,12 @@ scripts/run.sh
 ```
 KiraAI/
   core/               # 核心模块
+    event_bus.py        # 事件总线：内部与平台事件的异步发布/订阅
+    launcher.py         # KiraLauncher：启动 WebUI 与生命周期
+    lifecycle.py        # KiraLifecycle：所有模块与后台任务的核心管理器
+    llm_client.py       # LLMClient：统一 LLM 客户端（含工具调用）
+    logging_manager.py  # 彩色控制台日志 + 滚动文件日志
+    temp_monitor.py     # AsyncTempMonitor：异步清理临时/缓存目录
     adapter/           # 适配器（聊天平台接入）
     agent/             # 代理执行器、MCP 管理、技能管理
     chat/              # 会话管理与消息处理
@@ -147,4 +226,3 @@ KiraAI/
 
 ## ✨ Star History
 [![Star History Chart](https://api.star-history.com/svg?repos=xxynet/KiraAI&type=date&legend=top-left)](https://www.star-history.com/#xxynet/KiraAI&type=date&legend=top-left)
-


### PR DESCRIPTION
## What does this PR do?

Documentation-only changes that close two open issues:

- **#215** — README fixes:
  - `Add-ons, expand the boundarieds` → `Plugins, expand the boundaries` (unify Plugin wording + fix typo)
  - Complete the `core/` top-level module tree with `event_bus.py`, `launcher.py`, `lifecycle.py`, `llm_client.py`, `logging_manager.py`, `temp_monitor.py` (each with a one-line comment)
  - Add a Docker deployment section to Quick Start (verified: `docker-compose.yml` has no `build` section, uses prebuilt image `xxynet/kira-ai:latest`)
- **#214** — New docs:
  - `## CLI Parameters` section with the full parameter table (`--data-dir`, `--env`, `--disable-webui-auth`, `--telemetry-server`, `--webui-dir`, `--ignore-webui-version-check`) and env vars (`KIRA_ENV`, `KIRA_TELEMETRY_SERVER`)
  - `## Telemetry` section disclosing that telemetry is enabled by default, what is collected, and how to disable it (env var `KIRA_TELEMETRY_ENABLED=0` or `system_config.json`)

Both `README.md` and `docs/README.zh.md` are updated in sync. Also unified Docker commands across `CONTRIBUTING.md` (`docker compose up --build` → `docker compose up -d`) and `AGENTS.md` (`docker-compose up` → `docker compose up -d`).

## Related issues

Closes #214
Closes #215

## Checklist

- [x] Docs only — no code changes
- [x] CN/EN docs kept in sync
- [x] Verified against actual repo files (structure tree, docker-compose.yml, CLI args)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Docker deployment instructions, including startup, logging, shutdown, persistence, and service access details.
  * Documented command-line parameters, environment variables, telemetry collection, and opt-out options.
  * Clarified plugin capabilities and expanded project structure descriptions.
  * Updated contributor guidance for reporting issues and managing Docker containers.
  * Synchronized the English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->