### PR TITLE
fix: validate cross-session targets

### DIFF
--- a/core/adapter/adapter_registry.py
+++ b/core/adapter/adapter_registry.py
@@ -221,6 +221,12 @@ class AdapterManager:
                 return False
         return True
 
+    @staticmethod
+    def _validate_adapter_name(name: str):
+        """Reject adapter names that cannot be represented in session IDs."""
+        if ":" in name:
+            raise ValueError("Adapter name must not contain ':'")
+
     def generate_adapter_config(self, platform: str, name: str) -> Optional[str]:
         schema_fields = self.get_schema(platform)
         if not schema_fields:
@@ -263,6 +269,8 @@ class AdapterManager:
         if not name or not platform:
             logger.error("Adapter name and platform are required for creation")
             return None
+
+        self._validate_adapter_name(name)
 
         if not self._check_name_unique(name):
             raise ValueError(f"Adapter name '{name}' is already in use")
@@ -333,6 +341,8 @@ class AdapterManager:
         old_desc = config_entry.get("desc") or ""
 
         new_name_for_check = name or old_name
+        if name:
+            self._validate_adapter_name(name)
         if name and old_name != new_name_for_check and not self._check_name_unique(new_name_for_check, exclude_id=adapter_id):
             raise ValueError(f"Adapter name '{new_name_for_check}' is already in use")
 

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -773,8 +773,8 @@ class MessageProcessor:
         :param tag_set: TagSet object
         :return: list[KiraIMSentResult]
         """
-        parts = event.sid.split(":")
-        if len(parts) != 3:
+        parts = event.sid.split(":", maxsplit=2)
+        if len(parts) != 3 or any(not part for part in parts):
             raise ValueError("invalid target, must follow the form of <adapter>:<dm|gm>:<id>")
 
         message_results = []
@@ -825,8 +825,8 @@ class MessageProcessor:
         :param chain: MessageChain instance
         :return: KiraIMSentResult instance
         """
-        parts = session.split(":")
-        if len(parts) != 3:
+        parts = session.split(":", maxsplit=2)
+        if len(parts) != 3 or any(not part for part in parts):
             raise ValueError("invalid target, must follow <adapter>:<dm|gm>:<id>")
 
         adapter_name, chat_type, pid = parts

--- a/core/plugin/builtin_plugins/session_tools/main.py
+++ b/core/plugin/builtin_plugins/session_tools/main.py
@@ -81,8 +81,8 @@ class SessionPlugin(BasePlugin):
         }
     )
     async def session_send(self, event: KiraMessageBatchEvent, target: str, description: str):
-        parts = target.split(":")
-        if not len(parts) == 3:
+        parts = target.split(":", maxsplit=2)
+        if len(parts) != 3 or any(not part for part in parts):
             raise ValueError(f"Failed to parse sid")
         if event.sid == target:
             return "Do not send messages to current session using this tool, output directly to send messages"

