### PR TITLE
feat(webui): improve mobile header and plugin store layout

### DIFF
--- a/webui/frontend/src/components/icons.ts
+++ b/webui/frontend/src/components/icons.ts
@@ -28,6 +28,10 @@ export const IconHamburger = svgIcon(
   '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />',
 )
 
+export const IconMoreVertical = svgIcon(
+  '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 5.25a.75.75 0 110-1.5.75.75 0 010 1.5zm0 7.5a.75.75 0 110-1.5.75.75 0 010 1.5zm0 7.5a.75.75 0 110-1.5.75.75 0 010 1.5z" />',
+)
+
 export const IconChevronDown = svgIcon(
   '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />',
 )

--- a/webui/frontend/src/components/layout/AppHeader.vue
+++ b/webui/frontend/src/components/layout/AppHeader.vue
@@ -12,9 +12,10 @@
         {{ title }}
       </h2>
     </div>
-    <div class="flex items-center gap-2">
+    <div class="header-actions flex items-center gap-2">
       <!-- Update -->
       <button
+        type="button"
         class="p-1.5 rounded-lg bg-[#f5f5f5] hover:bg-[#e7e7e8] dark:bg-[#121215] dark:hover:bg-[#2b2b2e] transition-colors"
         :class="hasNewVersion ? 'text-blue-500 dark:text-blue-400' : 'text-gray-500 dark:text-gray-400'"
         :aria-label="t('header.releases')"
@@ -46,10 +47,11 @@
       </a>
       <!-- Theme Toggle -->
       <button
+        type="button"
         class="p-1.5 rounded-lg bg-[#f5f5f5] hover:bg-[#e7e7e8] dark:bg-[#121215] dark:hover:bg-[#2b2b2e] text-gray-500 dark:text-gray-400 transition-colors"
         :aria-label="appStore.isDark ? t('header.switch_to_light') : t('header.switch_to_dark')"
         :title="appStore.isDark ? t('header.switch_to_light') : t('header.switch_to_dark')"
-        @click="toggleTheme"
+        @click="handleThemeToggle"
       >
         <IconMoon v-if="!appStore.isDark" class="w-6 h-6" />
         <IconSun v-else class="w-6 h-6" />
@@ -65,6 +67,63 @@
       </button>
     </div>
 
+    <div ref="mobileMenu" class="mobile-header-menu relative">
+      <button
+        type="button"
+        class="p-1.5 rounded-lg bg-[#f5f5f5] hover:bg-[#e7e7e8] dark:bg-[#121215] dark:hover:bg-[#2b2b2e] text-gray-500 dark:text-gray-400 transition-colors"
+        :aria-label="t('header.more_actions')"
+        :title="t('header.more_actions')"
+        :aria-expanded="mobileMenuOpen"
+        aria-haspopup="menu"
+        @click="mobileMenuOpen = !mobileMenuOpen"
+      >
+        <IconMoreVertical class="w-6 h-6" />
+      </button>
+      <Transition name="mobile-header-menu">
+        <div
+          v-if="mobileMenuOpen"
+          class="mobile-header-menu-panel absolute right-0 top-full mt-2 min-w-48 rounded-xl border border-gray-200 bg-white/95 p-1.5 text-gray-600 shadow-lg dark:border-gray-700 dark:bg-[#1b1b1f]/95 dark:text-gray-300"
+          role="menu"
+        >
+          <button type="button" class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]" role="menuitem" @click="openReleases">
+            <IconDownload class="w-5 h-5" :class="hasNewVersion ? 'text-blue-500 dark:text-blue-400' : ''" />
+            <span>{{ t('header.releases') }}</span>
+          </button>
+          <a
+            :href="t('header.docs_url')"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]"
+            role="menuitem"
+            @click="mobileMenuOpen = false"
+          >
+            <IconBook class="w-5 h-5" />
+            <span>{{ t('header.docs') }}</span>
+          </a>
+          <a
+            href="https://github.com/xxynet/KiraAI"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]"
+            role="menuitem"
+            @click="mobileMenuOpen = false"
+          >
+            <IconGithub class="w-5 h-5" />
+            <span>GitHub</span>
+          </a>
+          <button type="button" class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]" role="menuitem" @click="handleThemeToggle">
+            <IconMoon v-if="!appStore.isDark" class="w-5 h-5" />
+            <IconSun v-else class="w-5 h-5" />
+            <span>{{ appStore.isDark ? t('header.switch_to_light') : t('header.switch_to_dark') }}</span>
+          </button>
+          <button type="button" class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]" role="menuitem" @click="handleLogout">
+            <IconLogout class="w-5 h-5" />
+            <span>{{ t('header.logout') }}</span>
+          </button>
+        </div>
+      </Transition>
+    </div>
+
     <!-- Releases Modal -->
     <ReleasesModal
       v-model="showReleases"
