### PR TITLE
fix: guard duplicate plugin installation

### DIFF
--- a/core/plugin/plugin_installer.py
+++ b/core/plugin/plugin_installer.py
@@ -20,7 +20,7 @@ import sys
 import uuid
 import zipfile
 from pathlib import Path
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from core.logging_manager import get_logger
 from core.utils.github_api import parse_github_url, pick_fastest_source
@@ -28,6 +28,10 @@ from core.utils.network import download_file
 from core.utils.path_utils import get_data_path, is_within_directory
 
 logger = get_logger("plugin_installer", "cyan")
+
+
+class PluginAlreadyInstalledError(ValueError):
+    """Raised when an archive declares a plugin already registered at runtime."""
 
 
 def _temp_dir() -> Path:
@@ -45,6 +49,8 @@ async def install_from_github(
     plugins_dir: Path,
     proxy: Optional[str] = None,
     gh_proxy: Optional[str] = None,
+    is_plugin_installed: Optional[Callable[[str], bool]] = None,
+    target_dir: Optional[Path] = None,
 ) -> Path:
     """
     Download a plugin from GitHub, extract it, and move it into plugins_dir.
@@ -52,6 +58,10 @@ async def install_from_github(
     proxy    — HTTP/SOCKS proxy forwarded to download_file
     gh_proxy — GitHub reverse-proxy URL prefix (e.g. "https://ghproxy.com/")
                The direct archive link is appended to this prefix.
+    is_plugin_installed — callback used to reject an archive whose manifest
+                          declares an already registered plugin ID.
+    target_dir — existing plugin directory to replace. Used by updates when
+                 its folder name differs from the plugin ID.
 
     Returns the installed plugin directory.
     Raises ValueError for bad URL / missing manifest.
@@ -80,19 +90,31 @@ async def install_from_github(
         temp_zip.unlink(missing_ok=True)
         raise ConnectionError(f"Failed to download from GitHub: {e}") from e
 
-    return await _extract_and_install(temp_zip, plugins_dir, preferred_name=repo)
+    return await _extract_and_install(
+        temp_zip,
+        plugins_dir,
+        preferred_name=repo,
+        is_plugin_installed=is_plugin_installed,
+        target_dir=target_dir,
+    )
 
 
 async def install_from_zip(
     zip_bytes: bytes,
     plugins_dir: Path,
     preferred_name: str = "",
+    is_plugin_installed: Optional[Callable[[str], bool]] = None,
+    target_dir: Optional[Path] = None,
 ) -> Path:
     """
     Install a plugin from an uploaded zip archive.
 
     Writes the bytes to data/temp/ first so large uploads are not kept in
     memory during extraction, then extracts and moves to plugins_dir.
+
+    is_plugin_installed — callback used to reject an archive whose manifest
+                          declares an already registered plugin ID.
+    target_dir — existing plugin directory to replace.
 
     Returns the installed plugin directory.
     Raises ValueError if the archive is invalid or manifest.json is missing.
@@ -104,7 +126,13 @@ async def install_from_zip(
         temp_zip.unlink(missing_ok=True)
         raise IOError(f"Failed to write uploaded zip to temp: {e}") from e
 
-    return await _extract_and_install(temp_zip, plugins_dir, preferred_name=preferred_name)
+    return await _extract_and_install(
+        temp_zip,
+        plugins_dir,
+        preferred_name=preferred_name,
+        is_plugin_installed=is_plugin_installed,
+        target_dir=target_dir,
+    )
 
 
 async def install_requirements(plugin_dir: Path, pypi_mirror: Optional[str] = None) -> List[str]:
@@ -153,6 +181,8 @@ async def _extract_and_install(
     temp_zip: Path,
     plugins_dir: Path,
     preferred_name: str = "",
+    is_plugin_installed: Optional[Callable[[str], bool]] = None,
+    target_dir: Optional[Path] = None,
 ) -> Path:
     """
     Extract temp_zip into a staging directory under data/temp/, move the result
@@ -189,6 +219,10 @@ async def _extract_and_install(
                 raise ValueError(
                     "manifest.json does not contain 'plugin_id' and no name could be inferred"
                 )
+            if is_plugin_installed and is_plugin_installed(plugin_id):
+                raise PluginAlreadyInstalledError(
+                    f"Plugin '{plugin_id}' is already installed. Use the update action instead."
+                )
 
             staging = _temp_dir() / f"extract_{uuid.uuid4().hex[:8]}_{plugin_id}"
             staging.mkdir(parents=True, exist_ok=True)
@@ -206,9 +240,15 @@ async def _extract_and_install(
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_bytes(zf.read(item.filename))
 
-        # Move staging → plugins_dir/<plugin_id>/  (replace if already exists)
+        # Updates may preserve a legacy directory name. New installs always
+        # use plugins_dir/<plugin_id>/.
         plugins_dir.mkdir(parents=True, exist_ok=True)
-        dest = plugins_dir / plugin_id
+        if target_dir is None:
+            dest = plugins_dir / plugin_id
+        else:
+            dest = target_dir
+            if dest.resolve().parent != plugins_dir.resolve():
+                raise ValueError("Plugin update target must be a direct child of the plugins directory")
         if dest.exists():
             shutil.rmtree(dest)
         shutil.move(str(staging), str(dest))

--- a/core/plugin/plugin_installer.py
+++ b/core/plugin/plugin_installer.py
@@ -51,6 +51,7 @@ async def install_from_github(
     gh_proxy: Optional[str] = None,
     is_plugin_installed: Optional[Callable[[str], bool]] = None,
     target_dir: Optional[Path] = None,
+    expected_plugin_id: Optional[str] = None,
 ) -> Path:
     """
     Download a plugin from GitHub, extract it, and move it into plugins_dir.
@@ -62,6 +63,8 @@ async def install_from_github(
                           declares an already registered plugin ID.
     target_dir — existing plugin directory to replace. Used by updates when
                  its folder name differs from the plugin ID.
+    expected_plugin_id — plugin ID expected by an update request. The archive
+                         is rejected before replacing target_dir if it differs.
 
     Returns the installed plugin directory.
     Raises ValueError for bad URL / missing manifest.
@@ -96,6 +99,7 @@ async def install_from_github(
         preferred_name=repo,
         is_plugin_installed=is_plugin_installed,
         target_dir=target_dir,
+        expected_plugin_id=expected_plugin_id,
     )
 
 
@@ -105,6 +109,7 @@ async def install_from_zip(
     preferred_name: str = "",
     is_plugin_installed: Optional[Callable[[str], bool]] = None,
     target_dir: Optional[Path] = None,
+    expected_plugin_id: Optional[str] = None,
 ) -> Path:
     """
     Install a plugin from an uploaded zip archive.
@@ -115,6 +120,7 @@ async def install_from_zip(
     is_plugin_installed — callback used to reject an archive whose manifest
                           declares an already registered plugin ID.
     target_dir — existing plugin directory to replace.
+    expected_plugin_id — plugin ID expected by an update request.
 
     Returns the installed plugin directory.
     Raises ValueError if the archive is invalid or manifest.json is missing.
@@ -132,6 +138,7 @@ async def install_from_zip(
         preferred_name=preferred_name,
         is_plugin_installed=is_plugin_installed,
         target_dir=target_dir,
+        expected_plugin_id=expected_plugin_id,
     )
 
 
@@ -183,6 +190,7 @@ async def _extract_and_install(
     preferred_name: str = "",
     is_plugin_installed: Optional[Callable[[str], bool]] = None,
     target_dir: Optional[Path] = None,
+    expected_plugin_id: Optional[str] = None,
 ) -> Path:
     """
     Extract temp_zip into a staging directory under data/temp/, move the result
@@ -218,6 +226,10 @@ async def _extract_and_install(
             if not plugin_id:
                 raise ValueError(
                     "manifest.json does not contain 'plugin_id' and no name could be inferred"
+                )
+            if expected_plugin_id and plugin_id != expected_plugin_id:
+                raise ValueError(
+                    f"Plugin identity changed: expected '{expected_plugin_id}', got '{plugin_id}'"
                 )
             if is_plugin_installed and is_plugin_installed(plugin_id):
                 raise PluginAlreadyInstalledError(

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -50,3 +50,25 @@ def test_update_replaces_legacy_plugin_directory(tmp_path, monkeypatch):
     assert installed_dir == legacy_dir
     assert not (legacy_dir / "stale.txt").exists()
     assert not (plugins_dir / "plugin-id").exists()
+
+
+def test_update_rejects_a_changed_plugin_id_before_replacing_files(tmp_path, monkeypatch):
+    plugins_dir = tmp_path / "plugins"
+    legacy_dir = plugins_dir / "repository-folder"
+    legacy_dir.mkdir(parents=True)
+    stale_file = legacy_dir / "stale.txt"
+    stale_file.write_text("old plugin", encoding="utf-8")
+    monkeypatch.setattr(plugin_installer, "get_data_path", lambda: tmp_path)
+
+    with pytest.raises(ValueError, match="Plugin identity changed"):
+        asyncio.run(
+            plugin_installer.install_from_zip(
+                _plugin_archive("different-plugin-id"),
+                plugins_dir,
+                target_dir=legacy_dir,
+                expected_plugin_id="plugin-id",
+            )
+        )
+
+    assert stale_file.read_text(encoding="utf-8") == "old plugin"
+    assert not (legacy_dir / "main.py").exists()

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -1,0 +1,52 @@
+import asyncio
+import io
+import json
+import zipfile
+
+import pytest
+
+import core.plugin.plugin_installer as plugin_installer
+
+
+def _plugin_archive(plugin_id: str) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("plugin-main/manifest.json", json.dumps({"plugin_id": plugin_id}))
+        archive.writestr("plugin-main/main.py", "# plugin entry point\n")
+    return buffer.getvalue()
+
+
+def test_install_rejects_registered_plugin_before_extraction(tmp_path, monkeypatch):
+    monkeypatch.setattr(plugin_installer, "get_data_path", lambda: tmp_path)
+
+    with pytest.raises(plugin_installer.PluginAlreadyInstalledError):
+        asyncio.run(
+            plugin_installer.install_from_zip(
+                _plugin_archive("existing-plugin"),
+                tmp_path / "plugins",
+                is_plugin_installed=lambda plugin_id: plugin_id == "existing-plugin",
+            )
+        )
+
+    assert not (tmp_path / "plugins" / "existing-plugin").exists()
+    assert not list((tmp_path / "temp").glob("extract_*"))
+
+
+def test_update_replaces_legacy_plugin_directory(tmp_path, monkeypatch):
+    plugins_dir = tmp_path / "plugins"
+    legacy_dir = plugins_dir / "repository-folder"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "stale.txt").write_text("old plugin", encoding="utf-8")
+    monkeypatch.setattr(plugin_installer, "get_data_path", lambda: tmp_path)
+
+    installed_dir = asyncio.run(
+        plugin_installer.install_from_zip(
+            _plugin_archive("plugin-id"),
+            plugins_dir,
+            target_dir=legacy_dir,
+        )
+    )
+
+    assert installed_dir == legacy_dir
+    assert not (legacy_dir / "stale.txt").exists()
+    assert not (plugins_dir / "plugin-id").exists()

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -345,6 +345,7 @@ export default {
     install_installing: 'Installing...',
     install_success: 'Plugin installed successfully',
     install_failed: 'Installation failed',
+    install_already_installed: 'This plugin is already installed. Please use the update action instead.',
     install_warning: 'Installed with warnings',
     install_url_required: 'Repository URL is required',
     install_no_file: 'Please select a .zip file',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -345,6 +345,7 @@ export default {
     install_installing: '安装中...',
     install_success: '插件安装成功',
     install_failed: '安装失败',
+    install_already_installed: '该插件已安装，请使用更新功能。',
     install_warning: '安装完成（有警告）',
     install_url_required: '请输入仓库链接',
     install_no_file: '请选择 .zip 文件',

--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -1457,8 +1457,12 @@ async function handleInstall() {
     installDialogVisible.value = false
     notify(t('plugin.install_success'), 'success')
     await loadPlugins()
-  } catch {
-    notify(t('plugin.install_failed'), 'error')
+  } catch (e: any) {
+    if (e?.response?.status === 409) {
+      notify(t('plugin.install_already_installed'), 'error')
+    } else {
+      notify(t('plugin.install_failed'), 'error')
+    }
   } finally {
     installing.value = false
   }

--- a/webui/routes/plugins.py
+++ b/webui/routes/plugins.py
@@ -9,7 +9,12 @@ from fastapi import Depends, File, HTTPException, Query, Response, UploadFile
 
 from core.plugin.plugin_registry import PluginManager, PLUGIN_CONFIG_DIR, PLUGIN_DATA_DIR, _compare_versions
 from core.logging_manager import get_logger
-from core.plugin.plugin_installer import install_from_github, install_from_zip, install_requirements
+from core.plugin.plugin_installer import (
+    PluginAlreadyInstalledError,
+    install_from_github,
+    install_from_zip,
+    install_requirements,
+)
 from core.utils.path_utils import get_data_path
 from webui.models import (
     PageMenu, PluginConfigUpdateRequest, PluginInstallGithubRequest, PluginInstallResult, PluginItem,
@@ -371,7 +376,10 @@ class PluginsRoutes(Routes):
                 plugin_manager.plugin_dir,
                 proxy=payload.proxy,
                 gh_proxy=payload.gh_proxy,
+                is_plugin_installed=plugin_manager.has_plugin,
             )
+        except PluginAlreadyInstalledError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e))
         except ConnectionError as e:
@@ -396,7 +404,13 @@ class PluginsRoutes(Routes):
 
         zip_bytes = await file.read()
         try:
-            plugin_dir = await install_from_zip(zip_bytes, plugin_manager.plugin_dir)
+            plugin_dir = await install_from_zip(
+                zip_bytes,
+                plugin_manager.plugin_dir,
+                is_plugin_installed=plugin_manager.has_plugin,
+            )
+        except PluginAlreadyInstalledError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except (ValueError, IOError) as e:
             raise HTTPException(status_code=422, detail=str(e))
 
@@ -527,11 +541,16 @@ class PluginsRoutes(Routes):
         if not info.repo:
             raise HTTPException(status_code=400, detail="Plugin has no repo URL configured")
 
+        plugin_dir = plugin_manager.get_plugin_module_path(plugin_id)
+        if not plugin_dir:
+            raise HTTPException(status_code=500, detail="Could not resolve installed plugin directory")
+
         try:
             plugin_dir = await install_from_github(
                 info.repo,
                 plugin_manager.plugin_dir,
                 gh_proxy=payload.gh_proxy,
+                target_dir=plugin_dir,
             )
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e))

--- a/webui/routes/plugins.py
+++ b/webui/routes/plugins.py
@@ -379,7 +379,7 @@ class PluginsRoutes(Routes):
                 is_plugin_installed=plugin_manager.has_plugin,
             )
         except PluginAlreadyInstalledError as e:
-            raise HTTPException(status_code=409, detail=str(e))
+            raise HTTPException(status_code=409, detail=str(e)) from e
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e))
         except ConnectionError as e:
@@ -410,7 +410,7 @@ class PluginsRoutes(Routes):
                 is_plugin_installed=plugin_manager.has_plugin,
             )
         except PluginAlreadyInstalledError as e:
-            raise HTTPException(status_code=409, detail=str(e))
+            raise HTTPException(status_code=409, detail=str(e)) from e
         except (ValueError, IOError) as e:
             raise HTTPException(status_code=422, detail=str(e))
 
@@ -551,6 +551,7 @@ class PluginsRoutes(Routes):
                 plugin_manager.plugin_dir,
                 gh_proxy=payload.gh_proxy,
                 target_dir=plugin_dir,
+                expected_plugin_id=plugin_id,
             )
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e))


### PR DESCRIPTION
## Summary

Prevent duplicate plugin installations from overwriting existing plugins, preserve legacy plugin directory names when updating, and show a localized reason when installation is rejected.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [x] test: Adding or updating tests

## Changes

- Reject URL and ZIP plugin installations whose manifest `plugin_id` is already registered.
- Update plugins in their currently registered directory to avoid leaving duplicate legacy directories.
- Display a localized duplicate-installation message in the WebUI.

## Screenshots / Logs

No visual layout change. `npm run build` passed.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin updates can replace existing installations while preserving legacy folder locations.
  * New installations use the plugin ID as the directory name.
* **Bug Fixes**
  * Duplicate plugin installations are now rejected before extraction.
  * Plugin installation conflicts display a clear, localized message.
  * Updates remove stale files from the existing plugin directory.
* **Localization**
  * Added English and Chinese messages for already-installed plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->