--- a/core/plugin/builtin_plugins/session_tools/main.py
+++ b/core/plugin/builtin_plugins/session_tools/main.py
@@ -12,6 +12,10 @@ SESSION_TOOL_FEW_SHOT = """
 当你需要在其他会话（私聊、群聊等）发送消息时，
 即 当前会话 ≠ 发消息目标会话时，需要调用 `session_send` 工具进行**跨会话发送**。
 
+`target` 必须从「当前存在的会话」列表中逐字复制完整会话标识。标识第一段
+`adapter_name` 是用户配置的适配器实例名，可能是任意名称，和 QQ、Telegram 等
+平台名称没有必然关系；不得根据平台猜测或替换成 `qq` 等名称。
+
 #### 示例
 * 场景：在群 1 中
 * user：到群 12345678（群 2）发一条消息
@@ -60,14 +64,16 @@ class SessionPlugin(BasePlugin):
 
     @register.tool(
         name="session_send",
-        description="向指定会话发送跨会话消息（私聊消息和群聊消息），仅当目标会话和当前会话不同时使用。 target 形如 qq:dm:123456 或 qq:gm:123456",
+        description=(
+            "向指定会话发送跨会话消息（私聊消息和群聊消息），仅当目标会话和当前会话不同时使用。"
+        ),
         params={
             "type": "object",
             "properties": {
                 "target": {"type": "string", "description": (
                     "目标会话标识，格式为 adapter_name:session_type:session_id。"
-                    "可直接从「当前存在的会话」列表中复制完整的会话标识使用。"
-                    "示例：qq:dm:123456（私聊）、qq:gm:789012（群聊）"
+                    "必须从「当前存在的会话」列表中逐字复制完整标识。adapter_name 是用户配置的"
+                    "实例名，可能与实际平台名称不同，示例：qq:dm:123456（私聊）、ada:gm:789012（群聊）"
                 )},
                 "description": {"type": "string", "description": DESC_PROMPT}
             },
@@ -80,6 +86,25 @@ class SessionPlugin(BasePlugin):
             raise ValueError(f"Failed to parse sid")
         if event.sid == target:
             return "Do not send messages to current session using this tool, output directly to send messages"
+
+        adapter_name, session_type, session_id = parts
+        if session_type not in {"dm", "gm"}:
+            return "Permission denied: target session type must be dm or gm"
+
+        adapter = self.ctx.adapter_mgr.get_adapter(adapter_name)
+        if not adapter:
+            return f"Permission denied: adapter not found: {adapter_name}"
+
+        target_list = adapter.user_list if session_type == "dm" else adapter.group_list
+        target_is_listed = session_id in {str(item) for item in target_list}
+        is_allowed = (
+            adapter.permission_mode == "allow_list" and target_is_listed
+        ) or (
+            adapter.permission_mode == "deny_list" and not target_is_listed
+        )
+        if not is_allowed:
+            return f"Permission denied: target session is not allowed by adapter {adapter_name}"
+
         try:
             cross_session_prompt = CROSS_SESSION_PROMPT.format(session_id=event.sid, description=description)
 
@@ -90,9 +115,14 @@ class SessionPlugin(BasePlugin):
 
     def get_session_list_prompt(self) -> str:
         session_info_list = self.ctx.session_mgr.get_session_info()
-        return "\n".join(
+        session_list = "\n".join(
             f"{session_info.sid}(title: {session_info.session_title})"
             for session_info in session_info_list
+        )
+        return (
+            "以下为可用会话的完整标识；调用 session_send 时必须逐字复制其中一项。"
+            "adapter_name 是配置实例名，不代表平台类型，不能自行替换或猜测。\n"
+            f"{session_list}"
         )
 
     @on.llm_request()

--- a/core/plugin/plugin_context.py
+++ b/core/plugin/plugin_context.py
@@ -162,8 +162,8 @@ class PluginContext:
         """
         import time
         cur_time = int(time.time())
-        parts = session.split(":")
-        if not len(parts) == 3:
+        parts = session.split(":", maxsplit=2)
+        if len(parts) != 3 or any(not part for part in parts):
             raise ValueError("Failed to parse session string")
         ada_name, st, sid = parts
         ada = self.adapter_mgr.get_adapter(ada_name)

--- a/tests/test_adapter_manager.py
+++ b/tests/test_adapter_manager.py
@@ -1,0 +1,12 @@
+import pytest
+
+from core.adapter.adapter_registry import AdapterManager
+
+
+def test_adapter_name_rejects_colon():
+    with pytest.raises(ValueError, match="must not contain"):
+        AdapterManager._validate_adapter_name("my:adapter")
+
+
+def test_adapter_name_allows_regular_name():
+    AdapterManager._validate_adapter_name("my-adapter")


### PR DESCRIPTION
## Summary

Fixes cross-session sends so they respect the target adapter's allow/deny list, and makes the AI copy configured adapter instance names directly from the session list.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Validate cross-session targets against the destination adapter's permission mode and relevant user/group list.
- Reject invalid target session types and unknown adapters before publishing a cross-session notice.
- Instruct the model to copy full session identifiers and not infer adapter names from platform names.

## Screenshots / Logs

Not applicable. `python -m compileall -q core\\plugin\\builtin_plugins\\session_tools\\main.py` and `git diff --check` passed.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session messaging validation to ensure valid session types, configured adapters, and permitted destinations.
  * Enhanced session tool guidance with clearer instructions for copying complete session identifiers.
  * Clarified that adapter names refer to configuration instance names rather than platform names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->