@@ -78,7 +137,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
 import { useRouter } from 'vue-router'
@@ -88,7 +147,7 @@ import { getReleases } from '@/api/auth'
 import ReleasesModal from './ReleasesModal.vue'
 import type { ReleaseItem } from '@/types'
 import {
-  IconHamburger, IconDownload, IconBook, IconGithub, IconMoon, IconSun, IconLogout,
+  IconHamburger, IconMoreVertical, IconDownload, IconBook, IconGithub, IconMoon, IconSun, IconLogout,
 } from '@/components/icons'
 
 defineProps<{ title: string }>()
@@ -100,6 +159,8 @@ const authStore = useAuthStore()
 const router = useRouter()
 const { toggleTheme } = useTheme()
 
+const mobileMenu = ref<HTMLElement | null>(null)
+const mobileMenuOpen = ref(false)
 const showReleases = ref(false)
 const releases = ref<ReleaseItem[]>([])
 const currentVersion = ref('')
@@ -115,6 +176,7 @@ const hasNewVersion = computed(() => {
 })
 
 onMounted(async () => {
+  document.addEventListener('pointerdown', closeMobileMenuOnOutsideClick)
   try {
     const { data } = await getReleases()
     currentVersion.value = data.current_version
@@ -124,7 +186,18 @@ onMounted(async () => {
   }
 })
 
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', closeMobileMenuOnOutsideClick)
+})
+
+function closeMobileMenuOnOutsideClick(event: PointerEvent) {
+  if (!mobileMenu.value?.contains(event.target as Node)) {
+    mobileMenuOpen.value = false
+  }
+}
+
 async function openReleases() {
+  mobileMenuOpen.value = false
   showReleases.value = true
   releasesLoading.value = true
   releasesError.value = false
@@ -139,7 +212,13 @@ async function openReleases() {
   }
 }
 
+function handleThemeToggle() {
+  toggleTheme()
+  mobileMenuOpen.value = false
+}
+
 async function handleLogout() {
+  mobileMenuOpen.value = false
   try {
     await authStore.logout()
   } finally {
@@ -147,3 +226,48 @@ async function handleLogout() {
   }
 }
 </script>
+
+<style scoped>
+.mobile-header-menu {
+  display: none;
+}
+
+.mobile-header-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.625rem;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.15s ease, transform 0.15s ease;
+}
+
+.mobile-header-menu-item:active {
+  transform: scale(0.98);
+}
+
+.mobile-header-menu-enter-active,
+.mobile-header-menu-leave-active {
+  transform-origin: top right;
+  transition: opacity 0.16s ease, transform 0.16s ease;
+}
+
+.mobile-header-menu-enter-from,
+.mobile-header-menu-leave-to {
+  opacity: 0;
+  transform: translateY(-0.5rem) scale(0.96);
+}
+
+@media (max-width: 768px) {
+  .header-actions {
+    display: none;
+  }
+
+  .mobile-header-menu {
+    display: block;
+  }
+}
+</style>

--- a/webui/frontend/src/components/layout/AppHeader.vue
+++ b/webui/frontend/src/components/layout/AppHeader.vue
@@ -67,25 +67,26 @@
       </button>
     </div>
 
-    <div ref="mobileMenu" class="mobile-header-menu relative">
+    <div ref="mobileMenu" class="mobile-header-menu relative" @focusout="handleMobileMenuFocusOut" @keydown.esc.prevent.stop="closeMobileMenu(true)">
       <button
+        ref="mobileMenuTrigger"
         type="button"
         class="p-1.5 rounded-lg bg-[#f5f5f5] hover:bg-[#e7e7e8] dark:bg-[#121215] dark:hover:bg-[#2b2b2e] text-gray-500 dark:text-gray-400 transition-colors"
         :aria-label="t('header.more_actions')"
         :title="t('header.more_actions')"
         :aria-expanded="mobileMenuOpen"
-        aria-haspopup="menu"
-        @click="mobileMenuOpen = !mobileMenuOpen"
+        aria-controls="mobile-header-menu-panel"
+        @click="toggleMobileMenu"
       >
         <IconMoreVertical class="w-6 h-6" />
       </button>
       <Transition name="mobile-header-menu">
         <div
           v-if="mobileMenuOpen"
+          id="mobile-header-menu-panel"
           class="mobile-header-menu-panel absolute right-0 top-full mt-2 min-w-48 rounded-xl border border-gray-200 bg-white/95 p-1.5 text-gray-600 shadow-lg dark:border-gray-700 dark:bg-[#1b1b1f]/95 dark:text-gray-300"
-          role="menu"
         >
-          <button type="button" class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]" role="menuitem" @click="openReleases">
+          <button type="button" class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]" @click="openReleases">
             <IconDownload class="w-5 h-5" :class="hasNewVersion ? 'text-blue-500 dark:text-blue-400' : ''" />
             <span>{{ t('header.releases') }}</span>
           </button>
@@ -94,8 +95,7 @@
             target="_blank"
             rel="noopener noreferrer"
             class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]"
-            role="menuitem"
-            @click="mobileMenuOpen = false"
+            @click="() => closeMobileMenu()"
           >
             <IconBook class="w-5 h-5" />
             <span>{{ t('header.docs') }}</span>
@@ -105,18 +105,17 @@
             target="_blank"
             rel="noopener noreferrer"
             class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]"
-            role="menuitem"
-            @click="mobileMenuOpen = false"
+            @click="() => closeMobileMenu()"
           >
             <IconGithub class="w-5 h-5" />
             <span>GitHub</span>
           </a>
-          <button type="button" class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]" role="menuitem" @click="handleThemeToggle">
+          <button type="button" class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]" @click="handleThemeToggle">
             <IconMoon v-if="!appStore.isDark" class="w-5 h-5" />
             <IconSun v-else class="w-5 h-5" />
             <span>{{ appStore.isDark ? t('header.switch_to_light') : t('header.switch_to_dark') }}</span>
           </button>
-          <button type="button" class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]" role="menuitem" @click="handleLogout">
+          <button type="button" class="mobile-header-menu-item hover:bg-gray-100 active:bg-gray-200 focus-visible:bg-gray-100 dark:hover:bg-[#2b2b2e] dark:active:bg-[#3a3a3e] dark:focus-visible:bg-[#2b2b2e]" @click="handleLogout">
             <IconLogout class="w-5 h-5" />
             <span>{{ t('header.logout') }}</span>
           </button>
@@ -137,7 +136,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
 import { useRouter } from 'vue-router'
@@ -160,6 +159,7 @@ const router = useRouter()
 const { toggleTheme } = useTheme()
 
 const mobileMenu = ref<HTMLElement | null>(null)
+const mobileMenuTrigger = ref<HTMLButtonElement | null>(null)
 const mobileMenuOpen = ref(false)
 const showReleases = ref(false)
 const releases = ref<ReleaseItem[]>([])
@@ -192,12 +192,33 @@ onBeforeUnmount(() => {
 
 function closeMobileMenuOnOutsideClick(event: PointerEvent) {
   if (!mobileMenu.value?.contains(event.target as Node)) {
-    mobileMenuOpen.value = false
+    closeMobileMenu()
+  }
+}
+
+function toggleMobileMenu() {
+  if (mobileMenuOpen.value) {
+    closeMobileMenu()
+  } else {
+    mobileMenuOpen.value = true
+  }
+}
+
+function closeMobileMenu(restoreFocus = false) {
+  mobileMenuOpen.value = false
+  if (restoreFocus) {
+    nextTick(() => mobileMenuTrigger.value?.focus())
+  }
+}
+
+function handleMobileMenuFocusOut(event: FocusEvent) {
+  if (!event.relatedTarget || !mobileMenu.value?.contains(event.relatedTarget as Node)) {
+    closeMobileMenu()
   }
 }
 
 async function openReleases() {
-  mobileMenuOpen.value = false
+  closeMobileMenu()
   showReleases.value = true
   releasesLoading.value = true
   releasesError.value = false
@@ -212,13 +233,13 @@ async function openReleases() {
   }
 }
 
-function handleThemeToggle() {
-  toggleTheme()
-  mobileMenuOpen.value = false
+async function handleThemeToggle() {
+  closeMobileMenu()
+  await toggleTheme()
 }
 
 async function handleLogout() {
-  mobileMenuOpen.value = false
+  closeMobileMenu()
   try {
     await authStore.logout()
   } finally {

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -12,6 +12,7 @@ export default {
   },
   header: {
     logout: 'Logout',
+    more_actions: 'More actions',
     theme_toggle: 'Toggle theme',
     switch_to_light: 'Switch to light theme',
     switch_to_dark: 'Switch to dark theme',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -12,6 +12,7 @@ export default {
   },
   header: {
     logout: '退出登录',
+    more_actions: '更多操作',
     theme_toggle: '切换主题',
     switch_to_light: '切换到浅色主题',
     switch_to_dark: '切换到深色主题',

--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -6,7 +6,7 @@
     </div>
 
     <!-- Custom Tabs -->
-    <div class="flex space-x-4 mb-4 border-b border-gray-200 dark:border-gray-700">
+    <div class="flex flex-wrap gap-x-4 mb-4 border-b border-gray-200 dark:border-gray-700">
       <button
         type="button"
         class="px-3 py-2 text-sm font-medium border-b-2 focus:outline-none transition-colors duration-150"
@@ -51,7 +51,7 @@
 
     <!-- Plugins Tab Content -->
     <div v-show="activeTab === 'plugins'">
-      <div class="flex items-center justify-start mb-4">
+      <div class="flex flex-wrap items-center gap-2 mb-4">
         <button
           type="button"
           class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
@@ -62,20 +62,20 @@
         </button>
         <button
           type="button"
-          class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors ml-2"
+          class="inline-flex shrink-0 items-center whitespace-nowrap px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           :disabled="refreshingPlugins"
           @click="refreshPlugins"
         >
           <IconRefresh class="w-4 h-4 mr-1" :class="{ 'animate-spin': refreshingPlugins }" />
           <span>{{ $t('common.refresh') }}</span>
         </button>
-        <div class="relative ml-auto">
+        <div class="relative w-full sm:ml-auto sm:w-56">
           <input
             v-model="pluginsSearchTerm"
             type="text"
             :placeholder="$t('plugin.search_placeholder')"
             :aria-label="$t('plugin.search_placeholder')"
-            class="w-full sm:w-56 border border-gray-300 dark:border-gray-600 rounded-lg pl-9 pr-3 py-1.5 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+            class="w-full border border-gray-300 dark:border-gray-600 rounded-lg pl-9 pr-3 py-1.5 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
           />
           <IconSearch class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
         </div>
@@ -138,7 +138,7 @@
 
     <!-- MCP Tab Content -->
     <div v-show="activeTab === 'mcp'">
-      <div class="flex items-center justify-start mb-4">
+      <div class="flex flex-wrap items-center gap-2 mb-4">
         <button
           type="button"
           class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
@@ -220,7 +220,7 @@
 
     <!-- Skills Tab Content -->
     <div v-show="activeTab === 'skills'">
-      <div class="flex items-center justify-start mb-4">
+      <div class="flex flex-wrap items-center gap-2 mb-4">
         <button
           type="button"
           class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors mr-2"
@@ -231,7 +231,7 @@
         </button>
         <button
           type="button"
-          class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          class="inline-flex shrink-0 items-center whitespace-nowrap px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           @click="refreshSkillList"
         >
           <IconRefresh class="w-4 h-4 mr-1" />
@@ -447,10 +447,10 @@
     <!-- Plugin Store Tab Content -->
     <div v-show="activeTab === 'pluginStore'">
       <!-- Plugin Sources Button -->
-      <div class="flex items-center justify-start mb-4">
+      <div class="flex flex-wrap items-center gap-2 mb-4">
         <button
           type="button"
-          class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          class="inline-flex shrink-0 items-center whitespace-nowrap px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           @click="openSourceManage"
         >
           <IconCog class="w-4 h-4 mr-1" />
@@ -459,36 +459,36 @@
         <button
           v-if="currentStoreSource"
           type="button"
-          class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors ml-2"
+          class="inline-flex shrink-0 items-center whitespace-nowrap px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           :disabled="storeLoading"
           @click="() => fetchStorePlugins(true)"
         >
           <IconRefresh class="w-4 h-4 mr-1" :class="{ 'animate-spin': storeLoading }" />
           <span>{{ $t('common.refresh') }}</span>
         </button>
-        <span v-if="currentStoreSource" class="ml-3 text-sm text-gray-500 dark:text-gray-400">
+        <span v-if="currentStoreSource" class="w-full text-sm text-gray-500 dark:text-gray-400 sm:w-auto sm:ml-1">
           {{ $t('pluginStore.current_source') }}: <span class="font-medium text-gray-700 dark:text-gray-300">{{ currentStoreSource.name }}</span>
         </span>
-        <div v-if="currentStoreSource && !storeLoading && storePlugins.length > 0" class="ml-auto flex flex-wrap items-center justify-end gap-3">
-          <label class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+        <div v-if="currentStoreSource && !storeLoading && storePlugins.length > 0" class="flex w-full flex-col gap-3 sm:ml-auto sm:w-auto sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
+          <label class="flex w-full items-center justify-between gap-2 text-sm text-gray-600 dark:text-gray-300 sm:w-auto sm:justify-start">
             <span>{{ $t('pluginStore.category') }}</span>
-            <div class="w-32 plugin-store-select">
+            <div class="w-32 shrink-0 plugin-store-select">
               <CustomSelect v-model="storeCategory" :options="storeCategoryOptions" />
             </div>
           </label>
-          <label class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+          <label class="flex w-full items-center justify-between gap-2 text-sm text-gray-600 dark:text-gray-300 sm:w-auto sm:justify-start">
             <span>{{ $t('pluginStore.sort') }}</span>
-            <div class="w-32 plugin-store-select">
+            <div class="w-32 shrink-0 plugin-store-select">
               <CustomSelect v-model="storeSort" :options="storeSortOptions" />
             </div>
           </label>
-          <div class="relative">
+          <div class="relative w-full sm:w-56">
             <input
               v-model="storeSearchTerm"
               type="text"
               :placeholder="$t('plugin.search_placeholder')"
               :aria-label="$t('plugin.search_placeholder')"
-              class="w-full sm:w-56 border border-gray-300 dark:border-gray-600 rounded-lg pl-9 pr-3 py-1.5 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+              class="w-full border border-gray-300 dark:border-gray-600 rounded-lg pl-9 pr-3 py-1.5 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
             />
             <IconSearch class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
           </div>


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Improves the WebUI experience on small screens by moving header actions into a three-dot menu and restructuring Plugin Store controls to avoid compressed, wrapped labels.

## Type of change

- [x] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Add a responsive header actions menu for screens up to 768px, with labels, dark-mode styling, interaction states, and open/close animation.
- Add localized accessible text for the header actions menu and a reusable vertical ellipsis icon.
- Make Plugin page tabs and toolbars responsive; use a clear stacked layout for Plugin Store source, filters, and search on mobile.

## Screenshots / Logs

- `npm run build` passed (`vue-tsc -b && vite build`).

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive mobile overflow menu for header actions, including releases, documentation, GitHub, theme switching, and logout.
  * Added localized “More actions” labels in English and Chinese.
  * Added intuitive menu behavior, including outside-click, Escape-key, and focus-based dismissal.

* **UI Improvements**
  * Improved Plugin, MCP, Skills, and Plugin Store toolbar layouts on narrow screens.
  * Updated controls, filters, and source information to adapt more cleanly across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->