### PR TITLE
fix: normalize LLM request headers and tools

### DIFF
--- a/core/provider/src/aliyun_bailian/model_clients.py
+++ b/core/provider/src/aliyun_bailian/model_clients.py
@@ -27,6 +27,7 @@ from core.provider.llm_model import RerankResult
 from core.chat.message_elements import Record, Image
 from core.logging_manager import get_logger
 from core.utils.model_clients import OpenAICompatibleLLMClient
+from core.utils.model_clients import build_llm_default_headers
 
 logger = get_logger("provider", "purple")
 
@@ -205,14 +206,10 @@ class BailianLLMClient(OpenAICompatibleLLMClient):
     """LLM via DashScope OpenAI-compatible chat completions."""
 
     def _build_client(self) -> AsyncOpenAI:
-        section_advanced = self.model.provider_config.get("section_advanced")
-        default_headers = section_advanced.get("headers", {}) if isinstance(section_advanced, dict) else {}
-        if not isinstance(default_headers, dict) or not default_headers:
-            default_headers = None
         return AsyncOpenAI(
             api_key=self.model.provider_config.get("api_key", ""),
             base_url=resolve_compatible_base_url(self.model.provider_config),
-            default_headers=default_headers,
+            default_headers=build_llm_default_headers(self.model.provider_config),
         )
 
 

--- a/core/provider/src/anthropic/model_clients.py
+++ b/core/provider/src/anthropic/model_clients.py
@@ -8,6 +8,7 @@ from anthropic import AnthropicError, AsyncAnthropic
 
 from core.provider import LLMModelClient, ModelInfo, ProviderAPIError
 from core.provider.llm_model import LLMRequest, LLMResponse, LLMStreamChunk
+from core.utils.model_clients import build_llm_default_headers
 
 DEFAULT_BASE_URL = "https://api.anthropic.com"
 DEFAULT_API_VERSION = "2023-06-01"
@@ -28,16 +29,7 @@ def build_anthropic_headers(provider_config: dict) -> dict[str, str]:
         "anthropic-version": provider_config.get("anthropic_version")
         or DEFAULT_API_VERSION,
     }
-    advanced = provider_config.get("section_advanced") or {}
-    custom_headers = advanced.get("headers") if isinstance(advanced, dict) else None
-    if isinstance(custom_headers, dict):
-        headers.update(
-            {
-                str(key): str(value)
-                for key, value in custom_headers.items()
-                if value is not None
-            }
-        )
+    headers.update(build_llm_default_headers(provider_config))
     return headers
 
 

--- a/core/provider/src/deepseek/model_clients.py
+++ b/core/provider/src/deepseek/model_clients.py
@@ -1,10 +1,17 @@
-from openai import AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionError
+from openai import (
+    AsyncOpenAI,
+    APIStatusError,
+    APITimeoutError,
+    APIConnectionError,
+    NOT_GIVEN,
+)
 import time
 from typing import AsyncGenerator
 
 from core.provider import ModelInfo, LLMModelClient
 from core.provider.llm_model import LLMRequest, LLMResponse, LLMStreamChunk
 from core.logging_manager import get_logger
+from core.utils.model_clients import build_llm_default_headers
 
 logger = get_logger("provider", "purple")
 
@@ -25,14 +32,10 @@ class DeepSeekLLMClient(LLMModelClient):
 
     def _build_client(self) -> AsyncOpenAI:
         """Create an AsyncOpenAI client from provider config."""
-        section_advanced = self.model.provider_config.get("section_advanced")
-        default_headers = section_advanced.get("headers", {}) if isinstance(section_advanced, dict) else {}
-        if not isinstance(default_headers, dict) or not default_headers:
-            default_headers = None
         return AsyncOpenAI(
             api_key=self.model.provider_config.get("api_key", ""),
             base_url=self.model.provider_config.get("base_url", ""),
-            default_headers=default_headers,
+            default_headers=build_llm_default_headers(self.model.provider_config),
         )
 
     def _build_request_kwargs(self, request: LLMRequest, **overrides) -> dict:
@@ -59,8 +62,8 @@ class DeepSeekLLMClient(LLMModelClient):
         kwargs = dict(
             model=self.model.model_id,
             messages=[m if isinstance(m, dict) else m.to_dict() for m in request.messages],
-            tools=request.tools if request.tools else None,
-            tool_choice=request.tool_choice if request.tool_choice != "none" else None,
+            tools=request.tools if request.tools else NOT_GIVEN,
+            tool_choice=request.tool_choice if request.tool_choice != "none" else NOT_GIVEN,
         )
 
         if thinking_enabled:

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -27,10 +27,10 @@ def build_llm_default_headers(provider_config: dict | None) -> dict[str, str]:
         if isinstance(configured_headers, dict)
         else {}
     )
-    has_user_agent = any(
-        key.lower() == "user-agent" and value.strip()
-        for key, value in headers.items()
-    )
+    for key in list(headers):
+        if key.lower() == "user-agent" and not headers[key].strip():
+            del headers[key]
+    has_user_agent = any(key.lower() == "user-agent" for key in headers)
     if not has_user_agent:
         headers["User-Agent"] = DEFAULT_USER_AGENT
     return headers

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -7,6 +7,33 @@ from core.provider import ModelInfo
 from core.provider import LLMModelClient, TTSModelClient, ImageModelClient, EmbeddingModelClient
 from core.provider.llm_model import LLMRequest, LLMResponse, LLMStreamChunk
 from core.chat.message_elements import Record
+from core.config.default import VERSION
+
+
+DEFAULT_USER_AGENT = f"kira-ai/{VERSION.removeprefix('v')}"
+
+
+def build_llm_default_headers(provider_config: dict | None) -> dict[str, str]:
+    """Return configured LLM headers with KiraAI's default user agent."""
+    config = provider_config or {}
+    advanced = config.get("section_advanced") or {}
+    configured_headers = advanced.get("headers") if isinstance(advanced, dict) else None
+    headers = (
+        {
+            str(key): str(value)
+            for key, value in configured_headers.items()
+            if value is not None
+        }
+        if isinstance(configured_headers, dict)
+        else {}
+    )
+    has_user_agent = any(
+        key.lower() == "user-agent" and value.strip()
+        for key, value in headers.items()
+    )
+    if not has_user_agent:
+        headers["User-Agent"] = DEFAULT_USER_AGENT
+    return headers
 
 class OpenAICompatibleLLMClient(LLMModelClient):
     def __init__(self, model: ModelInfo):
@@ -14,14 +41,10 @@ class OpenAICompatibleLLMClient(LLMModelClient):
 
     def _build_client(self) -> AsyncOpenAI:
         """Create an AsyncOpenAI client from provider config."""
-        section_advanced = self.model.provider_config.get("section_advanced")
-        default_headers = section_advanced.get("headers", {}) if isinstance(section_advanced, dict) else {}
-        if not isinstance(default_headers, dict) or not default_headers:
-            default_headers = None
         return AsyncOpenAI(
             api_key=self.model.provider_config.get("api_key", ""),
             base_url=self.model.provider_config.get("base_url", ""),
-            default_headers=default_headers,
+            default_headers=build_llm_default_headers(self.model.provider_config),
         )
 
     def _build_request_kwargs(self, request: LLMRequest, **overrides) -> dict:
@@ -39,8 +62,8 @@ class OpenAICompatibleLLMClient(LLMModelClient):
         kwargs = dict(
             model=self.model.model_id,
             messages=[m if isinstance(m, dict) else m.to_dict() for m in request.messages],
-            tools=request.tools if request.tools else None,
-            tool_choice=request.tool_choice if request.tool_choice != "none" else None,
+            tools=request.tools if request.tools else NOT_GIVEN,
+            tool_choice=request.tool_choice if request.tool_choice != "none" else NOT_GIVEN,
             temperature=temperature if temperature is not None else NOT_GIVEN,
             timeout=timeout if timeout is not None else NOT_GIVEN,
         )
