### PR TITLE
refactor: introduce function tool manager

### DIFF
--- a/core/agent/agent_executor.py
+++ b/core/agent/agent_executor.py
@@ -7,7 +7,7 @@ from typing import AsyncIterator, Optional, TYPE_CHECKING, Literal
 from openai import APIStatusError, APITimeoutError, APIConnectionError
 
 from core.logging_manager import get_logger
-from core.llm_client import FuncToolManager
+from .func_tool_manager import FuncToolManager
 from core.provider import LLMRequest, LLMResponse, LLMModelClient, ProviderAPIError
 from core.agent.tool import ToolSet
 from core.agent.message import OpenAIMessage

--- a/core/agent/agent_executor.py
+++ b/core/agent/agent_executor.py
@@ -7,7 +7,7 @@ from typing import AsyncIterator, Optional, TYPE_CHECKING, Literal
 from openai import APIStatusError, APITimeoutError, APIConnectionError
 
 from core.logging_manager import get_logger
-from core.llm_client import LLMClient
+from core.llm_client import FuncToolManager
 from core.provider import LLMRequest, LLMResponse, LLMModelClient, ProviderAPIError
 from core.agent.tool import ToolSet
 from core.agent.message import OpenAIMessage
@@ -43,8 +43,8 @@ class AgentStepResult:
 
 
 class AgentExecutor:
