### PR TITLE
feat(file): add managed background exec tasks

### DIFF
--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -46,7 +46,7 @@ class BackgroundExecTask:
     execution_task: asyncio.Task[str] | None = None
     status: str = "starting"
     stop_requested: bool = False
-    notify_on_completion: bool = True
+    notify_on_completion: bool = False
 
 
 class FilePlugin(BasePlugin):
@@ -118,7 +118,25 @@ class FilePlugin(BasePlugin):
             req.tool_set.remove(*disabled)
 
     async def terminate(self):
-        pass
+        background_tasks = list(self._background_exec_tasks.values())
+        self._background_exec_tasks.clear()
+        for background_task in background_tasks:
+            background_task.stop_requested = True
+            background_task.notify_on_completion = False
+            await self._terminate_background_process(background_task.process)
+            if background_task.execution_task is not None:
+                background_task.execution_task.cancel()
+
+        notice_tasks = list(self._background_notice_tasks)
+        for notice_task in notice_tasks:
+            notice_task.cancel()
+
+        await asyncio.gather(
+            *(task.execution_task for task in background_tasks if task.execution_task is not None),
+            *notice_tasks,
+            return_exceptions=True,
+        )
+        self._background_notice_tasks.clear()
 
     @staticmethod
     def _run_shell_command(
@@ -207,20 +225,17 @@ class FilePlugin(BasePlugin):
                 asyncio.create_task(self._read_background_output(process.stderr, background_task)),
             ]
 
-            if background_task.stop_requested:
-                await self._terminate_background_process(process)
-                background_task.status = "stopped"
-                return "Shell command stopped by request"
-
+            timed_out = False
             try:
-                await asyncio.wait_for(process.wait(), timeout=background_task.timeout)
-            except asyncio.TimeoutError:
-                background_task.status = "timed_out"
-                await self._terminate_background_process(process)
-                return (
-                    f"Shell command timed out after {background_task.timeout} seconds: "
-                    f"{shell_command}"
-                )
+                if background_task.stop_requested:
+                    await self._terminate_background_process(process)
+                else:
+                    try:
+                        await asyncio.wait_for(process.wait(), timeout=background_task.timeout)
+                    except asyncio.TimeoutError:
+                        timed_out = True
+                        background_task.status = "timed_out"
+                        await self._terminate_background_process(process)
             finally:
                 await asyncio.gather(*readers, return_exceptions=True)
 
@@ -228,6 +243,11 @@ class FilePlugin(BasePlugin):
             if background_task.stop_requested:
                 background_task.status = "stopped"
                 return f"Shell command stopped by request:\n{output}"
+            if timed_out:
+                return (
+                    f"Shell command timed out after {background_task.timeout} seconds: "
+                    f"{shell_command}"
+                )
             if process.returncode == 0:
                 background_task.status = "completed"
                 return f"Shell command output:\n{output}"
@@ -985,17 +1005,16 @@ class FilePlugin(BasePlugin):
         )
         background_task.execution_task = command_task
         self._background_exec_tasks[task_id] = background_task
+        command_task.add_done_callback(
+            lambda task: self._on_background_exec_done(task_id, event.sid, task)
+        )
         try:
-            result = await asyncio.wait_for(
+            return await asyncio.wait_for(
                 asyncio.shield(command_task),
                 timeout=self._background_exec_wait_seconds,
             )
-            self._background_exec_tasks.pop(task_id, None)
-            return result
         except asyncio.TimeoutError:
-            command_task.add_done_callback(
-                lambda task: self._on_background_exec_done(task_id, event.sid, task)
-            )
+            background_task.notify_on_completion = True
             return (
                 f"Shell command is running in the background (task_id: {task_id}). "
                 "The result will be sent to this session when it completes."

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -4,11 +4,16 @@ import shutil
 import asyncio
 import posixpath
 import subprocess
+import signal
+from dataclasses import dataclass, field
+from time import monotonic
+from uuid import uuid4
 
 from pathlib import Path
 
 from core.plugin import BasePlugin, logger, on, Priority, register
-from core.chat import KiraMessageBatchEvent
+from core.chat import KiraMessageBatchEvent, MessageChain
+from core.chat.message_elements import Text
 from core.provider import LLMRequest
 
 from core.utils.path_utils import get_data_path, get_root_path
@@ -23,7 +28,25 @@ blocked_extensions = {'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg',
                       '.dll', '.so', '.dylib', '.pdf', '.doc', '.docx', '.xls', '.xlsx',
                       '.ppt', '.pptx', '.iso', '.img', '.dmg'}
 
-ALL_TOOL_NAMES = ["read_file", "write_file", "edit_file", "list_files", "grep", "search_files", "exec"]
+ALL_TOOL_NAMES = [
+    "read_file", "write_file", "edit_file", "list_files", "grep", "search_files",
+    "exec", "manage_background_exec",
+]
+
+
+@dataclass
+class BackgroundExecTask:
+    task_id: str
+    session: str
+    work_dir: Path
+    timeout: int
+    started_at: float = field(default_factory=monotonic)
+    output_chunks: list[str] = field(default_factory=list)
+    process: asyncio.subprocess.Process | None = None
+    execution_task: asyncio.Task[str] | None = None
+    status: str = "starting"
+    stop_requested: bool = False
+    notify_on_completion: bool = True
 
 
 class FilePlugin(BasePlugin):
@@ -39,10 +62,23 @@ class FilePlugin(BasePlugin):
         self.allowed_read_paths = tuple()
         self.allowed_write_paths = tuple()
 
+        self._exec_timeout = 30
+        self._background_exec_timeout = 300
+        self._background_exec_wait_seconds = 2
+        self._background_exec_tasks: dict[str, BackgroundExecTask] = {}
+        self._background_notice_tasks: set[asyncio.Task] = set()
+
     async def initialize(self):
         self.allowed_sessions = self.plugin_cfg.get("allowed_sessions", [])
         self.allowed_exec_sessions = self.plugin_cfg.get("allowed_exec_sessions", [])
         self.exec_deny_list = self.plugin_cfg.get("exec_deny_list", [])
+        self._exec_timeout = self._get_positive_int_config("exec_timeout", 30)
+        self._background_exec_timeout = self._get_positive_int_config(
+            "background_exec_timeout", 300
+        )
+        self._background_exec_wait_seconds = self._get_positive_int_config(
+            "background_exec_wait_seconds", 2
+        )
         base_read = ["data/files", "data/temp", "data/skills"]
         base_write = ["data/files", "data/temp"]
         extra_paths_cfg = self.plugin_cfg.get("extra_paths", {})
@@ -51,17 +87,206 @@ class FilePlugin(BasePlugin):
         self.allowed_read_paths = tuple(base_read + extra_read)
         self.allowed_write_paths = tuple(base_write + extra_write)
 
+    def _get_positive_int_config(self, key: str, default: int) -> int:
+        value = self.plugin_cfg.get(key, default)
+        if isinstance(value, bool):
+            value = None
+        else:
+            try:
+                value = int(value)
+            except (TypeError, ValueError):
+                value = None
+
+        if value is not None and value > 0:
+            return value
+
+        logger.warning(f"Invalid {key} value; using default of {default} seconds")
+        return default
+
     @on.llm_request(priority=Priority.LOW)
     async def filter_tools(self, event: KiraMessageBatchEvent, req: LLMRequest, *_):
         enabled = self.plugin_cfg.get("enabled_tools")
         if enabled is None:
             enabled = ALL_TOOL_NAMES
-        disabled = set(ALL_TOOL_NAMES) - set(enabled)
+        enabled = set(enabled)
+        if "exec" in enabled:
+            enabled.add("manage_background_exec")
+        else:
+            enabled.discard("manage_background_exec")
+        disabled = set(ALL_TOOL_NAMES) - enabled
         if disabled:
             req.tool_set.remove(*disabled)
 
     async def terminate(self):
         pass
+
+    @staticmethod
+    def _run_shell_command(
+        shell_command: str,
+        exec_timeout: int,
+        env: dict[str, str],
+        exec_work_dir: Path,
+    ) -> str:
+        try:
+            result = subprocess.run(
+                shell_command, shell=True, capture_output=True,
+                stdin=subprocess.DEVNULL,
+                timeout=exec_timeout, env=env, cwd=exec_work_dir,
+                encoding='utf-8', errors='replace'
+            )
+            output = (result.stdout or '') + (result.stderr or '')
+            if result.returncode == 0:
+                return f'Shell command output:\n{output}'
+            return f'Shell command failed (exit {result.returncode}):\n{output}'
+        except subprocess.TimeoutExpired:
+            return f'Shell command timed out after {exec_timeout} seconds: {shell_command}'
+        except Exception as e:
+            return f'Unexpected error while executing shell command: {e}'
+
+    @staticmethod
+    async def _read_background_output(
+        stream: asyncio.StreamReader | None,
+        background_task: BackgroundExecTask,
+    ):
+        if stream is None:
+            return
+        while chunk := await stream.read(4096):
+            background_task.output_chunks.append(chunk.decode("utf-8", errors="replace"))
+
+    @staticmethod
+    async def _terminate_background_process(process: asyncio.subprocess.Process | None):
+        if process is None or process.returncode is not None:
+            return
+
+        try:
+            if os.name == "nt":
+                killer = await asyncio.create_subprocess_exec(
+                    "taskkill", "/PID", str(process.pid), "/T", "/F",
+                    stdin=asyncio.subprocess.DEVNULL,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await asyncio.wait_for(killer.wait(), timeout=5)
+            else:
+                os.killpg(process.pid, signal.SIGTERM)
+        except (OSError, ProcessLookupError, asyncio.TimeoutError):
+            process.kill()
+
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5)
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+
+    async def _run_background_shell_command(
+        self,
+        shell_command: str,
+        background_task: BackgroundExecTask,
+        env: dict[str, str],
+    ) -> str:
+        process_kwargs = {}
+        if os.name == "nt":
+            process_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            process_kwargs["start_new_session"] = True
+
+        try:
+            process = await asyncio.create_subprocess_shell(
+                shell_command,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=background_task.work_dir,
+                env=env,
+                **process_kwargs,
+            )
+            background_task.process = process
+            background_task.status = "running"
+            readers = [
+                asyncio.create_task(self._read_background_output(process.stdout, background_task)),
+                asyncio.create_task(self._read_background_output(process.stderr, background_task)),
+            ]
+
+            if background_task.stop_requested:
+                await self._terminate_background_process(process)
+                background_task.status = "stopped"
+                return "Shell command stopped by request"
+
+            try:
+                await asyncio.wait_for(process.wait(), timeout=background_task.timeout)
+            except asyncio.TimeoutError:
+                background_task.status = "timed_out"
+                await self._terminate_background_process(process)
+                return (
+                    f"Shell command timed out after {background_task.timeout} seconds: "
+                    f"{shell_command}"
+                )
+            finally:
+                await asyncio.gather(*readers, return_exceptions=True)
+
+            output = "".join(background_task.output_chunks)
+            if background_task.stop_requested:
+                background_task.status = "stopped"
+                return f"Shell command stopped by request:\n{output}"
+            if process.returncode == 0:
+                background_task.status = "completed"
+                return f"Shell command output:\n{output}"
+            background_task.status = "failed"
+            return f"Shell command failed (exit {process.returncode}):\n{output}"
+        except Exception as e:
+            background_task.status = "failed"
+            return f"Unexpected error while executing shell command: {e}"
+
+    async def _stop_background_task(self, background_task: BackgroundExecTask):
+        background_task.stop_requested = True
+        background_task.notify_on_completion = False
+        if background_task.process is not None:
+            await self._terminate_background_process(background_task.process)
+
+    async def _publish_background_exec_result(
+        self,
+        task_id: str,
+        session: str,
+        status: str,
+        task: asyncio.Task[str],
+    ):
+        try:
+            result = task.result()
+        except asyncio.CancelledError:
+            result = "Shell command was cancelled"
+        except Exception as e:
+            result = f"Unexpected error while executing shell command: {e}"
+
+        try:
+            status_text = {
+                "completed": "completed",
+                "timed_out": "timed out",
+                "failed": "failed",
+            }.get(status, "finished")
+            message = f"Background shell command {status_text} (task_id: {task_id}):\n{result}"
+            await self.ctx.publish_notice(
+                session,
+                MessageChain([Text(message)]),
+                is_mentioned=True,
+            )
+        except Exception as e:
+            logger.error(f"Failed to publish background shell command result for task {task_id}: {e}")
+
+    def _on_background_exec_done(self, task_id: str, session: str, task: asyncio.Task[str]):
+        background_task = self._background_exec_tasks.pop(task_id, None)
+        if background_task is None or not background_task.notify_on_completion:
+            return
+        notice_task = asyncio.create_task(
+            self._publish_background_exec_result(
+                task_id,
+                session,
+                background_task.status,
+                task,
+            ),
+            name=f"file_exec_notice_{task_id}",
+        )
+        self._background_notice_tasks.add(notice_task)
+        notice_task.add_done_callback(self._background_notice_tasks.discard)
 
     def _is_path_allowed(self, path: str, allowed_prefixes: tuple) -> bool:
         """Check if path starts with an allowed prefix directory."""
@@ -684,7 +909,7 @@ class FilePlugin(BasePlugin):
                 },
                 "background": {
                     "type": "boolean",
-                    "description": "Whether to run the command in the background, without waiting for output. Defaults to false."
+                    "description": "Whether to run the command in the background. Waits for the configured background wait time before returning a task ID, then sends the completed result to this session. Defaults to false."
                 }
             },
             "required": ["cmd"]
@@ -693,8 +918,6 @@ class FilePlugin(BasePlugin):
     async def exec(self, event: KiraMessageBatchEvent, cmd: str, work_dir: str | None = None, background: bool = False) -> str:
         if event.sid not in self.allowed_exec_sessions:
             return "Permission denied: current session not allowed to execute shell commands"
-
-        import subprocess
 
         shell_command = cmd.strip()
 
@@ -739,22 +962,104 @@ class FilePlugin(BasePlugin):
         if os.name == 'nt':
             shell_command = f'chcp 65001 >nul && {shell_command}'
 
-        exec_timeout = 30  # seconds
-
         logger.info(f'Executing shell command: {shell_command} (cwd: {exec_work_dir})')
-        try:
-            result = subprocess.run(
-                shell_command, shell=True, capture_output=True,
-                stdin=subprocess.DEVNULL,
-                timeout=exec_timeout, env=env, cwd=exec_work_dir,
-                encoding='utf-8', errors='replace'
+        if not background:
+            return await asyncio.to_thread(
+                self._run_shell_command,
+                shell_command,
+                self._exec_timeout,
+                env,
+                exec_work_dir,
             )
-            output = (result.stdout or '') + (result.stderr or '')
-            if result.returncode == 0:
-                return f'Shell command output:\n{output}'
-            else:
-                return f'Shell command failed (exit {result.returncode}):\n{output}'
-        except subprocess.TimeoutExpired:
-            return f'Shell command timed out after {exec_timeout} seconds: {shell_command}'
-        except Exception as e:
-            return f'Unexpected error while executing shell command: {e}'
+
+        task_id = f"exec-{uuid4().hex}"
+        background_task = BackgroundExecTask(
+            task_id=task_id,
+            session=event.sid,
+            work_dir=exec_work_dir,
+            timeout=self._background_exec_timeout,
+        )
+        command_task = asyncio.create_task(
+            self._run_background_shell_command(shell_command, background_task, env),
+            name=f"exec_task_{task_id}",
+        )
+        background_task.execution_task = command_task
+        self._background_exec_tasks[task_id] = background_task
+        try:
+            result = await asyncio.wait_for(
+                asyncio.shield(command_task),
+                timeout=self._background_exec_wait_seconds,
+            )
+            self._background_exec_tasks.pop(task_id, None)
+            return result
+        except asyncio.TimeoutError:
+            command_task.add_done_callback(
+                lambda task: self._on_background_exec_done(task_id, event.sid, task)
+            )
+            return (
+                f"Shell command is running in the background (task_id: {task_id}). "
+                "The result will be sent to this session when it completes."
+            )
+
+    @register.tool(
+        "manage_background_exec",
+        "List, inspect output from, or stop background shell commands started in the current session.",
+        {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "output", "stop"],
+                    "description": "Use 'list' to view running tasks, 'output' to view a task's current output, or 'stop' to stop a task.",
+                },
+                "task_id": {
+                    "type": "string",
+                    "description": "Required for the 'output' and 'stop' actions."
+                },
+            },
+            "required": ["action"],
+        },
+    )
+    async def manage_background_exec(
+        self,
+        event: KiraMessageBatchEvent,
+        action: str,
+        task_id: str | None = None,
+    ) -> str:
+        if event.sid not in self.allowed_exec_sessions:
+            return "Permission denied: current session not allowed to manage shell commands"
+
+        if action == "list":
+            session_tasks = [
+                task for task in self._background_exec_tasks.values()
+                if task.session == event.sid
+            ]
+            if not session_tasks:
+                return "No background tasks are currently running."
+
+            return "Running background tasks:\n" + "\n".join(
+                (
+                    f"- {task.task_id} | status: {task.status} | "
+                    f"elapsed: {int(monotonic() - task.started_at)}s | "
+                    f"output: {sum(len(chunk) for chunk in task.output_chunks)} chars"
+                )
+                for task in session_tasks
+            )
+
+        if action not in {"output", "stop"}:
+            return "Invalid action. Use one of: list, output, stop."
+        if not task_id:
+            return f"task_id is required for the '{action}' action"
+
+        background_task = self._background_exec_tasks.get(task_id)
+        if background_task is None or background_task.session != event.sid:
+            return f"Background task not found: {task_id}"
+
+        if action == "output":
+            output = "".join(background_task.output_chunks)
+            if not output:
+                return f"No output has been produced yet for task {task_id}."
+            return f"Current output for task {task_id}:\n{output}"
+
+        await self._stop_background_task(background_task)
+        return f"Stop requested for background task {task_id}."

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -11,7 +11,7 @@ from core.plugin import BasePlugin, logger, on, Priority, register
 from core.chat import KiraMessageBatchEvent
 from core.provider import LLMRequest
 
-from core.utils.path_utils import get_data_path
+from core.utils.path_utils import get_data_path, get_root_path
 
 restricted_paths = ['~/.ssh/', '~/.gnupg/', '~/.aws/', '~/.config/gh/', '.pem',
                     '.p12', 'key', 'secret', 'password', 'token', 'credential']
@@ -678,17 +678,40 @@ class FilePlugin(BasePlugin):
             "type": "object",
             "properties": {
                 "cmd": {"type": "string", "description": "Command to execute"},
+                "work_dir": {
+                    "type": "string",
+                    "description": "Optional existing working directory. Relative paths are resolved from the application root."
+                },
+                "background": {
+                    "type": "boolean",
+                    "description": "Whether to run the command in the background, without waiting for output. Defaults to false."
+                }
             },
             "required": ["cmd"]
         }
     )
-    async def exec(self, event: KiraMessageBatchEvent, cmd: str) -> str:
+    async def exec(self, event: KiraMessageBatchEvent, cmd: str, work_dir: str | None = None, background: bool = False) -> str:
         if event.sid not in self.allowed_exec_sessions:
             return "Permission denied: current session not allowed to execute shell commands"
 
         import subprocess
 
         shell_command = cmd.strip()
+
+        exec_work_dir = get_root_path()
+        if work_dir is not None:
+            if not isinstance(work_dir, str) or not work_dir.strip():
+                return "Working directory must be a non-empty string"
+            try:
+                exec_work_dir = Path(work_dir).expanduser()
+                if not exec_work_dir.is_absolute():
+                    exec_work_dir = get_root_path() / exec_work_dir
+                exec_work_dir = exec_work_dir.resolve(strict=True)
+            except (OSError, RuntimeError, ValueError):
+                return f"Working directory not found: {work_dir}"
+
+            if not exec_work_dir.is_dir():
+                return f"Working directory is not a directory: {work_dir}"
 
         # Check deny list
         if self.exec_deny_list:
@@ -718,12 +741,13 @@ class FilePlugin(BasePlugin):
 
         exec_timeout = 30  # seconds
 
-        logger.info(f'Executing shell command: {shell_command} (cwd: {os.getcwd()})')
+        logger.info(f'Executing shell command: {shell_command} (cwd: {exec_work_dir})')
         try:
             result = subprocess.run(
                 shell_command, shell=True, capture_output=True,
                 stdin=subprocess.DEVNULL,
-                timeout=exec_timeout, env=env, encoding='utf-8', errors='replace'
+                timeout=exec_timeout, env=env, cwd=exec_work_dir,
+                encoding='utf-8', errors='replace'
             )
             output = (result.stdout or '') + (result.stderr or '')
             if result.returncode == 0:

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -32,6 +32,7 @@ ALL_TOOL_NAMES = [
     "read_file", "write_file", "edit_file", "list_files", "grep", "search_files",
     "exec", "manage_background_exec",
 ]
+PROCESS_TERMINATION_GRACE_SECONDS = 5
 
 
 @dataclass
@@ -184,16 +185,33 @@ class FilePlugin(BasePlugin):
                     stdout=asyncio.subprocess.DEVNULL,
                     stderr=asyncio.subprocess.DEVNULL,
                 )
-                await asyncio.wait_for(killer.wait(), timeout=5)
+                await asyncio.wait_for(killer.wait(), timeout=PROCESS_TERMINATION_GRACE_SECONDS)
+                if killer.returncode != 0 and process.returncode is None:
+                    logger.warning(
+                        f"taskkill failed for background process {process.pid} "
+                        f"with exit code {killer.returncode}; killing the shell process"
+                    )
+                    process.kill()
             else:
                 os.killpg(process.pid, signal.SIGTERM)
         except (OSError, ProcessLookupError, asyncio.TimeoutError):
-            process.kill()
+            if process.returncode is None:
+                process.kill()
 
         try:
-            await asyncio.wait_for(process.wait(), timeout=5)
+            await asyncio.wait_for(process.wait(), timeout=PROCESS_TERMINATION_GRACE_SECONDS)
         except asyncio.TimeoutError:
-            process.kill()
+            if os.name == "nt":
+                logger.warning(
+                    f"Background process {process.pid} did not exit after taskkill; killing the shell process"
+                )
+                if process.returncode is None:
+                    process.kill()
+            else:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except (OSError, ProcessLookupError):
+                    pass
             await process.wait()
 
     async def _run_background_shell_command(
@@ -1019,6 +1037,16 @@ class FilePlugin(BasePlugin):
                 f"Shell command is running in the background (task_id: {task_id}). "
                 "The result will be sent to this session when it completes."
             )
+        except asyncio.CancelledError:
+            background_task.notify_on_completion = False
+            await self._stop_background_task(background_task)
+            try:
+                await asyncio.shield(command_task)
+            except asyncio.CancelledError:
+                pass
+            finally:
+                self._background_exec_tasks.pop(task_id, None)
+            raise
 
     @register.tool(
         "manage_background_exec",

--- a/core/plugin/builtin_plugins/file/schema.json
+++ b/core/plugin/builtin_plugins/file/schema.json
@@ -36,6 +36,33 @@
       "zh": { "name": "命令黑名单", "hint": "禁止执行的命令列表" }
     }
   },
+  "exec_timeout": {
+    "name": "Exec Timeout",
+    "type": "integer",
+    "default": 30,
+    "hint": "Maximum runtime in seconds for commands without background mode.",
+    "locales": {
+      "zh": { "name": "前台命令超时", "hint": "未启用后台模式的命令最大运行时间，单位为秒。" }
+    }
+  },
+  "background_exec_timeout": {
+    "name": "Background Exec Timeout",
+    "type": "integer",
+    "default": 300,
+    "hint": "Maximum total runtime in seconds for commands in background mode.",
+    "locales": {
+      "zh": { "name": "后台命令超时", "hint": "启用后台模式的命令最大总运行时间，单位为秒。" }
+    }
+  },
+  "background_exec_wait_seconds": {
+    "name": "Background Exec Wait Time",
+    "type": "integer",
+    "default": 2,
+    "hint": "How long to wait in seconds for a background command to finish before returning a task ID.",
+    "locales": {
+      "zh": { "name": "后台命令等待时长", "hint": "后台命令开始后等待结果的时长；超过该时长将返回任务 ID，单位为秒。" }
+    }
+  },
   "extra_paths": {
     "type": "section",
     "name": "Extra Allowed Paths",

--- a/tests/test_file_plugin.py
+++ b/tests/test_file_plugin.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from core.plugin.builtin_plugins.file.main import FilePlugin
+
+
+@pytest.fixture
+def file_plugin():
+    plugin = FilePlugin.__new__(FilePlugin)
+    plugin.allowed_exec_sessions = ["test:dm:1"]
+    plugin.exec_deny_list = []
+    return plugin
+
+
+@pytest.mark.anyio
+async def test_exec_uses_resolved_work_dir(file_plugin, tmp_path):
+    event = SimpleNamespace(sid="test:dm:1")
+    completed = SimpleNamespace(stdout="ok", stderr="", returncode=0)
+
+    with patch(
+        "core.plugin.builtin_plugins.file.main.subprocess.run",
+        return_value=completed,
+    ) as run:
+        result = await file_plugin.exec(event, "echo test", str(tmp_path))
+
+    assert result == "Shell command output:\nok"
+    assert run.call_args.kwargs["cwd"] == tmp_path.resolve()
+
+
+@pytest.mark.anyio
+async def test_exec_rejects_missing_work_dir(file_plugin, tmp_path):
+    event = SimpleNamespace(sid="test:dm:1")
+    missing_dir = tmp_path / "missing"
+
+    with patch("core.plugin.builtin_plugins.file.main.subprocess.run") as run:
+        result = await file_plugin.exec(event, "echo test", str(missing_dir))
+
+    assert result == f"Working directory not found: {missing_dir}"
+    run.assert_not_called()

--- a/tests/test_file_plugin.py
+++ b/tests/test_file_plugin.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from core.plugin.builtin_plugins.file import main as file_main
 from core.plugin.builtin_plugins.file.main import BackgroundExecTask, FilePlugin
 
 
@@ -36,6 +37,25 @@ class FakeBackgroundProcess:
 
     def kill(self):
         self.terminate()
+
+
+class ResistantProcess:
+    def __init__(self):
+        self.pid = 12345
+        self.returncode = None
+        self._finished = asyncio.Event()
+
+    async def wait(self):
+        await self._finished.wait()
+        return self.returncode
+
+
+class FakeKillerProcess:
+    def __init__(self, returncode: int):
+        self.returncode = returncode
+
+    async def wait(self):
+        return self.returncode
 
 
 @pytest.fixture
@@ -239,11 +259,19 @@ async def test_cancelled_background_exec_cleans_up_task(file_plugin):
     event = SimpleNamespace(sid="test:dm:1")
     file_plugin.ctx = SimpleNamespace(publish_notice=AsyncMock())
     file_plugin._background_exec_wait_seconds = 1
-    process = FakeBackgroundProcess(delay=0.05)
+    process = FakeBackgroundProcess(delay=1)
+
+    async def terminate_process(fake_process):
+        fake_process.terminate()
+        await fake_process.wait()
 
     with patch(
         "core.plugin.builtin_plugins.file.main.asyncio.create_subprocess_shell",
         new=AsyncMock(return_value=process),
+    ), patch.object(
+        file_plugin,
+        "_terminate_background_process",
+        new=AsyncMock(side_effect=terminate_process),
     ):
         exec_call = asyncio.create_task(file_plugin.exec(event, "echo test", background=True))
         for _ in range(10):
@@ -253,8 +281,8 @@ async def test_cancelled_background_exec_cleans_up_task(file_plugin):
         exec_call.cancel()
         with pytest.raises(asyncio.CancelledError):
             await exec_call
-        await asyncio.sleep(0.1)
 
+    assert process.returncode == -15
     assert file_plugin._background_exec_tasks == {}
     file_plugin.ctx.publish_notice.assert_not_awaited()
 
@@ -286,3 +314,44 @@ async def test_terminate_stops_and_clears_background_tasks(file_plugin):
     assert file_plugin._background_exec_tasks == {}
     assert file_plugin._background_notice_tasks == set()
     file_plugin.ctx.publish_notice.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_terminate_background_process_force_kills_posix_process_group(monkeypatch):
+    process = ResistantProcess()
+    signals = []
+    sigkill = getattr(file_main.signal, "SIGKILL", 9)
+
+    def killpg(pid, signal_value):
+        signals.append((pid, signal_value))
+        if signal_value == sigkill:
+            process.returncode = -9
+            process._finished.set()
+
+    monkeypatch.setattr(file_main, "PROCESS_TERMINATION_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(file_main.signal, "SIGKILL", sigkill, raising=False)
+    with patch("core.plugin.builtin_plugins.file.main.os.name", "posix"), patch(
+        "core.plugin.builtin_plugins.file.main.os.killpg",
+        side_effect=killpg,
+        create=True,
+    ):
+        await FilePlugin._terminate_background_process(process)
+
+    assert signals == [
+        (process.pid, file_main.signal.SIGTERM),
+        (process.pid, sigkill),
+    ]
+
+
+@pytest.mark.anyio
+async def test_terminate_background_process_checks_taskkill_failure():
+    process = FakeBackgroundProcess(delay=1)
+    killer = FakeKillerProcess(returncode=1)
+
+    with patch("core.plugin.builtin_plugins.file.main.os.name", "nt"), patch(
+        "core.plugin.builtin_plugins.file.main.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=killer),
+    ):
+        await FilePlugin._terminate_background_process(process)
+
+    assert process.returncode == -15

--- a/tests/test_file_plugin.py
+++ b/tests/test_file_plugin.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from core.plugin.builtin_plugins.file.main import FilePlugin
+from core.plugin.builtin_plugins.file.main import BackgroundExecTask, FilePlugin
 
 
 class FakeBackgroundProcess:
@@ -201,4 +201,88 @@ async def test_manage_background_exec_lists_output_and_stops_own_task(file_plugi
         await asyncio.sleep(0.01)
 
     assert task_id not in file_plugin._background_exec_tasks
+    file_plugin.ctx.publish_notice.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_background_exec_stop_before_wait_returns_captured_output(file_plugin, tmp_path):
+    background_task = BackgroundExecTask(
+        task_id="exec-test",
+        session="test:dm:1",
+        work_dir=tmp_path,
+        timeout=30,
+        stop_requested=True,
+    )
+    process = FakeBackgroundProcess(stdout="started\n", delay=1)
+
+    async def terminate_process(fake_process):
+        fake_process.terminate()
+        await fake_process.wait()
+
+    with patch(
+        "core.plugin.builtin_plugins.file.main.asyncio.create_subprocess_shell",
+        new=AsyncMock(return_value=process),
+    ), patch.object(
+        file_plugin,
+        "_terminate_background_process",
+        new=AsyncMock(side_effect=terminate_process),
+    ):
+        result = await file_plugin._run_background_shell_command(
+            "echo test", background_task, {}
+        )
+
+    assert result == "Shell command stopped by request:\nstarted\n"
+
+
+@pytest.mark.anyio
+async def test_cancelled_background_exec_cleans_up_task(file_plugin):
+    event = SimpleNamespace(sid="test:dm:1")
+    file_plugin.ctx = SimpleNamespace(publish_notice=AsyncMock())
+    file_plugin._background_exec_wait_seconds = 1
+    process = FakeBackgroundProcess(delay=0.05)
+
+    with patch(
+        "core.plugin.builtin_plugins.file.main.asyncio.create_subprocess_shell",
+        new=AsyncMock(return_value=process),
+    ):
+        exec_call = asyncio.create_task(file_plugin.exec(event, "echo test", background=True))
+        for _ in range(10):
+            if file_plugin._background_exec_tasks:
+                break
+            await asyncio.sleep(0)
+        exec_call.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await exec_call
+        await asyncio.sleep(0.1)
+
+    assert file_plugin._background_exec_tasks == {}
+    file_plugin.ctx.publish_notice.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_terminate_stops_and_clears_background_tasks(file_plugin):
+    event = SimpleNamespace(sid="test:dm:1")
+    file_plugin.ctx = SimpleNamespace(publish_notice=AsyncMock())
+    file_plugin._background_exec_wait_seconds = 0.01
+    process = FakeBackgroundProcess(delay=1)
+
+    async def terminate_process(fake_process):
+        fake_process.terminate()
+        await fake_process.wait()
+
+    with patch(
+        "core.plugin.builtin_plugins.file.main.asyncio.create_subprocess_shell",
+        new=AsyncMock(return_value=process),
+    ), patch.object(
+        file_plugin,
+        "_terminate_background_process",
+        new=AsyncMock(side_effect=terminate_process),
+    ):
+        result = await file_plugin.exec(event, "echo test", background=True)
+        assert "task_id: exec-" in result
+        await file_plugin.terminate()
+
+    assert process.returncode == -15
+    assert file_plugin._background_exec_tasks == {}
+    assert file_plugin._background_notice_tasks == set()
     file_plugin.ctx.publish_notice.assert_not_awaited()

--- a/tests/test_file_plugin.py
+++ b/tests/test_file_plugin.py
@@ -1,9 +1,41 @@
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from core.plugin.builtin_plugins.file.main import FilePlugin
+
+
+class FakeBackgroundProcess:
+    def __init__(self, stdout: str = "", stderr: str = "", delay: float = 0):
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
+        self.stdout.feed_data(stdout.encode())
+        self.stdout.feed_eof()
+        self.stderr.feed_data(stderr.encode())
+        self.stderr.feed_eof()
+        self.delay = delay
+        self.pid = 12345
+        self.returncode = None
+        self._stopped = asyncio.Event()
+
+    async def wait(self):
+        if self.returncode is None and self.delay:
+            try:
+                await asyncio.wait_for(self._stopped.wait(), timeout=self.delay)
+            except asyncio.TimeoutError:
+                self.returncode = 0
+        elif self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+    def terminate(self):
+        self.returncode = -15
+        self._stopped.set()
+
+    def kill(self):
+        self.terminate()
 
 
 @pytest.fixture
@@ -11,7 +43,55 @@ def file_plugin():
     plugin = FilePlugin.__new__(FilePlugin)
     plugin.allowed_exec_sessions = ["test:dm:1"]
     plugin.exec_deny_list = []
+    plugin._exec_timeout = 30
+    plugin._background_exec_timeout = 30
+    plugin._background_exec_wait_seconds = 2
+    plugin._background_exec_tasks = {}
+    plugin._background_notice_tasks = set()
     return plugin
+
+
+@pytest.mark.anyio
+async def test_initialize_loads_exec_timeouts():
+    plugin = FilePlugin(
+        None,
+        {
+            "exec_timeout": 10,
+            "background_exec_timeout": 60,
+            "background_exec_wait_seconds": 3,
+        },
+    )
+
+    await plugin.initialize()
+
+    assert plugin._exec_timeout == 10
+    assert plugin._background_exec_timeout == 60
+    assert plugin._background_exec_wait_seconds == 3
+
+
+@pytest.mark.anyio
+async def test_filter_tools_enables_background_manager_with_exec(file_plugin):
+    file_plugin.plugin_cfg = {"enabled_tools": ["exec"]}
+    tool_set = SimpleNamespace(remove=Mock())
+    request = SimpleNamespace(tool_set=tool_set)
+
+    await file_plugin.filter_tools(SimpleNamespace(), request)
+
+    disabled_tools = set(tool_set.remove.call_args.args)
+    assert "exec" not in disabled_tools
+    assert "manage_background_exec" not in disabled_tools
+
+
+@pytest.mark.anyio
+async def test_filter_tools_disables_background_manager_without_exec(file_plugin):
+    file_plugin.plugin_cfg = {"enabled_tools": ["read_file"]}
+    tool_set = SimpleNamespace(remove=Mock())
+    request = SimpleNamespace(tool_set=tool_set)
+
+    await file_plugin.filter_tools(SimpleNamespace(), request)
+
+    disabled_tools = set(tool_set.remove.call_args.args)
+    assert {"exec", "manage_background_exec"} <= disabled_tools
 
 
 @pytest.mark.anyio
@@ -27,6 +107,7 @@ async def test_exec_uses_resolved_work_dir(file_plugin, tmp_path):
 
     assert result == "Shell command output:\nok"
     assert run.call_args.kwargs["cwd"] == tmp_path.resolve()
+    assert run.call_args.kwargs["timeout"] == 30
 
 
 @pytest.mark.anyio
@@ -39,3 +120,85 @@ async def test_exec_rejects_missing_work_dir(file_plugin, tmp_path):
 
     assert result == f"Working directory not found: {missing_dir}"
     run.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_exec_background_returns_immediate_result_when_command_finishes_quickly(file_plugin):
+    event = SimpleNamespace(sid="test:dm:1")
+    file_plugin._background_exec_timeout = 45
+    process = FakeBackgroundProcess(stdout="ok")
+
+    with patch(
+        "core.plugin.builtin_plugins.file.main.asyncio.create_subprocess_shell",
+        new=AsyncMock(return_value=process),
+    ):
+        result = await file_plugin.exec(event, "echo test", background=True)
+
+    assert result == "Shell command output:\nok"
+    assert file_plugin._background_exec_tasks == {}
+
+
+@pytest.mark.anyio
+async def test_exec_background_publishes_result_after_wait_timeout(file_plugin):
+    event = SimpleNamespace(sid="test:dm:1")
+    file_plugin.ctx = SimpleNamespace(publish_notice=AsyncMock())
+    file_plugin._background_exec_wait_seconds = 0.01
+    process = FakeBackgroundProcess(stdout="finished", delay=0.05)
+
+    with patch(
+        "core.plugin.builtin_plugins.file.main.asyncio.create_subprocess_shell",
+        new=AsyncMock(return_value=process),
+    ):
+        result = await file_plugin.exec(event, "echo test", background=True)
+
+    assert "Shell command is running in the background (task_id: exec-" in result
+    for _ in range(10):
+        if file_plugin.ctx.publish_notice.await_count:
+            break
+        await asyncio.sleep(0.02)
+
+    file_plugin.ctx.publish_notice.assert_awaited_once()
+    args = file_plugin.ctx.publish_notice.await_args
+    assert args.args[0] == event.sid
+    assert args.kwargs["is_mentioned"] is True
+    assert "Background shell command completed (task_id: exec-" in args.args[1][0].text
+    assert "Shell command output:\nfinished" in args.args[1][0].text
+
+
+@pytest.mark.anyio
+async def test_manage_background_exec_lists_output_and_stops_own_task(file_plugin):
+    event = SimpleNamespace(sid="test:dm:1")
+    file_plugin.ctx = SimpleNamespace(publish_notice=AsyncMock())
+    file_plugin._background_exec_wait_seconds = 0.01
+    process = FakeBackgroundProcess(stdout="started\n", delay=1)
+
+    async def terminate_process(fake_process):
+        fake_process.terminate()
+        await fake_process.wait()
+
+    with patch(
+        "core.plugin.builtin_plugins.file.main.asyncio.create_subprocess_shell",
+        new=AsyncMock(return_value=process),
+    ), patch.object(
+        file_plugin,
+        "_terminate_background_process",
+        new=AsyncMock(side_effect=terminate_process),
+    ):
+        result = await file_plugin.exec(event, "echo test", background=True)
+        task_id = result.split("task_id: ", maxsplit=1)[1].split(")", maxsplit=1)[0]
+
+        await asyncio.sleep(0)
+        listed = await file_plugin.manage_background_exec(event, "list")
+        output = await file_plugin.manage_background_exec(event, "output", task_id)
+        stopped = await file_plugin.manage_background_exec(event, "stop", task_id)
+
+    assert task_id in listed
+    assert "started" in output
+    assert stopped == f"Stop requested for background task {task_id}."
+    for _ in range(10):
+        if task_id not in file_plugin._background_exec_tasks:
+            break
+        await asyncio.sleep(0.01)
+
+    assert task_id not in file_plugin._background_exec_tasks
+    file_plugin.ctx.publish_notice.assert_not_awaited()


### PR DESCRIPTION
## Summary

Extend the File plugin's `exec` tool with configurable working directories and background execution. Background commands can now be monitored and stopped without generating duplicate completion replies after a user-requested stop.

## Type of change

<!-- Check the one that applies. -->

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Add `work_dir` support for shell commands, with existing-directory validation.
- Add configurable foreground/background execution timeouts and the background wait window.
- Add background task management for listing tasks, reading current output, and stopping tasks in the originating session.
- Stream background process output and suppress completion notices after an explicit stop request.

## Screenshots / Logs

`python -m pytest tests/test_file_plugin.py -v` — 8 passed.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Run shell commands in the foreground or background.
  - Specify a working directory for command execution.
  - Track background tasks, view their status and output, or stop them when needed.
  - Receive notifications when background commands complete.

- **Improvements**
  - Added configurable timeouts for foreground and background commands.
  - Improved process termination across supported platforms.
  - Added validation for working-directory paths and execution settings.
  - Ensured running tasks are cleaned up when execution ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->