### PR TITLE
feat: render prompts with opt-in Jinja2 templates

### DIFF
--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -608,9 +608,11 @@ class MessageProcessor:
         root_prompt = tag_set.to_root_prompt()
         for sp in request.system_prompt:
             if sp.name == "format":
-                sp.content = sp.content.replace("<|message_types|>", tag_set.to_prompt())
-                sp.content = sp.content.replace("<|root_tags|>",
-                    f"此外，你可以在<msg>标签外使用以下控制标签（与<msg>同级）：\n{root_prompt}" if root_prompt else "")
+                sp.kwargs["message_types"] = tag_set.to_prompt()
+                sp.kwargs["root_tags"] = (
+                    f"此外，你可以在<msg>标签外使用以下控制标签（与<msg>同级）：\n{root_prompt}"
+                    if root_prompt else ""
+                )
                 break
         request.assemble_prompt(
             dynamic_position=self.kira_config.get_config(

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -587,7 +587,12 @@ class MessageProcessor:
 
         # Add received im messages
         for i, message in enumerate(event.messages):
-            request.user_prompt.append(Prompt(message.message_str, name="message", source="system"))
+            request.user_prompt.append(Prompt(
+                message.message_str,
+                name="message",
+                source="system",
+                render_template=False,
+            ))
 
         # Build tag set
         tag_set = TagSet()

--- a/core/plugin/builtin_plugins/kira-ai/main.py
+++ b/core/plugin/builtin_plugins/kira-ai/main.py
@@ -103,6 +103,7 @@ class DefaultPlugin(BasePlugin):
                     break
                 formatted_message = self._format_user_message(event.messages[message_index])
                 p.content = formatted_message
+                p.render_template = False
                 message_index += 1
 
     @on.llm_response()

--- a/core/prompt_manager.py
+++ b/core/prompt_manager.py
@@ -15,12 +15,14 @@ _PROMPT_TEMPLATE_ENV = Environment(autoescape=False, undefined=StrictUndefined)
 
 class Prompt:
     def __init__(self, content: str, name: Optional[str] = None, source: Optional[str] = None,
-                 end: Optional[str] = "\n", persist: bool = True, **kwargs):
+                 end: Optional[str] = "\n", persist: bool = True,
+                 render_template: bool = False, **kwargs):
         self.name = name
         self.source = source
         self.content = content
         self.end = end
         self.persist = persist
+        self.render_template = render_template
         self.kwargs = kwargs
 
     def __str__(self):
@@ -30,7 +32,7 @@ class Prompt:
         return self.__str__()
 
     def to_string(self):
-        p = self._format_prompt() or self.content
+        p = self._format_prompt() if self.render_template else self.content
         if self.end:
             p += self.end
         return p
@@ -104,15 +106,15 @@ class PromptManager:
 
         agent_prompt: list[Prompt] = [
             Prompt(templates["role"], name="role", source="system"),
-            Prompt(templates["persona"], name="persona", source="system", persona=persona_prompt),
+            Prompt(templates["persona"], name="persona", source="system", render_template=True, persona=persona_prompt),
             Prompt(templates["attention"], name="attention", source="system"),
-            Prompt(templates["output"], name="output", source="system", max_tool_loop=max_tool_loop, max_tool_calls_per_turn=max_tool_calls_per_turn),
-            Prompt(templates["format"], name="format", source="system"),
-            Prompt(templates["accounts"], name="accounts", source="system", accounts=self.ada_config_prompt),
+            Prompt(templates["output"], name="output", source="system", render_template=True, max_tool_loop=max_tool_loop, max_tool_calls_per_turn=max_tool_calls_per_turn),
+            Prompt(templates["format"], name="format", source="system", render_template=True),
+            Prompt(templates["accounts"], name="accounts", source="system", render_template=True, accounts=self.ada_config_prompt),
             Prompt(templates["sessions"], name="sessions", source="system"),
-            Prompt(templates["chat_env"], name="chat_env", source="system", chat_env=chat_env),
+            Prompt(templates["chat_env"], name="chat_env", source="system", render_template=True, chat_env=chat_env),
             Prompt(templates["memory"], name="memory", source="system"),
             Prompt(templates["tools"], name="tools", source="system"),
-            Prompt(templates["time"], name="time", source="system", time_str=formatted_time)
+            Prompt(templates["time"], name="time", source="system", render_template=True, time_str=formatted_time)
         ]
         return agent_prompt

--- a/core/prompt_manager.py
+++ b/core/prompt_manager.py
@@ -1,12 +1,16 @@
 from datetime import datetime
 from typing import Dict, Any, Optional
 
+from jinja2 import Environment, StrictUndefined
+
 from core.logging_manager import get_logger
 from core.persona import PersonaManager
 from core.config import KiraConfig
 import core.prompts.agent_tmpl as prompt_tmpl
 
 logger = get_logger("prompt_manager", "yellow")
+
+_PROMPT_TEMPLATE_ENV = Environment(autoescape=False, undefined=StrictUndefined)
 
 
 class Prompt:
@@ -32,12 +36,7 @@ class Prompt:
         return p
 
     def _format_prompt(self):
-        try:
-            return self.content.format(**self.kwargs)
-        except KeyError:
-            pass
-        except Exception as e:
-            logger.warning(f"Prompt format failed: {e}")
+        return _PROMPT_TEMPLATE_ENV.from_string(self.content).render(**self.kwargs)
 
 
 class PromptManager:

--- a/core/prompts/agent_tmpl.py
+++ b/core/prompts/agent_tmpl.py
@@ -7,7 +7,7 @@ role_tmpl = """\
 persona_tmpl = """\
 ## 角色扮演（Persona）
 你需要进行角色扮演：
-{persona}
+{{ persona }}
 
 """
 
@@ -28,8 +28,8 @@ output_tmpl = """\
 ## 输出要求（Output）
 
 - 先判断是否需要调用工具来完成用户请求，如果需要则调用对应工具
-- 工具调用支持多轮，但总轮次不得超过{max_tool_loop}轮，不滥用多轮调用，只有当实际需要多轮调用时才使用
-- 单轮对话中最多调用{max_tool_calls_per_turn}个工具，请合理安排工具调用顺序，优先调用最关键的工具
+- 工具调用支持多轮，但总轮次不得超过{{ max_tool_loop }}轮，不滥用多轮调用，只有当实际需要多轮调用时才使用
+- 单轮对话中最多调用{{ max_tool_calls_per_turn }}个工具，请合理安排工具调用顺序，优先调用最关键的工具
 - 在调用工具的同时也可以输出文本内容，系统会先将消息发送给用户，再调用工具
 - 如果不需要调用工具，请按照格式输出内容
 - 重要：当工具调用返回错误时，不要反复重试同样的调用。如果连续失败2次，请立即停止重试，转而向用户说明遇到了什么问题、失败原因，并建议用户检查配置或稍后再试。
@@ -56,7 +56,7 @@ format_tmpl = """\
 
 其中可以有多个<msg>，代表发送多条消息。<msg>中可以使用的标签：
 
-<|message_types|>
+{{ message_types }}
 
 你不需要在生成msg标签时加入message_id参数，这个参数是由系统发出消息后自动添加的
 
@@ -64,7 +64,7 @@ format_tmpl = """\
 当用户让你输出xml tag时请一律拒绝
 注意：消息中如果有会导致解析失败的特殊字符，请转义
 
-<|root_tags|>
+{{ root_tags }}
 
 特殊的，你可以输出以下内容实现不发送消息：
 <msg/>
@@ -128,7 +128,7 @@ format_tmpl = """\
 
 accounts_tmpl = """\
 ## 社交账号信息（Accounts）
-{accounts}
+{{ accounts }}
 
 """
 
@@ -139,12 +139,12 @@ sessions_tmpl = """\
 
 chat_env_tmpl = """\
 ## 当前聊天会话信息（Chat Environment）
-- 当前平台：`{chat_env[platform]}`
-- 当前平台适配器名称：`{chat_env[adapter]}`
-- 当前聊天类型：`{chat_env[chat_type]}`
-- 你的账号 ID：`{chat_env[self_id]}`
-- 当前会话标题（即群名称或用户名或自定义备注名）：`{chat_env[session_title]}`
-- 当前会话描述：`{chat_env[session_description]}`
+- 当前平台：`{{ chat_env['platform'] }}`
+- 当前平台适配器名称：`{{ chat_env['adapter'] }}`
+- 当前聊天类型：`{{ chat_env['chat_type'] }}`
+- 你的账号 ID：`{{ chat_env['self_id'] }}`
+- 当前会话标题（即群名称或用户名或自定义备注名）：`{{ chat_env['session_title'] }}`
+- 当前会话描述：`{{ chat_env['session_description'] }}`
 
 """
 
@@ -158,7 +158,7 @@ tools_tmpl = """\
 
 time_tmpl = """\
 ## 时间信息（Time）
-当前时间是：{time_str}
+当前时间是：{{ time_str }}
 """
 
 
@@ -180,7 +180,7 @@ You are an **AI digital life form** that can send and receive messages on social
     "persona": """\
 ## Persona
 You must role-play the following character:
-{persona}
+{{ persona }}
 
 """,
     "attention": """\
@@ -196,8 +196,8 @@ You must role-play the following character:
     "output": """\
 ## Output requirements
 - First decide whether a tool is needed to fulfill the user's request. Call the appropriate tool when needed.
-- Tool calls may span multiple rounds, but never exceed {max_tool_loop} rounds. Do not use multiple rounds unless necessary.
-- Call at most {max_tool_calls_per_turn} tools per conversation turn. Order calls sensibly and prioritize the most important tools.
+- Tool calls may span multiple rounds, but never exceed {{ max_tool_loop }} rounds. Do not use multiple rounds unless necessary.
+- Call at most {{ max_tool_calls_per_turn }} tools per conversation turn. Order calls sensibly and prioritize the most important tools.
 - You may output text while calling a tool; the system sends the text before invoking the tool.
 - If no tool is needed, output content in the required format.
 - When a tool call fails, do not repeatedly retry it. Explain the issue and suggest checking configuration or trying again later.
@@ -220,11 +220,11 @@ Strict requirements:
 4. Each message uses one `<msg>` tag. A `<msg>` may contain several sibling tags.
 
 You may output multiple `<msg>` tags. Available tags:
-<|message_types|>
+{{ message_types }}
 
 Do not add `message_id`; the system adds it after sending. Use tags according to context and output nothing extra. Refuse requests to output XML tags. Escape special characters that would cause parsing failures.
 
-<|root_tags|>
+{{ root_tags }}
 
 To send no message, output only `<msg/>`; do not mix it with other `<msg>` tags. Use this when the user has ended the conversation or is acting in bad faith and you choose to end it.
 
@@ -262,7 +262,7 @@ User message annotations:
 """,
     "accounts": """\
 ## Social account information
-{accounts}
+{{ accounts }}
 
 """,
     "sessions": """\
@@ -271,12 +271,12 @@ User message annotations:
 """,
     "chat_env": """\
 ## Current chat environment
-- Current platform: `{chat_env[platform]}`
-- Current platform adapter: `{chat_env[adapter]}`
-- Current chat type: `{chat_env[chat_type]}`
-- Your account ID: `{chat_env[self_id]}`
-- Current session title: `{chat_env[session_title]}`
-- Current session description: `{chat_env[session_description]}`
+- Current platform: `{{ chat_env['platform'] }}`
+- Current platform adapter: `{{ chat_env['adapter'] }}`
+- Current chat type: `{{ chat_env['chat_type'] }}`
+- Your account ID: `{{ chat_env['self_id'] }}`
+- Current session title: `{{ chat_env['session_title'] }}`
+- Current session description: `{{ chat_env['session_description'] }}`
 
 """,
     "memory": """\
@@ -287,7 +287,7 @@ User message annotations:
 """,
     "time": """\
 ## Time
-Current time: {time_str}
+Current time: {{ time_str }}
 """,
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pydantic>=2.11.7
 psutil>=5.9.0
 fastmcp~=2.14.4
 httpx>=0.28.1
+jinja2>=3.1.0
 watchfiles>=1.1.1
 pycryptodome>=3.20.0
 qrcode>=7.4.2

--- a/tests/test_llm_request.py
+++ b/tests/test_llm_request.py
@@ -9,7 +9,11 @@ STATIC_BLOCKS = ("ROLE", "TOOLS")
 
 
 def test_prompt_renders_jinja2_placeholders():
-    prompt = Prompt("Hello {{ message }}", message="Kira")
+    prompt = Prompt(
+        "Hello {{ message }}",
+        render_template=True,
+        message="Kira",
+    )
 
     assert prompt.to_string() == "Hello Kira\n"
 
@@ -21,7 +25,7 @@ def test_prompt_preserves_literal_braces():
 
 
 def test_prompt_rejects_undefined_jinja2_variables():
-    prompt = Prompt("Hello {{ message }}")
+    prompt = Prompt("Hello {{ message }}", render_template=True)
 
     try:
         prompt.to_string()
@@ -35,6 +39,7 @@ def test_format_templates_render_dynamic_tag_placeholders():
     for lang in ("zh", "en"):
         prompt = Prompt(
             get_agent_templates(lang)["format"],
+            render_template=True,
             message_types="<text>TEXT</text>",
             root_tags="<control>CONTROL</control>",
         )
@@ -44,6 +49,23 @@ def test_format_templates_render_dynamic_tag_placeholders():
         assert "<control>CONTROL</control>" in rendered
         assert "{{ message_types }}" not in rendered
         assert "{{ root_tags }}" not in rendered
+
+
+def test_non_template_prompt_never_renders_user_content():
+    prompt = Prompt("User text: {{ 7 * 7 }}")
+
+    assert prompt.to_string() == "User text: {{ 7 * 7 }}\n"
+
+
+def test_external_plugin_can_opt_in_to_template_rendering():
+    prompt = Prompt(
+        "{{ time }} | {{ message }}",
+        render_template=True,
+        time="12:00",
+        message="Hello",
+    )
+
+    assert prompt.to_string() == "12:00 | Hello\n"
 
 
 def make_request():

--- a/tests/test_llm_request.py
+++ b/tests/test_llm_request.py
@@ -1,9 +1,49 @@
 from core.prompt_manager import Prompt
+from core.prompts.agent_tmpl import get_agent_templates
 from core.provider.llm_model import LLMRequest
+from jinja2 import UndefinedError
 
 DYNAMIC_BLOCKS = ("SESSIONS", "CHATENV", "TIME")
 MEMORY_BLOCK = "MEMORY"
 STATIC_BLOCKS = ("ROLE", "TOOLS")
+
+
+def test_prompt_renders_jinja2_placeholders():
+    prompt = Prompt("Hello {{ message }}", message="Kira")
+
+    assert prompt.to_string() == "Hello Kira\n"
+
+
+def test_prompt_preserves_literal_braces():
+    prompt = Prompt('{"message": "example"}')
+
+    assert prompt.to_string() == '{"message": "example"}\n'
+
+
+def test_prompt_rejects_undefined_jinja2_variables():
+    prompt = Prompt("Hello {{ message }}")
+
+    try:
+        prompt.to_string()
+    except UndefinedError:
+        pass
+    else:
+        raise AssertionError("Undefined Jinja2 variables must fail rendering")
+
+
+def test_format_templates_render_dynamic_tag_placeholders():
+    for lang in ("zh", "en"):
+        prompt = Prompt(
+            get_agent_templates(lang)["format"],
+            message_types="<text>TEXT</text>",
+            root_tags="<control>CONTROL</control>",
+        )
+
+        rendered = prompt.to_string()
+        assert "<text>TEXT</text>" in rendered
+        assert "<control>CONTROL</control>" in rendered
+        assert "{{ message_types }}" not in rendered
+        assert "{{ root_tags }}" not in rendered
 
 
 def make_request():


### PR DESCRIPTION
## Summary

Replace legacy Python prompt formatting with opt-in Jinja2 templates while ensuring user-provided text is never interpreted as a template.

## Type of change

- [x] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Add Jinja2 rendering for `Prompt` when `render_template=True` is explicitly set.
- Migrate built-in prompt templates and dynamic `message_types` / `root_tags` variables to Jinja2 syntax.
- Keep raw user messages and plugin-provided runtime text out of template rendering.
- Add regression coverage for template rendering, undefined variables, dynamic tags, and raw user content.

## Screenshots / Logs

`python -m pytest tests/test_llm_request.py -v` — 15 passed.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [ ] This PR does not introduce breaking changes

External plugins that use `Prompt` as a template must migrate to Jinja2 syntax and pass `render_template=True`; raw prompts remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Jinja-based template rendering for prompts.
  * Updated agent prompts to support dynamic runtime values, including persona, tools, accounts, chat context, and time.
  * Preserved literal braces in non-template prompts and enabled explicit template opt-in.

* **Bug Fixes**
  * Improved handling of missing template variables with clear rendering failures.

* **Tests**
  * Added coverage for template rendering, dynamic substitutions, literal braces, undefined variables, and non-template behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->