### PR TITLE
docs: 修正 Add-ons 用词、补全结构树、统一 Docker 命令、修复 CLAUDE.md 坏链、新增 JSON 配置参考并披露遥测

### DIFF
--- a/@AGENTS.md
+++ b/@AGENTS.md
@@ -1,0 +1,4 @@
+# CLAUDE.md
+
+The AI assistant guide for this repository is maintained in [AGENTS.md](./AGENTS.md) (single source of truth).
+This file exists only for AI tools that do not resolve symbolic links.

--- a/@AGENTS.md
+++ b/@AGENTS.md
@@ -1,4 +1,0 @@
-# CLAUDE.md
-
-The AI assistant guide for this repository is maintained in [AGENTS.md](./AGENTS.md) (single source of truth).
-This file exists only for AI tools that do not resolve symbolic links.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ npm run build    # Type-check (vue-tsc) + build → webui/static/dist/
 ### Docker
 
 ```bash
-docker-compose up
+docker compose up -d
 ```
 
 ## Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,4 @@
-@AGENTS.md
+# CLAUDE.md
+
+The AI assistant guide for this repository is maintained in [AGENTS.md](./AGENTS.md) (single source of truth).
+This file exists only for AI tools that do not resolve symbolic links.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ The Vite dev server starts on `:3000` and proxies API requests to the Python bac
 ### Docker (optional)
 
 ```bash
-docker compose up --build
+docker compose up -d
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Run the project & enter webui to configure:
 - Persona
 ...
 
+> [!NOTE]
+> **Telemetry**: KiraAI collects anonymous usage statistics (version, platform, message/LLM usage counts — **no chat content**) and reports them to `https://telemetry.kira-ai.top`. It is **enabled by default**. To disable it, set the environment variable `KIRA_TELEMETRY_ENABLED=0` or set `"telemetry": { "enabled": false }` in `data/config/system_config.json`.
+
 ## 🗂️ Project Structure
 
 <details>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ KiraAI, a modular, multi-platform AI digital life that connects various AI model
 - Easy-to-use WebUI
 - Customizable LLM providers and models
 - Flexible message sending mechanism, various message elements
-- Add-ons, expand the boundarieds of AI digital life
+- Plugins, expand the boundaries of AI digital life
 
 ## 📷 ScreenShots
 
@@ -58,6 +58,22 @@ Go to [Releases](https://github.com/xxynet/KiraAI/releases) and download `Source
 (zip)` from the release tagged latest
 
 Extract zip and run `scripts/run.bat` on Windows or run `scripts/run.sh` on Linux or Mac
+
+### 🐳 Docker (alternative)
+
+Prefer containers? Make sure [Docker](https://docs.docker.com/get-docker/) is installed, then run:
+
+```bash
+docker compose up -d
+```
+
+KiraAI will be served at `http://localhost:5267`. Runtime state (config, memory, plugins, DB) is persisted under `./data`.
+
+```bash
+docker compose logs -f    # follow logs
+docker compose down       # stop the container
+docker compose pull       # update to the latest image
+```
 
 ## 🧪 Development Guide
 
@@ -122,6 +138,12 @@ Run the project & enter webui to configure:
 ```
 KiraAI/
   core/               # Core modules
+    event_bus.py        # EventBus: async pub/sub bus for internal & platform events
+    launcher.py         # KiraLauncher: boots the WebUI & manages the lifecycle
+    lifecycle.py        # KiraLifecycle: central manager of modules & background tasks
+    llm_client.py       # LLMClient: unified LLM client with tool-calling support
+    logging_manager.py  # Colored console logging + rotating file handler
+    temp_monitor.py     # AsyncTempMonitor: async cleanup of temp/cache folders
     adapter/           # Chat platform adapters
     agent/             # Agent executor, MCP & skill management
     chat/              # Session management & message handling

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -19,7 +19,7 @@ KiraAI，一个模块化、跨平台的 AI 数字生命项目，以数字生命�
 - 易于使用的 WebUI
 - 可自定义的 LLM 提供商与模型
 - 灵活的消息发送机制，丰富的消息元素支持
-- 附加功能，可自行拓展数字生命能力边界
+- 插件，可自行拓展数字生命能力边界
 
 ## 📷 截图
 
@@ -57,6 +57,22 @@ KiraAI，一个模块化、跨平台的 AI 数字生命项目，以数字生命�
 前往 [Releases](https://github.com/xxynet/KiraAI/releases) 下载标记为 `latest` 的 Release 中的 `Source code
 (zip)`
 解压并执行 `scripts/run.bat` （Windows 用户） 或执行 `scripts/run.sh` （Linux、Mac 用户）
+
+### 🐳 Docker 部署（备选）
+
+更喜欢容器化部署？先安装 [Docker](https://docs.docker.com/get-docker/)，然后执行：
+
+```bash
+docker compose up -d
+```
+
+KiraAI 将运行在 `http://localhost:5267`。运行时数据（配置、记忆、插件、数据库）保存在 `./data` 目录。
+
+```bash
+docker compose logs -f    # 查看日志
+docker compose down       # 停止容器
+docker compose pull       # 更新到最新镜像
+```
 
 ## 🧪 开发指南
 
@@ -121,6 +137,12 @@ scripts/run.sh
 ```
 KiraAI/
   core/               # 核心模块
+    event_bus.py        # EventBus：内部与平台事件的异步发布/订阅总线
+    launcher.py         # KiraLauncher：启动 WebUI 并管理生命周期
+    lifecycle.py        # KiraLifecycle：模块与后台任务的统一管理器
+    llm_client.py       # LLMClient：统一 LLM 客户端，支持工具调用
+    logging_manager.py  # 彩色控制台日志 + 轮转文件日志
+    temp_monitor.py     # AsyncTempMonitor：异步清理临时/缓存目录
     adapter/           # 适配器（聊天平台接入）
     agent/             # 代理执行器、MCP 管理、技能管理
     chat/              # 会话管理与消息处理

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -129,6 +129,9 @@ scripts/run.sh
 - 人设
 ...
 
+> [!NOTE]
+> **遥测（Telemetry）**：KiraAI 会收集匿名使用统计（版本、平台、消息/LLM 用量计数——**不含聊天内容**）并上报至 `https://telemetry.kira-ai.top`，**默认开启**。如需关闭，可设置环境变量 `KIRA_TELEMETRY_ENABLED=0`，或将 `data/config/system_config.json` 中的 `"telemetry": { "enabled": false }` 改为 `false`。
+
 ## 🗂️ 项目结构
 
 <details>

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,0 +1,52 @@
+# 配置参考（Configuration Reference）
+
+KiraAI 的全部配置均为 **JSON** 格式，不存在 .ini 配置文件。
+配置文件位于 `data/` 目录下（可用 `--data-dir` 覆盖 `data` 的位置）。
+
+## data/config/system_config.json —— 核心配置
+
+首次启动时若文件不存在，会自动创建（内容为默认值）。
+由 `core/config/config_loader.py` 的 `KiraConfig` 加载；JSON 损坏时会抛出
+`ConfigError`。保存格式：`json.dumps(indent=4, ensure_ascii=False)`。
+
+顶层结构及各段说明：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `bot_config` | object | 机器人行为参数 |
+| `bot_config.bot` | object | `max_memory_length`、`max_message_interval`、`max_buffer_messages`、`min_message_delay`、`max_message_delay`、`dynamic_prompt_position` |
+| `bot_config.agent` | object | `max_tool_loop`、`max_tool_calls_per_turn`、`tool_call_timeout` |
+| `bot_config.selfie` | object | `path`（自拍/头像路径） |
+| `bot_config.cache` | object | `max_size_mb`、`max_files`、`max_age_hours` |
+| `bot_config.capabilities` | object | `image_recognition` / `tts` / `stt` / `image_generation` / `video_generation` / `forward_parsing` 各含 `enabled` |
+| `locale` | object | `lang`、`TZ`（IANA 时区，如 `Asia/Shanghai`） |
+| `onboarding` | object | `completed`、`version` |
+| `providers` | object | 按 ID 存储的提供商配置字典（WebUI 中维护） |
+| `models` | object | 默认模型选择器：`default_llm`、`default_fast_llm`、`default_vlm`、`default_tts`、`default_stt`、`default_image`、`default_embedding`、`default_rerank`、`default_video`（格式 `ProviderID - ModelID`） |
+| `adapters` | object | 按 ID 存储的适配器配置字典（WebUI 中维护） |
+| `network` | object | `pypi_mirror`、`http_proxy` |
+| `telemetry` | object | `enabled`、`client_uuid`、`secret_key` |
+| `database` | object | `url`（默认 None=SQLite）、`echo` |
+| `logging` | object | `log_level`、`log_file_path`（None=`{data}/log.log`）、`log_file_max_size`（MB） |
+
+完整默认值见 `core/config/default.py` 的 `DEFAULT_CONFIG`。
+
+## data/webui.json —— WebUI 运行时配置
+
+由 `core/launcher.py::_load_webui_config` 读取，不存在时自动创建：
+
+```json
+{
+  "host": "0.0.0.0",
+  "port": 5267
+}
+```
+
+`main.py::_get_port` 同样读取该文件的 `port` 决定 WebUI 端口（默认 5267）。
+
+## persona —— 遗留格式说明
+
+旧版 `persona.txt` 为**遗留格式**：启动时若数据库 persona 表为空且文件存在，
+内容会被迁移进数据库作为默认人设（见 `core/db/migrate_to_db.py`），迁移后不再
+使用。新人设由 `PersonaManager` 管理，存于数据库，支持 text / markdown / json /
+yaml 多种格式。


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

本 PR 集中修复仓库文档类问题，共关闭 4 个 Issue：

- Fixes #215：README 拼写错误 `boundarieds` → `boundaries`、`Add-ons` 用词统一为 `Plugins`、补全项目结构树（core/ 顶层模块）、Quick Start 补充 Docker 部署选项
- Fixes #216：CLAUDE.md 为**损坏的符号链接**（指向不存在的 `@AGENTS.md`，AI 工具读取为空）——替换为普通指针文件
- Fixes #214：README 披露遥测默认开启状态及关闭方法（`KIRA_TELEMETRY_ENABLED=0` / `telemetry.enabled=false`）
- Closes #213：新增 `docs/config-reference.md` JSON 配置权威参考（.ini 命名的 DeepWiki 页面为自动生成，据此文档重新抓取即可修正）

## Type of change

- [x] docs: Documentation update

## Changes

- `README.md`：`Add-ons` → `Plugins`、`boundarieds` → `boundaries`；结构树补入 `event_bus.py`/`launcher.py`/`lifecycle.py`/`llm_client.py`/`logging_manager.py`/`temp_monitor.py` 六个顶层模块；新增 Docker 部署小节；Configuration 小节披露遥测默认开启与关闭方法
- `docs/README.zh.md`：中英同步（`附加功能` → `插件`、结构树、Docker、遥测披露）
- `AGENTS.md`：Docker 命令统一为 `docker compose up -d`
- `CONTRIBUTING.md`：Docker 命令统一为 `docker compose up -d`
- `CLAUDE.md`：损坏的符号链接（目标 `@AGENTS.md` 不存在）替换为指向 `AGENTS.md` 的普通指针文件，修复 AI 工具读取为空的问题
- `docs/config-reference.md`：新增，权威说明 `data/config/system_config.json`、`data/webui.json` 与 persona 遗留格式

## Screenshots / Logs

不适用（纯文档改动）。

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes