### PR TITLE
feat(webui): enlarge plugin card icons

### DIFF
--- a/tests/test_plugin_store_cache_fallback.py
+++ b/tests/test_plugin_store_cache_fallback.py
@@ -68,3 +68,19 @@ def test_extract_plugins_reads_nested_github_stars():
     })
 
     assert plugins[0]["stars"] == 12
+
+
+def test_extract_plugins_preserves_store_icon_urls():
+    plugins = PluginsRoutes._extract_plugins({
+        "plugins": {
+            "example": {
+                "plugin_id": "example",
+                "display_name": "Example",
+                "icon": "https://store.example/icons/example.svg",
+                "icon_dark": "https://store.example/icons/example-dark.svg",
+            },
+        },
+    })
+
+    assert plugins[0]["icon"] == "https://store.example/icons/example.svg"
+    assert plugins[0]["icon_dark"] == "https://store.example/icons/example-dark.svg"

--- a/webui/frontend/src/components/common/PluginCard.vue
+++ b/webui/frontend/src/components/common/PluginCard.vue
@@ -9,35 +9,35 @@
     @keydown.space="onCardKeydown"
   >
     <div class="flex items-start justify-between mb-3">
-      <div class="min-w-0">
-        <div class="flex items-center gap-2">
-          <img v-if="displayIcon" :src="displayIcon" :alt="''" class="w-6 h-6 flex-shrink-0 object-contain" />
+      <div class="flex min-w-0 items-start gap-3">
+        <img v-if="displayIcon" :src="displayIcon" :alt="''" class="w-10 h-10 flex-shrink-0 object-contain" />
+        <div class="min-w-0">
           <div class="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">{{ name || id }}</div>
-        </div>
-        <div v-if="version || author" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          {{ version ? `v${version}` : '' }}{{ version && author ? ' · ' : '' }}{{ author || '' }}
-          <span v-if="hasUpdate" class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-400">
-            {{ $t('plugin.update_available') }}
-          </span>
-        </div>
-        <div v-if="coreVersion" class="mt-1 text-xs text-gray-400 dark:text-gray-500">
-          {{ $t('plugin.core_version') }}: {{ coreVersion }}
-        </div>
-        <div v-if="status === 'installing'" class="mt-2 flex items-center gap-1.5 text-xs">
-          <IconSpinner class="animate-spin h-3.5 w-3.5 text-yellow-500" />
-          <span class="text-yellow-600 dark:text-yellow-400">{{ $t('plugin.status_installing') }}</span>
-        </div>
-        <div v-else-if="status === 'loading'" class="mt-2 flex items-center gap-1.5 text-xs">
-          <IconSpinner class="animate-spin h-3.5 w-3.5 text-blue-500" />
-          <span class="text-blue-600 dark:text-blue-400">{{ $t('plugin.status_loading') }}</span>
-        </div>
-        <div v-else-if="status === 'pending'" class="mt-2 flex items-center gap-1.5 text-xs">
-          <span class="inline-block h-2 w-2 rounded-full bg-gray-400"></span>
-          <span class="text-gray-500 dark:text-gray-400">{{ $t('plugin.status_pending') }}</span>
-        </div>
-        <div v-if="error" class="mt-2 min-w-0 flex items-start gap-1.5 rounded-md bg-red-50 dark:bg-red-900/20 px-2 py-1.5 text-xs text-red-600 dark:text-red-400 overflow-hidden">
-          <IconInfo class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
-          <span class="min-w-0 break-all line-clamp-6">{{ error }}</span>
+          <div v-if="version || author" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {{ version ? `v${version}` : '' }}{{ version && author ? ' · ' : '' }}{{ author || '' }}
+            <span v-if="hasUpdate" class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-400">
+              {{ $t('plugin.update_available') }}
+            </span>
+          </div>
+          <div v-if="coreVersion" class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+            {{ $t('plugin.core_version') }}: {{ coreVersion }}
+          </div>
+          <div v-if="status === 'installing'" class="mt-2 flex items-center gap-1.5 text-xs">
+            <IconSpinner class="animate-spin h-3.5 w-3.5 text-yellow-500" />
+            <span class="text-yellow-600 dark:text-yellow-400">{{ $t('plugin.status_installing') }}</span>
+          </div>
+          <div v-else-if="status === 'loading'" class="mt-2 flex items-center gap-1.5 text-xs">
+            <IconSpinner class="animate-spin h-3.5 w-3.5 text-blue-500" />
+            <span class="text-blue-600 dark:text-blue-400">{{ $t('plugin.status_loading') }}</span>
+          </div>
+          <div v-else-if="status === 'pending'" class="mt-2 flex items-center gap-1.5 text-xs">
+            <span class="inline-block h-2 w-2 rounded-full bg-gray-400"></span>
+            <span class="text-gray-500 dark:text-gray-400">{{ $t('plugin.status_pending') }}</span>
+          </div>
+          <div v-if="error" class="mt-2 min-w-0 flex items-start gap-1.5 rounded-md bg-red-50 dark:bg-red-900/20 px-2 py-1.5 text-xs text-red-600 dark:text-red-400 overflow-hidden">
+            <IconInfo class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+            <span class="min-w-0 break-all line-clamp-6">{{ error }}</span>
+          </div>
         </div>
       </div>
       <div class="flex items-start space-x-2">

--- a/webui/frontend/src/types/models.ts
+++ b/webui/frontend/src/types/models.ts
@@ -266,6 +266,7 @@ export interface PluginStoreItem {
   category_locales?: Record<string, Record<string, string>>
   repo?: string | null
   icon?: string | null
+  icon_dark?: string | null
   downloads?: number
   tags?: string[]
   installed?: boolean

--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -558,6 +558,8 @@
           :author="item.author"
           :description="localize(item, 'description', item.description)"
           :repo="item.repo"
+          :icon="item.icon"
+          :icon-dark="item.icon_dark"
           :tags="item.tags"
           :installed="item.installed"
           :has-update="item.installed && pluginUpdates.has(item.id)"

--- a/webui/models.py
+++ b/webui/models.py
@@ -270,6 +270,8 @@ class PluginStoreItemResponse(BaseModel):
     category_name: Optional[str] = None
     category_locales: Dict[str, Dict[str, str]] = Field(default_factory=dict)
     repo: Optional[str] = None
+    icon: Optional[str] = None
+    icon_dark: Optional[str] = None
     locales: Dict[str, Dict[str, str]] = Field(default_factory=dict)
     tags: List[str] = Field(default_factory=list)
     stars: int = 0

--- a/webui/routes/plugins.py
+++ b/webui/routes/plugins.py
@@ -693,6 +693,8 @@ class PluginsRoutes(Routes):
                     category_name=item.get("category_name"),
                     category_locales=item.get("category_locales") or {},
                     repo=item.get("repo"),
+                    icon=item.get("icon"),
+                    icon_dark=item.get("icon_dark"),
                     locales=item.get("locales") or {},
                     tags=[str(t) for t in tags if t],
                     stars=item.get("stars", 0),
@@ -779,6 +781,8 @@ class PluginsRoutes(Routes):
             category_name = category_info.get("name") if isinstance(category_info, dict) else None
             category_locales = category_info.get("locales") if isinstance(category_info, dict) else None
             repo = raw.get("repo") or raw.get("repo_url")
+            icon = raw.get("icon")
+            icon_dark = raw.get("icon_dark") or raw.get("icon-dark")
             github_data = raw.get("github_data")
             github_stars = github_data.get("stars", 0) if isinstance(github_data, dict) else 0
             stars = raw.get("stars", raw.get("star_count", github_stars))
@@ -796,6 +800,8 @@ class PluginsRoutes(Routes):
                 "category_name": str(category_name) if category_name else None,
                 "category_locales": category_locales if isinstance(category_locales, dict) else {},
                 "repo": str(repo) if repo else None,
+                "icon": str(icon) if isinstance(icon, str) else None,
+                "icon_dark": str(icon_dark) if isinstance(icon_dark, str) else None,
                 "locales": locales if isinstance(locales, dict) else {},
                 "stars": int(stars) if isinstance(stars, (int, float, str)) and str(stars).isdigit() else 0,
                 "updated_at": updated_at if isinstance(updated_at, (int, str)) else None,


### PR DESCRIPTION
## Summary

Make plugin icons more prominent and align them with the complete plugin identity block on plugin cards.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Increase plugin card icons from 24px to 40px.
- Place each icon to the left of the plugin name, version, author, and status information.
- Preserve existing light and dark icon selection behavior.

## Screenshots / Logs

`npm run build` — passed (`vue-tsc -b && vite build`).

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for light and dark plugin store icons, including automatic handling of alternate dark-icon formats.
  * Plugin cards now display theme-appropriate icons when available.

* **Style**
  * Improved plugin card header layout for clearer visual organization.
  * Enlarged plugin icons for better visibility.
  * Refined alignment between plugin icons and metadata.

* **Bug Fixes**
  * Preserved both light and dark icon URLs when loading plugin store entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->