@@ -181,7 +204,7 @@ class OpenAICompatibleTTSClient(TTSModelClient):
         client = AsyncOpenAI(
             api_key=self.model.provider_config.get("api_key", ""),
             base_url=self.model.provider_config.get("base_url", ""),
-            default_headers=default_headers
+            default_headers=default_headers,
         )
 
         async with client.audio.speech.with_streaming_response.create(

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -13,6 +13,7 @@ from core.provider.src.anthropic.model_clients import (
     normalize_anthropic_base_url,
 )
 from core.provider.src.anthropic.provider import AnthropicProvider
+from core.utils.model_clients import DEFAULT_USER_AGENT
 
 
 def build_client(
@@ -58,6 +59,7 @@ def test_normalizes_compatible_base_urls_and_builds_headers():
     assert headers["anthropic-version"] == "custom-version"
     assert headers["x-api-key"] == "override"
     assert headers["x-tenant"] == "42"
+    assert headers["User-Agent"] == DEFAULT_USER_AGENT
 
 
 def test_converts_openai_messages_images_and_tool_round_trip():

--- a/tests/test_openai_request_kwargs.py
+++ b/tests/test_openai_request_kwargs.py
@@ -1,0 +1,41 @@
+import pytest
+from openai import NOT_GIVEN
+
+from core.provider import LLMRequest, ModelInfo, ModelType
+from core.provider.src.deepseek.model_clients import DeepSeekLLMClient
+from core.utils.model_clients import (
+    DEFAULT_USER_AGENT,
+    OpenAICompatibleLLMClient,
+    build_llm_default_headers,
+)
+
+
+def test_llm_headers_default_and_preserve_custom_user_agent():
+    assert build_llm_default_headers({}) == {"User-Agent": DEFAULT_USER_AGENT}
+    assert build_llm_default_headers(
+        {"section_advanced": {"headers": {"X-Tenant": 42}}}
+    ) == {"X-Tenant": "42", "User-Agent": DEFAULT_USER_AGENT}
+    assert build_llm_default_headers(
+        {"section_advanced": {"headers": {"user-agent": "custom-agent/1.0"}}}
+    ) == {"user-agent": "custom-agent/1.0"}
+
+
+@pytest.mark.parametrize(
+    "client_type",
+    [OpenAICompatibleLLMClient, DeepSeekLLMClient],
+)
+def test_openai_compatible_requests_omit_disabled_tool_parameters(client_type):
+    client = client_type(
+        ModelInfo(
+            model_type=ModelType.LLM,
+            model_id="test-model",
+            provider_id="test-provider",
+            provider_name="Test Provider",
+        )
+    )
+    request = LLMRequest(messages=[{"role": "user", "content": "ping"}])
+
+    kwargs = client._build_request_kwargs(request)
+
+    assert kwargs["tools"] is NOT_GIVEN
+    assert kwargs["tool_choice"] is NOT_GIVEN

--- a/tests/test_openai_request_kwargs.py
+++ b/tests/test_openai_request_kwargs.py
@@ -18,6 +18,9 @@ def test_llm_headers_default_and_preserve_custom_user_agent():
     assert build_llm_default_headers(
         {"section_advanced": {"headers": {"user-agent": "custom-agent/1.0"}}}
     ) == {"user-agent": "custom-agent/1.0"}
+    assert build_llm_default_headers(
+        {"section_advanced": {"headers": {"user-agent": ""}}}
+    ) == {"User-Agent": DEFAULT_USER_AGENT}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes OpenAI-compatible LLM requests that sent `tools` and `tool_choice` as JSON `null` when tool calling was disabled. It also supplies a KiraAI User-Agent for LLM SDK requests when the provider does not configure one, avoiding compatibility gateway blocks.

## Type of change

- [x] fix: Bug fix
- [x] test: Adding or updating tests

## Changes

- Omit disabled OpenAI-compatible `tools` and `tool_choice` parameters with `NOT_GIVEN`.
- Add `kira-ai/<version>` as the default User-Agent for LLM requests while preserving an explicitly configured User-Agent.
- Apply the header behaviour to OpenAI-compatible, DeepSeek, Bailian, and Anthropic LLM clients.
- Add request-parameter and Anthropic header regression coverage.

## Screenshots / Logs

Not applicable. `uv run pytest tests/test_openai_request_kwargs.py tests/test_anthropic_provider.py -v` passed: 12 tests passed. `git diff --check` also passed.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes
