### PR TITLE
fix: inject final-step hint as user prompt

### DIFF
--- a/core/agent/agent_executor.py
+++ b/core/agent/agent_executor.py
@@ -82,7 +82,7 @@ class AgentExecutor:
                     name="final_step_hint",
                     source="system",
                     persist=False,
-                    content="<system_reminder>⚠️ This is your last response opportunity in this turn. There will be no more conversation turns after this. If you need to communicate anything to the user, output it directly in this response. If you choose to end silently (<msg/>), no output is needed.</system_reminder>",
+                    content="<system_reminder>This is the final model call for this turn. Conclude this turn now; do not start further work that depends on tool results. Any tool result will not invoke you again this turn and will only be available the next time you are invoked. If you need to communicate anything to the user, provide it in this response, using the information already available. If a user-facing answer is needed but information is insufficient, clearly state what is missing and give the user a concise next step. You may end silently with <msg/> when no user-facing response is needed.</system_reminder>",
                 )
                 request.messages.append(OpenAIMessage(
                     role="user",

--- a/core/agent/agent_executor.py
+++ b/core/agent/agent_executor.py
@@ -13,6 +13,7 @@ from core.agent.tool import ToolSet
 from core.agent.message import OpenAIMessage
 from core.chat.message_utils import KiraExceptionEvent
 from core.plugin.plugin_handlers import event_handler_reg, EventType
+from core.prompt_manager import Prompt
 
 if TYPE_CHECKING:
     from core.chat.message_utils import KiraMessageBatchEvent
@@ -77,9 +78,15 @@ class AgentExecutor:
 
             # Inject last-step hint so the LLM knows to wrap up
             if is_final:
+                final_step_prompt = Prompt(
+                    name="final_step_hint",
+                    source="system",
+                    persist=False,
+                    content="<system_reminder>⚠️ This is your last response opportunity in this turn. There will be no more conversation turns after this. If you need to communicate anything to the user, output it directly in this response. If you choose to end silently (<msg/>), no output is needed.</system_reminder>",
+                )
                 request.messages.append(OpenAIMessage(
-                    role="system",
-                    content="⚠️ This is your last response opportunity in this turn. There will be no more conversation turns after this. If you need to communicate anything to the user, output it directly in this response. If you choose to end silently (<msg/>), no output is needed."
+                    role="user",
+                    content=final_step_prompt.to_string(),
                 ))
 
             # Try models in order, failover to next on provider/API errors.


### PR DESCRIPTION
## Summary

Deliver the final-step reminder as a request-only user message so the model receives it after any tool results. The reminder now guides the final call to conclude using available information, explain missing information when a reply is needed, and preserve intentional silent completion.

## Type of change

<!-- Check the one that applies. -->

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

<!-- List the key changes in this PR. -->

- Append the final-step hint as a non-persistent user message.
- Clarify final-step behavior when tool results cannot be consumed until a later invocation.

## Screenshots / Logs

Not applicable. Focused test passed: `python -m pytest tests/test_llm_request.py -v` (9 passed).

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Improvements**
  * Agents now conclude tasks more reliably after the final step.
  * Responses clearly communicate required information or identify missing details and next steps.
  * Tasks can end silently when no user-facing response is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->