### PR TITLE
feat: localize plugin store categories

### DIFF
--- a/webui/frontend/src/types/models.ts
+++ b/webui/frontend/src/types/models.ts
@@ -252,6 +252,8 @@ export interface PluginStoreItem {
   author: string
   description: string
   category?: string
+  category_name?: string | null
+  category_locales?: Record<string, Record<string, string>>
   repo?: string | null
   icon?: string | null
   downloads?: number

--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -844,7 +844,7 @@
             </div>
             <div v-if="'category' in selectedPlugin && selectedPlugin.category">
               <dt class="text-gray-500 dark:text-gray-400">{{ $t('plugin.category') }}</dt>
-              <dd class="mt-1 text-gray-900 dark:text-gray-100">{{ selectedPlugin.category }}</dd>
+              <dd class="mt-1 text-gray-900 dark:text-gray-100">{{ storeCategoryName(selectedPlugin) }}</dd>
             </div>
             <div v-if="'core_version' in selectedPlugin && selectedPlugin.core_version">
               <dt class="text-gray-500 dark:text-gray-400">{{ $t('plugin.core_version') }}</dt>
@@ -1782,16 +1782,16 @@ const STORE_PAGE_SIZE = 12
 const storePage = ref(1)
 
 const storeCategoryOptions = computed(() => {
-  const categories = new Set(
-    storePlugins.value
-      .map(item => item.category?.trim())
-      .filter((category): category is string => Boolean(category)),
-  )
+  const categories = new Map<string, PluginStoreItem>()
+  for (const item of storePlugins.value) {
+    const category = item.category?.trim()
+    if (category && !categories.has(category)) categories.set(category, item)
+  }
   return [
     { value: 'all', label: t('pluginStore.all_categories') },
-    ...Array.from(categories)
-      .sort((a, b) => a.localeCompare(b))
-      .map(category => ({ value: category, label: category })),
+    ...Array.from(categories.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([category, item]) => ({ value: category, label: storeCategoryName(item) })),
   ]
 })
 
@@ -1855,6 +1855,19 @@ watch(storeTotalPages, totalPages => {
 
 function storePluginName(item: PluginStoreItem): string {
   return localize(item, 'display_name', item.name || item.id)
+}
+
+function storeCategoryName(item: {
+  category?: string | null
+  category_name?: string | null
+  category_locales?: Record<string, Record<string, string>>
+}): string {
+  const category = item.category?.trim() || ''
+  return localize(
+    { name: item.category_name || category, locales: item.category_locales },
+    'name',
+    category,
+  )
 }
 
 function storePluginUpdatedAt(item: PluginStoreItem): number {

--- a/webui/models.py
+++ b/webui/models.py
@@ -261,6 +261,8 @@ class PluginStoreItemResponse(BaseModel):
     author: str = ""
     description: str = ""
     category: Optional[str] = None
+    category_name: Optional[str] = None
+    category_locales: Dict[str, Dict[str, str]] = Field(default_factory=dict)
     repo: Optional[str] = None
     locales: Dict[str, Dict[str, str]] = Field(default_factory=dict)
     tags: List[str] = Field(default_factory=list)

--- a/webui/routes/plugins.py
+++ b/webui/routes/plugins.py
@@ -637,6 +637,8 @@ class PluginsRoutes(Routes):
                     author=str(item.get("author", "")),
                     description=str(item.get("description", "")),
                     category=item.get("category"),
+                    category_name=item.get("category_name"),
+                    category_locales=item.get("category_locales") or {},
                     repo=item.get("repo"),
                     locales=item.get("locales") or {},
                     tags=[str(t) for t in tags if t],
@@ -692,8 +694,12 @@ class PluginsRoutes(Routes):
         GitHub metadata is limited to the public star count used for sorting.
         """
         raw_plugins: Any = None
+        category_catalog: Dict[str, Any] = {}
         if isinstance(raw_data, dict):
             raw_plugins = raw_data.get("plugins", [])
+            raw_categories = raw_data.get("categories")
+            if isinstance(raw_categories, dict):
+                category_catalog = raw_categories
         elif isinstance(raw_data, list):
             raw_plugins = raw_data
 
@@ -716,6 +722,9 @@ class PluginsRoutes(Routes):
             author = raw.get("author", "")
             description = raw.get("description", "")
             category = raw.get("category")
+            category_info = category_catalog.get(category) if isinstance(category, str) else None
+            category_name = category_info.get("name") if isinstance(category_info, dict) else None
+            category_locales = category_info.get("locales") if isinstance(category_info, dict) else None
             repo = raw.get("repo") or raw.get("repo_url")
             github_data = raw.get("github_data")
             github_stars = github_data.get("stars", 0) if isinstance(github_data, dict) else 0
@@ -731,6 +740,8 @@ class PluginsRoutes(Routes):
                 "author": str(author),
                 "description": str(description),
                 "category": str(category) if category else None,
+                "category_name": str(category_name) if category_name else None,
+                "category_locales": category_locales if isinstance(category_locales, dict) else {},
                 "repo": str(repo) if repo else None,
                 "locales": locales if isinstance(locales, dict) else {},
                 "stars": int(stars) if isinstance(stars, (int, float, str)) and str(stars).isdigit() else 0,


### PR DESCRIPTION
## Summary

Localize plugin-store category labels supplied by external catalogs while preserving their stable category IDs for filtering.

## Type of change

<!-- Check the one that applies. -->

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Parse the source catalog's top-level category metadata.
- Return category names and locale maps alongside normalized plugin-store items.
- Display localized category labels in the store filter and plugin detail view while filtering by `cate_id`.

## Screenshots / Logs

`npm run build` and `python -m py_compile webui/models.py webui/routes/plugins.py` completed successfully.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin store categories now display localized names where available.
  * Plugin detail pages show translated category labels.
  * Category filtering continues to work using the underlying category identifiers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->