-    def __init__(self, llm_api: LLMClient, tool_set: Optional[ToolSet] = None):
-        self.llm_api = llm_api
+    def __init__(self, tool_manager: FuncToolManager, tool_set: Optional[ToolSet] = None):
+        self.tool_manager = tool_manager
         self.tool_set = tool_set
 
     async def run(
@@ -178,7 +178,7 @@ class AgentExecutor:
             reasoning = llm_resp.reasoning_content or ""
 
             try:
-                await self.llm_api.execute_tool(event, llm_resp, tool_set=self.tool_set)
+                await self.tool_manager.execute_tool(event, llm_resp, tool_set=self.tool_set)
             except Exception as e:
                 logger.error(f"[{sid}] Tool execution failed: {e}")
                 exc_event = KiraExceptionEvent(

--- a/core/agent/func_tool_manager.py
+++ b/core/agent/func_tool_manager.py
@@ -7,9 +7,9 @@ import json
 import time
 
 from core.logging_manager import get_logger
-from .config import KiraConfig
-from .provider import LLMRequest, LLMResponse
-from .agent.tool import ToolResult, ToolSet
+from core.config import KiraConfig
+from core.provider import LLMRequest, LLMResponse
+from .tool import ToolResult, ToolSet
 from core.utils.tool_utils import BaseTool
 
 logger = get_logger("llm", "purple")

--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -5,7 +5,7 @@ from typing import Optional, Literal
 from dataclasses import dataclass, field
 from fastmcp import Client
 
-from core.llm_client import LLMClient
+from core.llm_client import FuncToolManager
 from core.utils.path_utils import get_config_path
 
 from core.logging_manager import get_logger
@@ -69,8 +69,8 @@ class MCPServer:
 
 
 class MCPManager:
-    def __init__(self, llm_api: LLMClient):
-        self.llm_api = llm_api
+    def __init__(self, tool_manager: FuncToolManager):
+        self.tool_manager = tool_manager
         self.mcp_config: dict = self.load_config()
         self.servers: list[MCPServer] = []
         # persistent fastmcp clients, one per server id
@@ -416,7 +416,7 @@ class MCPManager:
         target_server = next((s for s in self.servers if s.id == server_id), None)
         if target_server and target_server.enabled:
             for tool in target_server.tools:
-                self.llm_api.unregister_tool(tool.get("name"))
+                self.tool_manager.unregister_tool(tool.get("name"))
 
         await self.close_connection(server_id)
         self._client_locks.pop(server_id, None)
@@ -517,7 +517,7 @@ class MCPManager:
 
             func = self._make_mcp_func(target_server, tool_name)
 
-            self.llm_api.register_tool(
+            self.tool_manager.register_tool(
                 name=tool_name,
                 description=tool.get("description"),
                 parameters=tool.get("parameters"),
@@ -544,7 +544,7 @@ class MCPManager:
 
         for tool in target_server.tools:
             tool_name = tool.get("name")
-            self.llm_api.unregister_tool(tool_name)
+            self.tool_manager.unregister_tool(tool_name)
 
         await self.close_connection(server_id)
 
@@ -569,7 +569,7 @@ class MCPManager:
                     tool_name = tool.get("name")
                     tool_names.append(tool_name)
                     func = self._make_mcp_func(server, tool_name)
-                    self.llm_api.register_tool(
+                    self.tool_manager.register_tool(
                         name=tool_name,
                         description=tool.get("description"),
                         parameters=tool.get("parameters"),

--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -5,7 +5,7 @@ from typing import Optional, Literal
 from dataclasses import dataclass, field
 from fastmcp import Client
 
-from core.llm_client import FuncToolManager
+from .func_tool_manager import FuncToolManager
 from core.utils.path_utils import get_config_path
 
 from core.logging_manager import get_logger

--- a/core/lifecycle.py
+++ b/core/lifecycle.py
@@ -11,7 +11,7 @@ from .prompt_manager import PromptManager
 from core.chat.session_manager import SessionManager
 from .adapter import AdapterManager
 from .statistics import Statistics
-from .llm_client import FuncToolManager
+from .agent.func_tool_manager import FuncToolManager
 from .event_bus import EventBus
 from core.chat.message_utils import KiraMessageEvent, KiraMessageBatchEvent, KiraCommentEvent
 from .persona import PersonaManager

--- a/core/lifecycle.py
+++ b/core/lifecycle.py
@@ -11,7 +11,7 @@ from .prompt_manager import PromptManager
 from core.chat.session_manager import SessionManager
 from .adapter import AdapterManager
 from .statistics import Statistics
-from .llm_client import LLMClient
+from .llm_client import FuncToolManager
 from .event_bus import EventBus
 from core.chat.message_utils import KiraMessageEvent, KiraMessageBatchEvent, KiraCommentEvent
 from .persona import PersonaManager
@@ -46,7 +46,7 @@ class KiraLifecycle:
 
         self.provider_manager: Optional[ProviderManager] = None
 
-        self.llm_api: Optional[LLMClient] = None
+        self.tool_manager: Optional[FuncToolManager] = None
 
         self.adapter_manager: Optional[AdapterManager] = None
 
@@ -147,8 +147,8 @@ class KiraLifecycle:
         # ====== init ProviderManager config ======
         self.provider_manager = ProviderManager(self.db_service, self.kira_config)
 
-        # ====== init LLMClient ======
-        self.llm_api = LLMClient(self.kira_config, self.provider_manager)
+        # ====== init function tool manager ======
+        self.tool_manager = FuncToolManager(self.kira_config)
         # ====== init adapter manager ======
         self.adapter_manager = AdapterManager(self.kira_config, event_queue)
         await self.adapter_manager.initialize()
@@ -170,7 +170,7 @@ class KiraLifecycle:
 
         # ====== init MCP manager ======
         try:
-            self.mcp_manager = MCPManager(self.llm_api)
+            self.mcp_manager = MCPManager(self.tool_manager)
             await self.mcp_manager.init_mcp()
         except Exception as e:
             logger.error(f"Failed to initialize MCPManager: {e}")
@@ -183,7 +183,7 @@ class KiraLifecycle:
         self.message_processor = MessageProcessor(
             db=self.db_service,
             kira_config=self.kira_config,
-            llm_api=self.llm_api,
+            tool_manager=self.tool_manager,
             provider_manager=self.provider_manager,
             skills_manager=self.skills_manager,
             adapter_manager=self.adapter_manager,
@@ -211,7 +211,7 @@ class KiraLifecycle:
             config=self.kira_config,
             event_bus=self.event_bus,
             provider_mgr=self.provider_manager,
-            llm_api=self.llm_api,
+            tool_mgr=self.tool_manager,
             adapter_mgr=self.adapter_manager,
             persona_mgr=self.persona_manager,
             sticker_manager=self.sticker_manager,

--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from asyncio import Semaphore, wait_for, TimeoutError as AsyncTimeoutError
+from asyncio import wait_for, TimeoutError as AsyncTimeoutError
 from typing import Optional, Union, TYPE_CHECKING
 import copy
 import json
 import time
 
 from core.logging_manager import get_logger
-from core.chat.message_elements import Record, Image, Sticker
 from .config import KiraConfig
 from .provider import LLMRequest, LLMResponse
 from .agent.tool import ToolResult, ToolSet
 from core.utils.tool_utils import BaseTool
-from .provider import ProviderManager
 
 logger = get_logger("llm", "purple")
 tool_logger = get_logger("tool_use", "orange")
@@ -41,55 +39,27 @@ class _LegacyFuncTool(BaseTool):
         }
 
 
-class LLMClient:
-    def __init__(self, kira_config: KiraConfig, provider_mgr: ProviderManager):
+class FuncToolManager:
+    def __init__(self, kira_config: KiraConfig):
         self.kira_config = kira_config
 
-        self.provider_mgr = provider_mgr
-
-        self.tools_definitions: list[dict] = []
-        self.tools_functions = {}
-
-        self.llm_semaphore = Semaphore(2)
+        self.tool_set = ToolSet()
 
     def register_tool(self, name, description, parameters, func):
         """Register a tool"""
-        self.tools_definitions.append({
-            "type": "function",
-            "function": {
-                "name": name,
-                "description": description,
-                "parameters": parameters
-            }
-        })
-        self.tools_functions[name] = func
+        self.tool_set.add(_LegacyFuncTool(
+            name=name,
+            description=description,
+            parameters=parameters,
+            func=func,
+        ))
 
     def unregister_tool(self, name: str):
-        if name in self.tools_functions:
-            del self.tools_functions[name]
-
-        for i, tool_def in enumerate(self.tools_definitions):
-            if tool_def.get("function", {}).get("name") == name:
-                del self.tools_definitions[i]
+        self.tool_set.remove(name)
 
     def build_tool_set(self) -> ToolSet:
-        """Wrap all registered legacy tools into a unified ToolSet."""
-        tool_set = ToolSet()
-        for td in self.tools_definitions:
-            func_def = td.get("function", {})
-            name = func_def.get("name")
-            if not name:
-                continue
-            func = self.tools_functions.get(name)
-            if not func:
-                continue
-            tool_set.add(_LegacyFuncTool(
-                name=name,
-                description=func_def.get("description", ""),
-                parameters=func_def.get("parameters", {}),
-                func=func,
-            ))
-        return tool_set
+        """Return a request-local copy of the registered tools."""
+        return ToolSet(tools=self.tool_set.tools.copy())
 
     async def execute_tool(self, event: KiraMessageBatchEvent, resp: LLMResponse, tool_set: Optional[ToolSet] = None):
         max_tool_calls_per_turn = self.kira_config.get_config("bot_config.agent.max_tool_calls_per_turn")

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -36,7 +36,7 @@ from core.chat.message_elements import (
     Video
 )
 
-from core.llm_client import FuncToolManager
+from core.agent.func_tool_manager import FuncToolManager
 from core.chat.session_manager import SessionManager
 from .prompt_manager import PromptManager
 from .adapter import AdapterManager

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -36,7 +36,7 @@ from core.chat.message_elements import (
     Video
 )
 
-from core.llm_client import LLMClient
+from core.llm_client import FuncToolManager
 from core.chat.session_manager import SessionManager
 from .prompt_manager import PromptManager
 from .adapter import AdapterManager
@@ -149,7 +149,7 @@ class MessageProcessor:
     def __init__(self,
                  db: DatabaseService,
                  kira_config,
-                 llm_api: LLMClient,
+                 tool_manager: FuncToolManager,
                  provider_manager: ProviderManager,
                  skills_manager: SkillsManager,
                  adapter_manager: AdapterManager,
@@ -165,7 +165,7 @@ class MessageProcessor:
         self.min_message_delay = float(self.bot_config.get("min_message_delay", "0.8"))
         self.max_message_delay = float(self.bot_config.get("max_message_delay", "1.5"))
 
-        self.llm_api = llm_api
+        self.tool_manager = tool_manager
         self.event_bus: Optional[EventBus] = None
 
         self.message_processing_semaphore = Semaphore(max_concurrent_messages)
@@ -574,7 +574,7 @@ class MessageProcessor:
         # Filter tools by scope
         tool_server_map = self.mcp_manager.get_tool_server_map()
 
-        tool_set = self.llm_api.build_tool_set()
+        tool_set = self.tool_manager.build_tool_set()
         # Remove tools blocked by MCP server scope
         tool_set.tools = [
             t for t in tool_set.tools
@@ -642,7 +642,7 @@ class MessageProcessor:
 
         max_agent_steps = max_tool_loop
 
-        agent_executor = AgentExecutor(self.llm_api, request.tool_set)
+        agent_executor = AgentExecutor(self.tool_manager, request.tool_set)
         agent_ctx = AgentExecutionContext(
             event=event,
             request=request,

--- a/core/plugin/plugin_context.py
+++ b/core/plugin/plugin_context.py
@@ -10,7 +10,7 @@ from ..provider import ProviderManager, LLMModelClient, EmbeddingModelClient
 from core.chat.session_manager import SessionManager
 from ..adapter import AdapterManager
 from core.event_bus import EventBus
-from core.llm_client import LLMClient
+from core.llm_client import FuncToolManager
 from core.chat import KiraMessageEvent, KiraIMMessage, MessageChain, User, Group, KiraIMSentResult
 from core.config import KiraConfig
 from core.persona import PersonaManager
@@ -34,7 +34,7 @@ class PluginContext:
 
     provider_mgr: ProviderManager
 
-    llm_api: LLMClient
+    tool_mgr: FuncToolManager
 
     adapter_mgr: AdapterManager
 

--- a/core/plugin/plugin_context.py
+++ b/core/plugin/plugin_context.py
@@ -10,7 +10,7 @@ from ..provider import ProviderManager, LLMModelClient, EmbeddingModelClient
 from core.chat.session_manager import SessionManager
 from ..adapter import AdapterManager
 from core.event_bus import EventBus
-from core.llm_client import FuncToolManager
+from core.agent.func_tool_manager import FuncToolManager
 from core.chat import KiraMessageEvent, KiraIMMessage, MessageChain, User, Group, KiraIMSentResult
 from core.config import KiraConfig
 from core.persona import PersonaManager

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -784,7 +784,7 @@ class PluginManager:
             bound_func = func
             if plugin_instance is not None and hasattr(plugin_instance, func.__name__):
                 bound_func = getattr(plugin_instance, func.__name__)
-            self.ctx.llm_api.register_tool(
+            self.ctx.tool_mgr.register_tool(
                 name=tool_name,
                 description=meta.get("description", ""),
                 parameters=meta.get("parameters") or {},
@@ -1451,10 +1451,10 @@ class PluginManager:
             return
 
         # clean up tool registration
-        if self.ctx and getattr(self.ctx, "llm_api", None):
+        if self.ctx and getattr(self.ctx, "tool_mgr", None):
             for tool_name in list(comp.tools.keys()):
                 try:
-                    self.ctx.llm_api.unregister_tool(tool_name)
+                    self.ctx.tool_mgr.unregister_tool(tool_name)
                 except Exception as e:
                     logger.error(f"Failed to unregister tool {tool_name} for plugin {plugin_id}: {e}")
 

--- a/core/workflow/workflow_context.py
+++ b/core/workflow/workflow_context.py
@@ -8,7 +8,7 @@ from ..adapter import AdapterManager
 from core.chat.session_manager import SessionManager
 from core.config import KiraConfig
 from core.event_bus import EventBus
-from core.llm_client import FuncToolManager
+from core.agent.func_tool_manager import FuncToolManager
 from core.persona import PersonaManager
 from core.utils.path_utils import get_data_path
 

--- a/core/workflow/workflow_context.py
+++ b/core/workflow/workflow_context.py
@@ -8,7 +8,7 @@ from ..adapter import AdapterManager
 from core.chat.session_manager import SessionManager
 from core.config import KiraConfig
 from core.event_bus import EventBus
-from core.llm_client import LLMClient
+from core.llm_client import FuncToolManager
 from core.persona import PersonaManager
 from core.utils.path_utils import get_data_path
 
@@ -24,7 +24,7 @@ class WorkflowContext:
 
     provider_mgr: ProviderManager
 
-    llm_api: LLMClient
+    tool_mgr: FuncToolManager
 
     adapter_mgr: AdapterManager
 

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -61,7 +61,7 @@ class FakeClient:
         ]
 
 
-class FakeLLMClient:
+class FakeFuncToolManager:
     def __init__(self):
         self.registered = {}
 
@@ -77,7 +77,7 @@ def manager(monkeypatch, tmp_path):
     monkeypatch.setattr(mcp_mgr, "MCP_CONFIG_PATH", tmp_path / "mcp.json")
     monkeypatch.setattr(mcp_mgr, "Client", FakeClient)
     FakeClient.instances = []
-    mgr = MCPManager(FakeLLMClient())
+    mgr = MCPManager(FakeFuncToolManager())
     return mgr
 
 
@@ -228,13 +228,13 @@ async def test_disable_server_closes_connection(manager):
     assert server.enabled is True
     assert server.id in manager._clients
     assert manager._clients[server.id].connected is True
-    assert "echo" in manager.llm_api.registered
+    assert "echo" in manager.tool_manager.registered
 
     await manager.disable_server(server.id)
     assert server.enabled is False
     assert server.id not in manager._clients
     assert FakeClient.instances[0].close_count == 1
-    assert "echo" not in manager.llm_api.registered
+    assert "echo" not in manager.tool_manager.registered
 
 
 @pytest.mark.anyio
@@ -297,7 +297,7 @@ async def test_no_reconnect_after_disable(manager):
     manager.mcp_config = {"mcpServers": {server.id: {"command": "echo"}}}
 
     await manager.enable_server(server.id)
-    func = manager.llm_api.registered["echo"]
+    func = manager.tool_manager.registered["echo"]
     await func(x=1)
 
     await manager.disable_server(server.id)
@@ -326,5 +326,5 @@ async def test_enable_server_fails_when_unreachable(manager, monkeypatch):
     # server must not be marked enabled, nothing registered, no client kept
     assert server.enabled is False
     assert manager.mcp_config["mcpServers"][server.id].get("enabled") is not True
-    assert manager.llm_api.registered == {}
+    assert manager.tool_manager.registered == {}
     assert server.id not in manager._clients


### PR DESCRIPTION
## Summary

Refactors function-tool management away from the misleading `LLMClient` name and consolidates registered tools in `ToolSet`.

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [x] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Replace parallel function definitions and callbacks with a single `ToolSet` in `FuncToolManager`.
- Rename and relocate the manager to `core/agent/func_tool_manager.py`.
- Update MCP, agent, lifecycle, plugin, workflow, and test references to the new manager name.

## Screenshots / Logs

Not applicable.

## Checklist

- [ ] I have tested these changes locally (pytest is unavailable in the current environment; syntax compilation passed)
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved tool management across agents, plugins, workflows, and integrations.
  - Tool registration, removal, and execution now use a dedicated tool manager.
  - Plugin and workflow contexts provide consistent access to available tools.

- **Bug Fixes**
  - Improved tool lifecycle handling when integrations are enabled, disabled, or removed.

- **Tests**
  - Updated coverage to verify tool registration and cleanup across integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->