### PR TITLE
fix: reliability and robustness fixes from a full-codebase review (#248–#252)

### DIFF
--- a/core/adapter/adapter_registry.py
+++ b/core/adapter/adapter_registry.py
@@ -32,6 +32,7 @@ class AdapterManager:
     def __init__(self, kira_config: KiraConfig, event_queue: asyncio.Queue):
         self.kira_config = kira_config
         self._adapters: dict[str, Union[IMAdapter, SocialMediaAdapter]] = {}
+        self._adapter_tasks: dict[str, asyncio.Task] = {}
         self.adas_config: dict = kira_config.get("adapters", {}) or {}
         self.event_queue = event_queue
 
@@ -151,6 +152,9 @@ class AdapterManager:
                     logger.warning(f"Failed to load manifest from {manifest_path}: {e}")
 
             platform_name = manifest.get("name") if isinstance(manifest, dict) else None
+            if not platform_name:
+                logger.warning(f"Manifest without a valid 'name' in {adapter_dir}, skipping")
+                continue
 
             schema_fields: list[BaseConfigField] = []
             schema_path = os.path.join(adapter_dir, "schema.json")
@@ -200,6 +204,11 @@ class AdapterManager:
             found = False
             for attr_name, attr_value in inspect.getmembers(module):
                 if inspect.isclass(attr_value) and issubclass(attr_value, (IMAdapter, SocialMediaAdapter)) and attr_value not in (IMAdapter, SocialMediaAdapter):
+                    registered_dir = cls._manifest_dirs.get(platform_name)
+                    if registered_dir and registered_dir != Path(adapter_dir):
+                        logger.warning(
+                            f"Adapter name '{platform_name}' from {adapter_dir} overrides the one registered from {registered_dir}"
+                        )
                     cls._registry[platform_name] = attr_value
                     cls._manifests[platform_name] = manifest
                     cls._manifest_dirs[platform_name] = Path(adapter_dir)
@@ -454,13 +463,27 @@ class AdapterManager:
         self._adapters[name] = instance
         await self.start_adapter(name)
 
+    def _on_adapter_task_done(self, name: str, task: asyncio.Task):
+        self._adapter_tasks.pop(name, None)
+        if task.cancelled():
+            logger.info(f"Adapter {name} task cancelled")
+            return
+        exc = task.exception()
+        if exc:
+            logger.error(f"Adapter {name} task failed: {exc}", exc_info=exc)
+        else:
+            logger.info(f"Adapter {name} task finished")
+
     async def start_adapter(self, name):
         """start an adapter by specified adapter name"""
         try:
             task = asyncio.create_task(self._adapters[name].start())
-            task.add_done_callback(lambda t: logger.info(f"Started adapter {name}"))
         except Exception as e:
             logger.error(f"Failed to start adapter {name}: {e}")
+            return
+        self._adapter_tasks[name] = task
+        task.add_done_callback(lambda t: self._on_adapter_task_done(name, t))
+        logger.info(f"Started adapter {name}")
 
     async def stop_adapter(self, name: str):
         """stop an adapter by specified adapter name"""
@@ -500,8 +523,11 @@ class AdapterManager:
 
     async def stop_adapters(self):
         """stop all running adapters"""
-        for ada in self._adapters:
-            await self._adapters[ada].stop()
+        for name, adapter in list(self._adapters.items()):
+            try:
+                await adapter.stop()
+            except Exception as e:
+                logger.error(f"Failed to stop adapter {name}: {e}")
 
     def get_adapters(self) -> dict[str, Union[IMAdapter, SocialMediaAdapter]]:
         """return the entire dict where adapters are registered"""

--- a/core/adapter/adapter_utils.py
+++ b/core/adapter/adapter_utils.py
@@ -25,10 +25,24 @@ class IMAdapter(ABC):
 
         self.permission_mode = None
 
-        self.group_list: List[Union[int, str]] = []
-        self.user_list: List[Union[int, str]] = []
+        self.group_list: List[str] = []
+        self.user_list: List[str] = []
 
         self._init_permission_lists()
+
+    @staticmethod
+    def _normalize_id_list(raw) -> List[str]:
+        """Normalize configured ids to strings, matching the `str(chat.id)` lookups"""
+        if not isinstance(raw, list):
+            return []
+        normalized = []
+        for item in raw:
+            if item is None:
+                continue
+            value = str(item).strip()
+            if value:
+                normalized.append(value)
+        return normalized
 
     def _init_permission_lists(self):
         """init permission lists"""
@@ -38,21 +52,11 @@ class IMAdapter(ABC):
         self.permission_mode = _permission_mode
 
         if _permission_mode == "allow_list":
-            group_allow_list = self.config.get("group_allow_list", "")
-            user_allow_list = self.config.get("user_allow_list", "")
-
-            if group_allow_list and isinstance(group_allow_list, list):
-                self.group_list = group_allow_list
-            if user_allow_list and isinstance(user_allow_list, list):
-                self.user_list = user_allow_list
+            self.group_list = self._normalize_id_list(self.config.get("group_allow_list", ""))
+            self.user_list = self._normalize_id_list(self.config.get("user_allow_list", ""))
         elif _permission_mode == "deny_list":
-            group_deny_list = self.config.get("group_deny_list", "")
-            user_deny_list = self.config.get("user_deny_list", "")
-
-            if group_deny_list and isinstance(group_deny_list, list):
-                self.group_list = group_deny_list
-            if user_deny_list and isinstance(user_deny_list, list):
-                self.user_list = user_deny_list
+            self.group_list = self._normalize_id_list(self.config.get("group_deny_list", ""))
+            self.user_list = self._normalize_id_list(self.config.get("user_deny_list", ""))
         else:
             self.permission_mode = "allow_list"
 

--- a/core/adapter/src/bilibili/bilibili.py
+++ b/core/adapter/src/bilibili/bilibili.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+from collections import OrderedDict
 from datetime import datetime
 import re
 import time
@@ -10,6 +11,7 @@ from bilibili_api.utils.aid_bvid_transformer import bvid2aid
 from bilibili_api.utils import network
 
 from core.adapter.adapter_utils import SocialMediaAdapter
+from core.logging_manager import get_logger
 from core.chat import KiraCommentEvent
 from core.logging_manager import get_logger
 
@@ -26,12 +28,19 @@ from core.chat.message_elements import (
 )
 
 
+DEFAULT_LISTENING_INTERVAL = 20.0
+DEFAULT_MESSAGE_PROCESS_INTERVAL = 5.0
+PROCESSED_COMMENT_ID_LIMIT = 500
+
+
 class BiliBiliAdapter(SocialMediaAdapter):
     def __init__(self, info, event_bus: asyncio.Queue):
         super().__init__(info, event_bus)
         self.emoji_dict: Optional[dict] = None
         self.last_process_ts: int = int(time.time())
         self.listening_task = None
+        self.logger = get_logger(info.name, "purple")
+        self._processed_cmt_ids: "OrderedDict[int, None]" = OrderedDict()
         self.bot_uid = self.config.get("bot_uid")
         self.logger = get_logger(info.name, "blue")
         self._credential = Credential(
@@ -42,14 +51,25 @@ class BiliBiliAdapter(SocialMediaAdapter):
             ac_time_value=self.config.get("ac_time_value", ""),
         )
 
+    def _float_config(self, key: str, default: float) -> float:
+        """Read a float config value, falling back when it is missing or malformed"""
+        try:
+            return float(self.config.get(key))
+        except (TypeError, ValueError):
+            return default
+
     async def start(self):
         network.select_client("aiohttp")
         session = network.get_session()
         session.headers["Accept-Encoding"] = "gzip, deflate"
         await self._log_login_status()
         if self.config.get("listening_bvid"):
-            self.listening_task = asyncio.create_task(self._start_listening(self.config.get("listening_interval")))
-            await self.listening_task
+            interval = self._float_config("listening_interval", DEFAULT_LISTENING_INTERVAL)
+            self.listening_task = asyncio.create_task(self._start_listening(interval))
+            try:
+                await self.listening_task
+            except asyncio.CancelledError:
+                pass
         else:
             return
 
@@ -158,16 +178,19 @@ class BiliBiliAdapter(SocialMediaAdapter):
                 credential=self._credential
             )
             self.logger.debug(f"回复成功: {result}")
+            return result
         except Exception as e:
-            self.logger.debug(f"回复失败: {e}")
+            self.logger.error(f"回复失败: {e}")
+            raise
 
-    async def _start_listening(self, interval: float = 20.0):
+    async def _start_listening(self, interval: float = DEFAULT_LISTENING_INTERVAL):
         """开始监听，默认20秒检查一次"""
         while True:
             try:
-                # print(f"last_process_ts: {self.last_process_ts}")
                 await self._check_new_comments()
                 await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
                 self.logger.error(f"Bilibili 监听出错: {e}")
                 await asyncio.sleep(interval)
@@ -219,48 +242,78 @@ class BiliBiliAdapter(SocialMediaAdapter):
         # process comments
         await self._handle_new_comment(comments)
 
+    def _is_already_processed(self, cmt_id: int) -> bool:
+        """Return True when the comment was already published, otherwise remember it."""
+        if cmt_id in self._processed_cmt_ids:
+            return True
+        self._processed_cmt_ids[cmt_id] = None
+        while len(self._processed_cmt_ids) > PROCESSED_COMMENT_ID_LIMIT:
+            self._processed_cmt_ids.popitem(last=False)
+        return False
+
+    def _collect_pending_comments(self, comments: list) -> list:
+        """Collect comments newer than the cursor as (ctime, comment, sub_comment) tuples.
+
+        Top-level comments and sub replies are gathered together and sorted by their own
+        timestamp, because a sub reply under an older thread may be newer than a later
+        top-level comment.
+        """
+        pending = []
+        for cmt in comments:
+            cmt_ts = int(cmt.get("ctime"))
+            is_own_comment = str(cmt.get("uid")) == str(self.bot_uid)
+            if not is_own_comment and cmt_ts >= self.last_process_ts:
+                pending.append((cmt_ts, cmt, None))
+            if is_own_comment:
+                for sub_cmt in cmt.get("sub_replies") or []:
+                    sub_cmt_ts = int(sub_cmt.get("ctime"))
+                    if str(sub_cmt.get("uid")) != str(self.bot_uid) and sub_cmt_ts >= self.last_process_ts:
+                        pending.append((sub_cmt_ts, cmt, sub_cmt))
+        pending.sort(key=lambda item: item[0])
+        return pending
+
     async def _handle_new_comment(self, comments: list):
         """处理评论"""
-        for cmt in comments:
+        pending = self._collect_pending_comments(comments)
+        if not pending:
+            return
+
+        interval = self._float_config("message_process_interval", DEFAULT_MESSAGE_PROCESS_INTERVAL)
+
+        for cmt_ts, cmt, sub_cmt in pending:
+            self.last_process_ts = max(self.last_process_ts, cmt_ts)
             cmt_id = int(cmt.get("comment_id"))
             cmt_content = cmt.get("message")
-            commenter = cmt.get("user")
-            commenter_id = cmt.get("uid")
-            cmt_ts = int(cmt.get("ctime"))
-            if cmt_ts > self.last_process_ts and str(cmt.get("uid")) != str(self.bot_uid):
+
+            if sub_cmt is None:
+                if self._is_already_processed(cmt_id):
+                    continue
                 cmt_obj = KiraCommentEvent(
                     platform=self.info.platform,
                     adapter_name=self.info.name,
-                    commenter_id=commenter_id,
-                    commenter_nickname=commenter,
+                    commenter_id=cmt.get("uid"),
+                    commenter_nickname=cmt.get("user"),
                     cmt_id=cmt_id,
                     self_id=self.bot_uid,
                     cmt_content=[Text(cmt_content)],
                     timestamp=int(time.time())
                 )
-                await self.event_bus.put(cmt_obj)
-                self.last_process_ts = int(cmt.get("ctime"))
-                await asyncio.sleep(self.config.get("message_process_interval"))
-            if str(cmt.get("uid")) == str(self.bot_uid):
-                for sub_cmt in cmt.get("sub_replies"):
-                    sub_cmt_id = int(sub_cmt.get("comment_id"))
-                    sub_cmt_content = sub_cmt.get("message")
-                    sub_cmt_ts = int(sub_cmt.get("ctime"))
-                    sub_commenter = sub_cmt.get("user")
-                    sub_commenter_uid = sub_cmt.get("uid")
-                    if sub_cmt_ts > self.last_process_ts and str(sub_commenter_uid) != str(self.bot_uid):
-                        cmt_obj = KiraCommentEvent(
-                            platform=self.info.platform,
-                            adapter_name=self.info.name,
-                            commenter_id=sub_commenter_uid,
-                            commenter_nickname=sub_commenter,
-                            cmt_id=cmt_id,
-                            cmt_content=[Text(cmt_content)],
-                            sub_cmt_id=sub_cmt_id,
-                            sub_cmt_content=[Text(sub_cmt_content)],
-                            self_id=self.bot_uid,
-                            timestamp=int(time.time())
-                        )
-                        await self.event_bus.put(cmt_obj)
-                        self.last_process_ts = sub_cmt_ts
-                        await asyncio.sleep(self.config.get("message_process_interval"))
+            else:
+                sub_cmt_id = int(sub_cmt.get("comment_id"))
+                if self._is_already_processed(sub_cmt_id):
+                    continue
+                cmt_obj = KiraCommentEvent(
+                    platform=self.info.platform,
+                    adapter_name=self.info.name,
+                    commenter_id=sub_cmt.get("uid"),
+                    commenter_nickname=sub_cmt.get("user"),
+                    cmt_id=cmt_id,
+                    cmt_content=[Text(cmt_content)],
+                    sub_cmt_id=sub_cmt_id,
+                    sub_cmt_content=[Text(sub_cmt.get("message"))],
+                    self_id=self.bot_uid,
+                    timestamp=int(time.time())
+                )
+
+            await self.event_bus.put(cmt_obj)
+            await asyncio.sleep(interval)

--- a/core/adapter/src/qq/napcat_client/client.py
+++ b/core/adapter/src/qq/napcat_client/client.py
@@ -53,6 +53,7 @@ class NapCatWebSocketClient:
         self.last_heartbeat: Optional[int] = None
         self.login_success_event: asyncio.Event = asyncio.Event()
         self._listening_task: Optional[asyncio.Task] = None
+        self._verify_task: Optional[asyncio.Task] = None
         self.event_callbacks: dict[str, list[Callable]] = {
             "group": [],
             "private": [],
@@ -124,18 +125,34 @@ class NapCatWebSocketClient:
 
     async def _reconnect(self):
         attempt = 0
-        while not self.shutdown_event.is_set() and attempt < 20:
+        while not self.shutdown_event.is_set():
             attempt += 1
             logger.warning(f"🔄 WebSocket 连接断开，正在尝试第 {attempt} 次重连")
             resp = await self.connect()
             if resp.get("status") == "ok":
                 logger.info("✅ WebSocket 重连成功")
                 self.login_success_event.set()
+                self._verify_task = asyncio.create_task(self._verify_login_account())
                 return True
             elif resp.get("status") == "failed":
                 logger.warning(f"WebSocket 重连失败: {resp.get('message')}")
-            await asyncio.sleep(min(2 ** attempt, 60))
+            await asyncio.sleep(min(2 ** min(attempt, 6), 60))
         return False
+
+    async def _verify_login_account(self):
+        """Check that the reconnected NapCat session still serves the configured account.
+
+        Runs outside the receive loop so ``get_login_info`` can be resolved by it.
+        """
+        try:
+            login_info = await self.get_login_info()
+        except Exception as e:
+            logger.warning(f"重连后获取登录信息失败: {e}")
+            return
+        login_id = (login_info.get("data") or {}).get("user_id")
+        if str(login_id) != str(self.self_id):
+            logger.error("配置的账号与 NapCat 登录账号不一致")
+            await self.close()
 
     def group_event(self):
         def wrapper(func):
@@ -178,16 +195,21 @@ class NapCatWebSocketClient:
                         await self.handle_message(data)
                     except json.JSONDecodeError:
                         logger.error(f"❌ 无法解析消息: {message}")
+                    except Exception as e:
+                        logger.error(f"❌ 处理消息失败: {e}\n{traceback.format_exc()}")
             except websockets.exceptions.ConnectionClosed:
                 logger.warning("🔌 WebSocket 连接已关闭")
-                success = await self._reconnect()
-                if not success:
-                    logger.error("❌ 重连次数达到上限，WebSocket 重连失败！")
-                    await self.close()
-                    break
-                continue
             except Exception as e:
-                logger.error(f"❌ 监听错误: {e}")
+                logger.error(f"❌ 监听错误: {e}\n{traceback.format_exc()}")
+                # Avoid spinning when the receive stream fails immediately
+                await asyncio.sleep(1)
+
+            if self.shutdown_event.is_set():
+                break
+
+            if not await self._reconnect():
+                logger.error("❌ WebSocket 重连失败！")
+                await self.close()
                 break
 
     async def handle_message(self, data: dict):
@@ -380,6 +402,8 @@ class NapCatWebSocketClient:
     async def close(self):
         self.shutdown_event.set()
         self.login_success_event.clear()
+        if self._verify_task and not self._verify_task.done() and self._verify_task is not asyncio.current_task():
+            self._verify_task.cancel()
         if self.websocket:
             await self.websocket.close()
         if self._listening_task and not self._listening_task.done():

--- a/core/adapter/src/qq/napcat_client/utils.py
+++ b/core/adapter/src/qq/napcat_client/utils.py
@@ -1,6 +1,11 @@
 from typing import Union, Optional, Type
 import re
 
+from core.logging_manager import get_logger
+
+
+logger = get_logger("napcat", "blue")
+
 
 class QQMessageType:
     class Text:
@@ -85,8 +90,22 @@ class QQMessageType:
 
 
 class QQMessageChain:
+    SUPPORTED_TYPES = (
+        QQMessageType.Text,
+        QQMessageType.Image,
+        QQMessageType.At,
+        QQMessageType.Reply,
+        QQMessageType.Emoji,
+        QQMessageType.Sticker,
+        QQMessageType.Record,
+    )
+
     def __init__(self, msg_list: Optional[list] = None):
         self.msg_seg_list = msg_list if msg_list else []
+
+    def unsupported_elements(self) -> list:
+        """Return the elements that ``to_list`` is unable to serialise"""
+        return [ele for ele in self.msg_seg_list if not isinstance(ele, self.SUPPORTED_TYPES)]
 
     def to_list(self):
         msg_list = []
@@ -175,4 +194,6 @@ class QQMessageChain:
                         "file": file_param
                     }
                 })
+            else:
+                logger.warning(f"无法序列化的消息段，已跳过：{type(ele).__name__}")
         return msg_list

--- a/core/adapter/src/qq/qq.py
+++ b/core/adapter/src/qq/qq.py
@@ -3,7 +3,7 @@ import json
 import time
 from datetime import datetime
 import asyncio
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from core.adapter.adapter_utils import IMAdapter
 from core.logging_manager import get_logger
@@ -27,6 +27,10 @@ from core.chat.message_elements import (
 from core.chat import Session, Group, User
 
 from .napcat_client import NapCatWebSocketClient, QQMessageChain, QQMessageType
+
+
+# Elements that need a dedicated API call instead of a plain message chain
+SPECIAL_ELEMENT_TYPES = (Poke, File, Video, Forward)
 
 
 def extract_card_info(card_json: str) -> dict:
@@ -67,6 +71,7 @@ class QQAdapter(IMAdapter):
         self.emoji_dict = self._load_dict(os.path.join(os.path.dirname(os.path.abspath(__file__)), "emoji.json"))
         self.message_types = ["text", "img", "at", "reply", "record", "emoji", "sticker", "poke", "selfie", "file", "video", "forward"]
         self.bot: NapCatWebSocketClient = NapCatWebSocketClient()
+        self._start_task: Optional[asyncio.Task] = None
         self.logger = get_logger(info.name, "blue")
         self.debug_mode = self.config.get("debug_mode", False)
         self.debug_mode_list = self.config.get("debug_mode_list", [])
@@ -132,7 +137,15 @@ class QQAdapter(IMAdapter):
         await self.bot.run(bt_uin=self.config["bot_pid"], ws_uri=self.config["ws_uri"], ws_token=self.config["ws_token"])
 
     async def start(self):
-        task = asyncio.create_task(self.start_blocking())
+        self._start_task = asyncio.create_task(self.start_blocking())
+        self._start_task.add_done_callback(self._on_start_task_done)
+
+    def _on_start_task_done(self, task: asyncio.Task):
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc:
+            self.logger.error(f"QQ 适配器运行任务异常退出: {exc}", exc_info=exc)
 
     async def stop(self):
         await self.bot.close()
@@ -140,13 +153,68 @@ class QQAdapter(IMAdapter):
     def get_client(self) -> NapCatWebSocketClient:
         return self.bot
 
+    @staticmethod
+    def _merge_sent_results(results: list) -> KiraIMSentResult:
+        """Fold the per-element results of one message chain into a single result"""
+        merged = KiraIMSentResult(None)
+        errors = []
+        for res in results:
+            if res.message_id:
+                merged.message_id = res.message_id
+            if not res.ok:
+                merged.ok = False
+                if res.err:
+                    errors.append(res.err)
+        merged.is_notice = bool(results) and all(res.is_notice for res in results)
+        merged.err = "; ".join(errors)
+        return merged
+
     async def send_group_message(self, group_id, send_message_obj):
         try:
             message_chain = await self._process_outgoing_message(send_message_obj)
             if not message_chain:
                 self.logger.warning("处理后的消息链为空，跳过群消息发送")
                 return KiraIMSentResult(None, ok=False, err="Empty message chain after processing")
-            ele = message_chain[0]
+
+            plain_elements = [ele for ele in message_chain if not isinstance(ele, SPECIAL_ELEMENT_TYPES)]
+
+            results = []
+            if plain_elements and not all(isinstance(ele, QQMessageType.Reply) for ele in plain_elements):
+                results.append(await self._send_plain_group_message(group_id, plain_elements))
+            for ele in message_chain:
+                if isinstance(ele, SPECIAL_ELEMENT_TYPES):
+                    results.append(await self._send_group_element(group_id, ele))
+
+            if not results:
+                self.logger.warning("消息链中没有可发送的内容，跳过群消息发送")
+                return KiraIMSentResult(None, ok=False, err="Nothing to send in message chain")
+            return self._merge_sent_results(results)
+        except Exception as e:
+            return KiraIMSentResult(None, ok=False, err=str(e))
+
+    async def _send_plain_group_message(self, group_id, elements: list) -> KiraIMSentResult:
+        qq_message_chain = QQMessageChain(elements)
+        unsupported = qq_message_chain.unsupported_elements()
+        result = await self.bot.send_group_message(group_id=group_id, msg=qq_message_chain)
+        status = result.get("status")
+        retcode = result.get("retcode")
+        msg_res = KiraIMSentResult(None)
+        if status == "failed":
+            msg_res.ok = False
+            if retcode == 1200:
+                msg_res.err = "禁言中或达到发言频率限制，消息发送失败"
+            else:
+                msg_res.err = f"未知错误，消息发送失败，错误码：{retcode}"
+            return msg_res
+        msg_res.message_id = str((result.get("data", {}) or {}).get("message_id"))
+        if unsupported:
+            msg_res.ok = False
+            msg_res.err = f"消息段无法发送：{[type(ele).__name__ for ele in unsupported]}"
+            self.logger.warning(msg_res.err)
+        return msg_res
+
+    async def _send_group_element(self, group_id, ele) -> KiraIMSentResult:
+        try:
             if isinstance(ele, Poke):
                 await self.bot.send_poke(user_id=ele.pid, group_id=group_id)
                 return KiraIMSentResult(message_id=None, is_notice=True)
@@ -274,34 +342,54 @@ class QQAdapter(IMAdapter):
                     msg_res.err = f"Error occurred while forwarding message: {e}"
                 return msg_res
 
-            message_chain = QQMessageChain(message_chain)
-            result = await self.bot.send_group_message(group_id=group_id, msg=message_chain)
-            status = result.get("status")
-            retcode = result.get("retcode")
-            msg_res = KiraIMSentResult(None)
-            if status == "failed":
-                msg_res.ok = False
-                if retcode == 1200:
-                    msg_res.err = "禁言中或达到发言频率限制，消息发送失败"
-                else:
-                    msg_res.err = f"未知错误，消息发送失败，错误码：{retcode}"
-                return msg_res
-            message_id = str((result.get("data", {}) or {}).get("message_id"))
-            msg_res.message_id = message_id
-            return msg_res
+            return KiraIMSentResult(None, ok=False, err=f"Unsupported message element: {type(ele).__name__}")
         except Exception as e:
             return KiraIMSentResult(None, ok=False, err=str(e))
 
     async def send_direct_message(self, user_id, send_message_obj):
-        msg_res = KiraIMSentResult(None)
         try:
             message_chain = await self._process_outgoing_message(send_message_obj)
             if not message_chain:
                 self.logger.warning("处理后的消息链为空，跳过私聊消息发送")
-                msg_res.ok = False
-                msg_res.err = "Empty message chain after processing"
-                return msg_res
-            ele = message_chain[0]
+                return KiraIMSentResult(None, ok=False, err="Empty message chain after processing")
+
+            plain_elements = [ele for ele in message_chain if not isinstance(ele, SPECIAL_ELEMENT_TYPES)]
+
+            results = []
+            if plain_elements and not all(isinstance(ele, QQMessageType.Reply) for ele in plain_elements):
+                results.append(await self._send_plain_direct_message(user_id, plain_elements))
+            for ele in message_chain:
+                if isinstance(ele, SPECIAL_ELEMENT_TYPES):
+                    results.append(await self._send_direct_element(user_id, ele))
+
+            if not results:
+                self.logger.warning("消息链中没有可发送的内容，跳过私聊消息发送")
+                return KiraIMSentResult(None, ok=False, err="Nothing to send in message chain")
+            return self._merge_sent_results(results)
+        except Exception as e:
+            return KiraIMSentResult(None, ok=False, err=str(e))
+
+    async def _send_plain_direct_message(self, user_id, elements: list) -> KiraIMSentResult:
+        qq_message_chain = QQMessageChain(elements)
+        unsupported = qq_message_chain.unsupported_elements()
+        result = await self.bot.send_direct_message(user_id=user_id, msg=qq_message_chain)
+        status = result.get("status")
+        retcode = result.get("retcode")
+        msg_res = KiraIMSentResult(None)
+        if status == "failed":
+            msg_res.ok = False
+            msg_res.err = f"未知错误，消息发送失败，错误码：{retcode}"
+            return msg_res
+        msg_res.message_id = str((result.get("data", {}) or {}).get("message_id"))
+        if unsupported:
+            msg_res.ok = False
+            msg_res.err = f"消息段无法发送：{[type(ele).__name__ for ele in unsupported]}"
+            self.logger.warning(msg_res.err)
+        return msg_res
+
+    async def _send_direct_element(self, user_id, ele) -> KiraIMSentResult:
+        msg_res = KiraIMSentResult(None)
+        try:
             if isinstance(ele, Poke):
                 await self.bot.send_poke(user_id=ele.pid)
                 msg_res.is_notice = True
@@ -428,16 +516,8 @@ class QQAdapter(IMAdapter):
                     msg_res.err = f"Error occurred while forwarding message: {e}"
                 return msg_res
 
-            message_chain = QQMessageChain(message_chain)
-            result = await self.bot.send_direct_message(user_id=user_id, msg=message_chain)
-            status = result.get("status")
-            retcode = result.get("retcode")
-            if status == "failed":
-                msg_res.ok = False
-                msg_res.err = f"未知错误，消息发送失败，错误码：{retcode}"
-                return msg_res
-            message_id = str((result.get("data", {}) or {}).get("message_id"))
-            msg_res.message_id = message_id
+            msg_res.ok = False
+            msg_res.err = f"Unsupported message element: {type(ele).__name__}"
         except Exception as e:
             msg_res.ok = False
             msg_res.err = str(e)

--- a/core/adapter/src/telegram/telegram.py
+++ b/core/adapter/src/telegram/telegram.py
@@ -96,8 +96,10 @@ class TelegramAdapter(IMAdapter):
         # Register command handlers
         self.app.add_handler(CommandHandler("start", self._cmd_start))
         self.app.add_handler(CommandHandler("help", self._cmd_help))
-        # Register message handler for text, images, voice, etc. (excluding edited messages)
-        self.app.add_handler(MessageHandler(filters.ALL, self._on_message))
+        # Register message handler for text, images, voice, etc.
+        # UpdateType.MESSAGE only matches update.message, so edited messages and
+        # (edited) channel posts are excluded
+        self.app.add_handler(MessageHandler(filters.UpdateType.MESSAGE, self._on_message))
 
         # Initialize and start the application asynchronously
         try:
@@ -139,6 +141,10 @@ class TelegramAdapter(IMAdapter):
         msg = update.effective_message
         chat = msg.chat
         user = msg.from_user
+
+        if user is None:
+            logger.debug(f"[{self.info.name}] Ignored message without sender in chat {chat.id}")
+            return
 
         if chat.type in ("group", "supergroup"):
 
@@ -212,7 +218,7 @@ class TelegramAdapter(IMAdapter):
                     ),
                     is_mentioned=is_mentioned,
                     message_id=str(msg.id),
-                    self_id=self.config["bot_pid"],
+                    self_id=self.config.get("bot_pid", ""),
                     chain=message_chain,
                 ),
                 timestamp=int(msg.date.timestamp() or time.time())
@@ -243,7 +249,7 @@ class TelegramAdapter(IMAdapter):
                     ),
                     is_mentioned=True,
                     message_id=str(msg.id),
-                    self_id=self.config["bot_pid"],
+                    self_id=self.config.get("bot_pid", ""),
                     chain=message_chain,
                 ),
                 timestamp=int(msg.date.timestamp() or time.time())
@@ -329,22 +335,28 @@ class TelegramAdapter(IMAdapter):
 
         # Voice/Audio
         if tg_message.voice:
-            voice_id = tg_message.voice.file_id
-            voice_file = await self.app.bot.get_file(voice_id)
-            voice_url = voice_file.file_path
+            try:
+                voice_id = tg_message.voice.file_id
+                voice_file = await self.app.bot.get_file(voice_id)
+                voice_url = voice_file.file_path
 
-            voice_content = await get_file_content(voice_url)
-            base64_data = base64.b64encode(voice_content)
-            elements.append(Record(record=base64_data.decode('utf-8')))
+                voice_content = await get_file_content(voice_url)
+                base64_data = base64.b64encode(voice_content)
+                elements.append(Record(record=base64_data.decode('utf-8')))
+            except Exception:
+                elements.append(Text("[Voice]"))
 
         elif tg_message.audio:
-            audio_id = tg_message.audio.file_id
-            audio_file = await self.app.bot.get_file(audio_id)
-            audio_url = audio_file.file_path
+            try:
+                audio_id = tg_message.audio.file_id
+                audio_file = await self.app.bot.get_file(audio_id)
+                audio_url = audio_file.file_path
 
-            audio_content = await get_file_content(audio_url)
-            base64_data = base64.b64encode(audio_content)
-            elements.append(Record(record=base64_data.decode('utf-8')))
+                audio_content = await get_file_content(audio_url)
+                base64_data = base64.b64encode(audio_content)
+                elements.append(Record(record=base64_data.decode('utf-8')))
+            except Exception:
+                elements.append(Text("[Audio]"))
 
         # Document (File)
         if tg_message.document:
@@ -421,7 +433,11 @@ class TelegramAdapter(IMAdapter):
 
             # Reply element: capture target message id and advance
             if isinstance(ele, Reply):
-                reply_to_id = int(ele.message_id)
+                try:
+                    reply_to_id = int(ele.message_id)
+                except (ValueError, TypeError):
+                    logger.warning(f"Invalid reply target message id: {ele.message_id!r}")
+                    reply_to_id = None
                 idx += 1
                 continue
 

--- a/core/adapter/src/weixin_oc/weixin_oc.py
+++ b/core/adapter/src/weixin_oc/weixin_oc.py
@@ -106,6 +106,8 @@ class WeixinOCAdapter(IMAdapter):
         self._context_tokens: dict[str, str] = {}
         self._typing_states: dict[str, TypingSessionState] = {}
         self._last_inbound_error = ""
+        self._inbound_error_backoff_s = 0.0
+        self._run_task: asyncio.Task | None = None
         self._typing_keepalive_interval_s = max(
             1, int(self.config.get("weixin_oc_typing_keepalive_interval", 5))
         )
@@ -450,7 +452,13 @@ class WeixinOCAdapter(IMAdapter):
         )
         self.publish(message_obj)
 
-    async def _poll_inbound_updates(self) -> None:
+    def _next_inbound_backoff(self) -> float:
+        """Grow the inbound retry delay, capped, so repeated failures cannot spin"""
+        self._inbound_error_backoff_s = min(max(self._inbound_error_backoff_s * 2, 5.0), 60.0)
+        return self._inbound_error_backoff_s
+
+    async def _poll_inbound_updates(self) -> bool:
+        """Fetch pending updates, returning False when the server reported an error"""
         data = await self.client.request_json(
             "POST",
             "ilink/bot/getupdates",
@@ -465,7 +473,7 @@ class WeixinOCAdapter(IMAdapter):
         )
         ret = int(data.get("ret") or 0)
         errcode = data.get("errcode", 0)
-        if ret != 0 and ret is not None:
+        if ret != 0:
             errmsg = str(data.get("errmsg", ""))
             self._last_inbound_error = f"ret={ret}, errcode={errcode}, errmsg={errmsg}"
             self.logger.warning(
@@ -473,7 +481,7 @@ class WeixinOCAdapter(IMAdapter):
                 self.info.name,
                 self._last_inbound_error,
             )
-            return
+            return False
         if errcode and int(errcode) != 0:
             errmsg = str(data.get("errmsg", ""))
             self._last_inbound_error = f"ret={ret}, errcode={errcode}, errmsg={errmsg}"
@@ -488,13 +496,13 @@ class WeixinOCAdapter(IMAdapter):
                 self._context_tokens.clear()
                 self._login_session = None
                 await self._save_account_state()
-                return
+                return True
             self.logger.warning(
                 "weixin_oc(%s): getupdates error: %s",
                 self.info.name,
                 self._last_inbound_error,
             )
-            return
+            return False
 
         if data.get("get_updates_buf"):
             self._sync_buf = str(data.get("get_updates_buf"))
@@ -502,10 +510,12 @@ class WeixinOCAdapter(IMAdapter):
 
         for msg in data.get("msgs", []) if isinstance(data.get("msgs"), list) else []:
             if self._shutdown_event.is_set():
-                return
+                return True
             if not isinstance(msg, dict):
                 continue
             await self._handle_inbound_message(msg)
+
+        return True
 
     async def _send_items_to_session(
         self,
@@ -773,7 +783,15 @@ class WeixinOCAdapter(IMAdapter):
         self._sync_client_state()
 
     async def start(self):
-        asyncio.create_task(self._run_loop())
+        self._run_task = asyncio.create_task(self._run_loop())
+        self._run_task.add_done_callback(self._on_run_task_done)
+
+    def _on_run_task_done(self, task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc:
+            self.logger.error("weixin_oc(%s): run loop task failed: %s", self.info.name, exc)
 
     async def _run_loop(self) -> None:
         try:
@@ -822,19 +840,33 @@ class WeixinOCAdapter(IMAdapter):
                     continue
 
                 try:
-                    await self._poll_inbound_updates()
+                    polled = await self._poll_inbound_updates()
                 except asyncio.TimeoutError:
+                    self._inbound_error_backoff_s = 0.0
                     self.logger.debug(
                         "weixin_oc(%s): inbound long-poll timeout",
                         self.info.name,
                     )
                 except Exception as e:
+                    delay = self._next_inbound_backoff()
                     self.logger.error(
-                        "weixin_oc(%s): poll inbound failed, retry in 5s: %s",
+                        "weixin_oc(%s): poll inbound failed, retry in %.0fs: %s",
                         self.info.name,
+                        delay,
                         e,
                     )
-                    await asyncio.sleep(5)
+                    await asyncio.sleep(delay)
+                else:
+                    if polled:
+                        self._inbound_error_backoff_s = 0.0
+                    else:
+                        delay = self._next_inbound_backoff()
+                        self.logger.warning(
+                            "weixin_oc(%s): inbound poll failed, retry in %.0fs",
+                            self.info.name,
+                            delay,
+                        )
+                        await asyncio.sleep(delay)
         except asyncio.CancelledError:
             raise
         except Exception as e:

--- a/core/agent/func_tool_manager.py
+++ b/core/agent/func_tool_manager.py
@@ -92,13 +92,16 @@ class FuncToolManager:
                 })
                 continue
 
+            # Some providers omit "arguments" entirely for no-arg tool calls
             raw_args = tool_call.get("function", {}).get("arguments")
+            if isinstance(raw_args, str):
+                raw_args = raw_args.strip()
             try:
-                if not raw_args.strip():
+                if not raw_args:
                     args = {}
                 else:
                     args = json.loads(raw_args)
-            except json.JSONDecodeError as e:
+            except (TypeError, ValueError) as e:
                 logger.error(f"Failed to parse function calling arguments: {e}")
                 logger.error(f"Raw args: {raw_args}")
                 args = {}

--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -139,11 +139,18 @@ class MCPManager:
                 description=description
             )
 
+            timeout = server_config.get("timeout")
+            if isinstance(timeout, (int, float)) and not isinstance(timeout, bool):
+                server.timeout = float(timeout)
+
             if server_type == "stdio":
                 command = server_config.get("command")
                 args = server_config.get("args", [])
+                env = server_config.get("env", {})
                 server.command = command
                 server.args = args
+                if isinstance(env, dict):
+                    server.env = env
             elif server_type in ("sse", "streamable_http"):
                 url = server_config.get("url", "")
                 headers = server_config.get("headers", {})
@@ -577,8 +584,14 @@ class MCPManager:
                     )
                 logger.info(f"Registered {len(tool_names)} MCP tools from {server.name}: {tool_names}")
 
-        for server in self.servers:
-            asyncio.create_task(init_server(server))
+        servers = list(self.servers)
+        results = await asyncio.gather(
+            *(init_server(server) for server in servers),
+            return_exceptions=True,
+        )
+        for server, result in zip(servers, results):
+            if isinstance(result, Exception):
+                logger.error(f"Failed to initialize MCP server {server.name}: {result}")
 
     def _make_mcp_func(self, server: MCPServer, tool_name: str):
         async def _wrapped(*_, **kwargs):

--- a/core/agent/skills_mgr.py
+++ b/core/agent/skills_mgr.py
@@ -150,7 +150,7 @@ class SkillsManager:
             if not s.enabled:
                 continue
 
-            p.content += f"- **{s.name}**: {s.description}\n  Path: {str(s.path)}"
+            p.content += f"- **{s.name}**: {s.description}\n  Path: {str(s.path)}\n"
 
         return p
 

--- a/core/agent/tool.py
+++ b/core/agent/tool.py
@@ -28,9 +28,8 @@ class ToolSet:
                 tool_inst = tool
             else:
                 continue
-            for i, t in enumerate(self.tools):
-                if t.name == tool.name:
-                    self.tools.pop(i)
+            # Read the name off the instance: a subclass may only set it in __init__
+            self.tools = [t for t in self.tools if t.name != tool_inst.name]
             self.tools.append(tool_inst)
 
     def remove(self, *tool_names: str):

--- a/core/chat/message_utils.py
+++ b/core/chat/message_utils.py
@@ -183,7 +183,8 @@ class KiraMessageBatchEvent:
     _is_stopped: bool = False
 
     def __post_init__(self):
-        self.event_id = uuid.uuid4().hex
+        if not self.event_id:
+            self.event_id = uuid.uuid4().hex
 
     def is_group_message(self):
         return self.messages[-1].group is not None

--- a/core/chat/session_manager.py
+++ b/core/chat/session_manager.py
@@ -189,6 +189,7 @@ class SessionManager:
             return copy.deepcopy(session_data.get("memory", []))
 
     def write_memory(self, session: str, memory: list[list[dict]]):
+        self._ensure_session_data(session)
         with self.memory_lock:
             old_memory = copy.deepcopy(self.chat_memory[session].get("memory", []))
             self.chat_memory[session]["memory"] = memory

--- a/core/db/db_mgr.py
+++ b/core/db/db_mgr.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
 )
 from sqlalchemy.orm import declarative_base
-from sqlalchemy.engine import Result
 
 Base = declarative_base()
 
@@ -85,16 +84,6 @@ class DatabaseManager:
         async with self.get_session() as session:
             async with session.begin():
                 yield session
-
-    async def execute(
-        self,
-        statement,
-        params: Optional[dict[str, Any]] = None,
-    ) -> Result[Any]:
-        """Execute a statement and return the result object."""
-        async with self.get_session() as session:
-            result = await session.execute(statement, params or {})
-            return result
 
     async def fetch_one(
         self,

--- a/core/db/service.py
+++ b/core/db/service.py
@@ -1,5 +1,6 @@
 import time
 import uuid
+import warnings
 from typing import Optional
 from sqlalchemy import select, delete, or_, and_, func, cast, Integer
 
@@ -503,6 +504,18 @@ class DatabaseService:
         ]
 
     async def mark_telemetry_reported(self) -> None:
+        """Mark every unreported telemetry row as reported.
+
+        Deprecated: marking by window instead of by primary key marks rows that were
+        inserted after aggregation and therefore never sent. Use
+        :meth:`mark_telemetry_messages_by_ids` / :meth:`mark_telemetry_llm_by_ids`.
+        """
+        warnings.warn(
+            "mark_telemetry_reported is deprecated; use mark_telemetry_messages_by_ids / "
+            "mark_telemetry_llm_by_ids instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         async with self.db.transaction() as session:
             await session.execute(
                 TelemetryMessage.__table__.update()

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -30,6 +30,14 @@ if TYPE_CHECKING:
     from core.db.service import DatabaseService
 
 
+# Sentinel pushed by stop() to unblock the dispatch() queue wait
+_STOP_SENTINEL = object()
+
+
+def _describe(obj) -> str:
+    return getattr(obj, "__qualname__", None) or getattr(obj, "__name__", None) or repr(obj)
+
+
 class EventBus:
     """事件总线"""
 
@@ -148,9 +156,10 @@ class EventBus:
                     self.event_bus_stats["processed"] += 1
                     self.stats.set_stats("event_bus", self.event_bus_stats)
 
-            except Exception as e:
+            except Exception:
                 self.event_bus_stats["errors"] += 1
                 self.stats.set_stats("event_bus", self.event_bus_stats)
+                self.logger.exception("Unhandled exception in event bus consumer loop")
 
     async def _process_event(self, event):
         """处理单个事件"""
@@ -164,9 +173,13 @@ class EventBus:
             for handler in tuple(self.subscribers[event_type]):
                 try:
                     await handler(event)
-                except Exception as e:
+                except Exception:
                     self.event_bus_stats["errors"] += 1
                     self.stats.set_stats("event_bus", self.event_bus_stats)
+                    self.logger.exception(
+                        f"Unhandled exception in handler {_describe(handler)} "
+                        f"for event {_describe(event_type)}"
+                    )
 
     async def dispatch(self):
         """start event bus"""
@@ -174,6 +187,8 @@ class EventBus:
 
         while self._running_event.is_set():
             event: Union[KiraMessageEvent, KiraCommentEvent] = await self.event_queue.get()
+            if event is _STOP_SENTINEL:
+                break
             if isinstance(event, (KiraMessageEvent, KiraCommentEvent)):
                 self.total_messages_stats["total_messages"] += 1
                 self.stats.set_stats("messages", self.total_messages_stats)
@@ -200,6 +215,9 @@ class EventBus:
     async def stop(self):
         """stop event bus"""
         self._running_event.clear()
+        # dispatch() blocks on queue.get(), so clearing the flag alone would not
+        # be noticed until the next event arrives
+        await self.event_queue.put(_STOP_SENTINEL)
         # for task in self._running_tasks:
         #     task.cancel()
         # await asyncio.gather(*self._running_tasks, return_exceptions=True)

--- a/core/launcher.py
+++ b/core/launcher.py
@@ -53,6 +53,8 @@ class KiraLauncher:
 
         loop.set_exception_handler(_suppress_proactor_reset)
 
+        running_tasks: list[asyncio.Task] = []
+
         self.stats = Statistics()
 
         self.lifecycle = KiraLifecycle(stats=self.stats)
@@ -87,14 +89,26 @@ class KiraLauncher:
                 except Exception as e:
                     self.logger.warning(f"Failed to get ip addresses: {e}")
 
-            tasks = asyncio.gather(
-                self.lifecycle.init_and_run_system(),
-                self.webui.run(host, port)
-            )
-            await tasks
+            running_tasks = [
+                asyncio.create_task(self.lifecycle.init_and_run_system(), name="kira_system"),
+                asyncio.create_task(self.webui.run(host, port), name="kira_webui"),
+            ]
+            await asyncio.gather(*running_tasks)
         except (asyncio.CancelledError, KeyboardInterrupt):
             self.logger.info("✨ Exiting KiraAI...")
-            await self.lifecycle.stop()
+        except Exception as e:
+            self.logger.error(f"KiraAI stopped due to an unexpected error: {e}", exc_info=True)
+        finally:
+            if self.lifecycle is not None:
+                try:
+                    await self.lifecycle.stop()
+                except Exception as e:
+                    self.logger.error(f"Error during shutdown: {e}", exc_info=True)
+            # asyncio.gather() leaves siblings running when one of them fails
+            for task in running_tasks:
+                task.cancel()
+            if running_tasks:
+                await asyncio.gather(*running_tasks, return_exceptions=True)
             self.logger.info("✔ Exited KiraAI")
 
     @staticmethod
@@ -110,17 +124,27 @@ class KiraLauncher:
                 ip_addresses.append((interface, address.address))
         return ip_addresses
 
-    @staticmethod
-    def _load_webui_config() -> dict:
+    def _load_webui_config(self) -> dict:
         """Load WebUI configuration from data/webui.json"""
+        default_config = {"host": "0.0.0.0", "port": 5267}
         config_path = get_data_path() / "webui.json"
         if config_path.exists():
-            with open(config_path, 'r', encoding='utf-8') as f:
-                return json.load(f)
+            try:
+                with open(config_path, 'r', encoding='utf-8') as f:
+                    config = json.load(f)
+            except (json.JSONDecodeError, OSError) as e:
+                self.logger.warning(
+                    f"Failed to read {config_path}, falling back to defaults "
+                    f"(host={default_config['host']}, port={default_config['port']}): {e}"
+                )
+                return dict(default_config)
+            if not isinstance(config, dict):
+                self.logger.warning(
+                    f"{config_path} must contain a JSON object, falling back to defaults"
+                )
+                return dict(default_config)
+            return config
         else:
             with open(config_path, 'w', encoding='utf-8') as f:
-                f.write(json.dumps({
-                    "host": "0.0.0.0",
-                    "port": 5267
-                }))
-            return {"host": "0.0.0.0", "port": 5267}
+                f.write(json.dumps(default_config))
+            return dict(default_config)

--- a/core/lifecycle.py
+++ b/core/lifecycle.py
@@ -77,14 +77,18 @@ class KiraLifecycle:
 
         self.tasks: list[asyncio.Task] = []
 
+        self._stopped = False
+
     async def schedule_tasks(self):
-        self.tasks = [
+        scheduled_tasks: list[asyncio.Task] = [
             # asyncio.create_task(self.sticker_manager.scan_and_register_sticker(), name="sticker_scan")
         ]
-        results = await asyncio.gather(*self.tasks, return_exceptions=True)
+        # Keep the references in self.tasks so stop() can cancel them
+        self.tasks.extend(scheduled_tasks)
+        results = await asyncio.gather(*scheduled_tasks, return_exceptions=True)
         for i, result in enumerate(results):
             if isinstance(result, Exception):
-                task = self.tasks[i]
+                task = scheduled_tasks[i]
                 logger.error(f"Scheduled task '{task.get_name()}' failed: {result}")
 
     def _apply_network_env(self):
@@ -258,13 +262,21 @@ class KiraLifecycle:
         )
 
         # ====== schedule tasks ======
-        asyncio.create_task(self.schedule_tasks())
+        self.tasks.append(
+            asyncio.create_task(self.schedule_tasks(), name="schedule_tasks")
+        )
 
         logger.info("All modules initialized, starting message processing loop...")
 
         await self.event_bus.dispatch()
 
     async def stop(self):
+        # stop() is reachable from the launcher teardown and from the WebUI
+        # restart/update routes, so it must never tear down twice
+        if self._stopped:
+            return
+        self._stopped = True
+
         # Fire ON_SHUTDOWN lifecycle event (before any teardown)
         shutdown_handlers = event_handler_reg.get_handlers(EventType.ON_SHUTDOWN)
         for handler in shutdown_handlers:
@@ -294,10 +306,20 @@ class KiraLifecycle:
         if self.event_bus:
             await self.event_bus.stop()
 
+        # stop temp folder monitor
+        if self.temp_monitor:
+            try:
+                await self.temp_monitor.stop_monitoring()
+            except Exception as e:
+                logger.error(f"Temp monitor shutdown error: {e}")
+
+        # cancel all tasks
+        tasks, self.tasks = self.tasks, []
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
         # dispose database manager
         if self.db_manager:
             await self.db_manager.dispose()
-
-        # cancel all tasks
-        for task in self.tasks:
-            task.cancel()

--- a/core/message_manager.py
+++ b/core/message_manager.py
@@ -58,6 +58,22 @@ logger = get_logger("message", "cyan")
 llm_logger = get_logger("llm", "purple")
 
 
+def _config_float(value: Any, default: float) -> float:
+    """Coerce a config value to float, falling back to default on null/garbage."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _config_int(value: Any, default: int) -> int:
+    """Coerce a config value to int, falling back to default on null/garbage."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 class SessionBuffer:
     def __init__(self, max_count: int = None):
         self.buffer: list = []
@@ -66,6 +82,15 @@ class SessionBuffer:
 
     def add(self, message: KiraMessageEvent):
         self.buffer.append(message)
+        # Safety net: the buffer is normally drained by a message plugin flush,
+        # but a disabled or failing plugin must not let it grow without bound
+        if self.max_count and len(self.buffer) > self.max_count:
+            overflow = len(self.buffer) - self.max_count
+            del self.buffer[:overflow]
+            logger.warning(
+                f"Session buffer exceeded max_count={self.max_count}, "
+                f"dropped {overflow} oldest buffered message(s)"
+            )
 
     def pop(self, count: int = 1):
         if self.get_length() < count:
@@ -162,10 +187,10 @@ class MessageProcessor:
         self.db = db
         self.kira_config = kira_config
         self.bot_config = kira_config["bot_config"].get("bot")
-        self.max_message_interval = float(self.bot_config.get("max_message_interval"))
-        self.max_buffer_messages = int(self.bot_config.get("max_buffer_messages"))
-        self.min_message_delay = float(self.bot_config.get("min_message_delay", "0.8"))
-        self.max_message_delay = float(self.bot_config.get("max_message_delay", "1.5"))
+        self.max_message_interval = _config_float(self.bot_config.get("max_message_interval"), 2.0)
+        self.max_buffer_messages = _config_int(self.bot_config.get("max_buffer_messages"), 5)
+        self.min_message_delay = _config_float(self.bot_config.get("min_message_delay"), 0.8)
+        self.max_message_delay = _config_float(self.bot_config.get("max_message_delay"), 1.5)
 
         self.tool_manager = tool_manager
         self.event_bus: Optional[EventBus] = None
@@ -720,11 +745,7 @@ class MessageProcessor:
         # Get max tool loop config, defaults to 2 if not a valid integer
         # Note: This variable represents the total agent loop iterations (not just tool calls),
         # but the name is kept as-is for backward compatibility with existing config files.
-        max_tool_loop = self.kira_config.get_config("bot_config.agent.max_tool_loop")
-        try:
-            max_tool_loop = int(max_tool_loop)
-        except ValueError:
-            max_tool_loop = 2
+        max_tool_loop = _config_int(self.kira_config.get_config("bot_config.agent.max_tool_loop"), 2)
 
         max_agent_steps = max_tool_loop
 
@@ -759,10 +780,11 @@ class MessageProcessor:
                     return False
             if raw_output:
                 llm_resp.text_response = step_result.raw_output
-                for idx in range(-1, -len(new_messages), -1):
-                    if new_messages[idx].role == "assistant":
-                        new_messages[idx].content = step_result.raw_output
-                        request.messages[idx].content = step_result.raw_output
+                # new_messages and request.messages hold the same OpenAIMessage
+                # objects, so updating the message in place covers both lists
+                for message in reversed(new_messages):
+                    if message.role == "assistant":
+                        message.content = step_result.raw_output
                         break
             return True
 
@@ -786,6 +808,12 @@ class MessageProcessor:
                 )
             except Exception as e:
                 logger.debug(f"Failed to record telemetry LLM usage: {e}")
+
+            # A stopped step's assistant message is deliberately kept out of
+            # new_messages, so its response must not be sent either
+            if step.state == "stopped":
+                logger.info(f"Event {event.event_id} stopped, response not sent")
+                break
 
             if not await send_llm_text(llm_resp):
                 break
@@ -838,7 +866,7 @@ class MessageProcessor:
         except Exception as e:
             logger.debug(f"Failed to record telemetry LLM usage: {e}")
 
-        response = llm_resp.text_response.strip()
+        response = (llm_resp.text_response or "").strip()
 
         logger.info(f"LLM: {response}")
 

--- a/core/plugin/builtin_plugins/chat/main.py
+++ b/core/plugin/builtin_plugins/chat/main.py
@@ -29,8 +29,17 @@ class DefaultChatPlugin(BasePlugin):
     async def terminate(self):
         """
         Cleanup when plugin is terminated
+
+        Debounce loops run forever and hold on to self.ctx, so they must not
+        outlive the plugin instance.
         """
-        pass
+        tasks = list(self.session_tasks.values())
+        for task in tasks:
+            task.cancel()
+        self.session_tasks.clear()
+        self.session_events.clear()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     @on.im_message(priority=Priority.HIGH)
     async def handle_msg(self, event: KiraMessageEvent):

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -18,8 +18,42 @@ from core.provider import LLMRequest
 
 from core.utils.path_utils import get_data_path, get_root_path
 
-restricted_paths = ['~/.ssh/', '~/.gnupg/', '~/.aws/', '~/.config/gh/', '.pem',
-                    '.p12', 'key', 'secret', 'password', 'token', 'credential']
+restricted_dir_segments = (('.ssh',), ('.gnupg',), ('.aws',), ('.config', 'gh'))
+
+restricted_extensions = frozenset({'.pem', '.p12'})
+
+restricted_name_words = frozenset({
+    'key', 'keys', 'secret', 'secrets', 'password', 'passwords',
+    'token', 'tokens', 'credential', 'credentials',
+})
+
+_NAME_WORD_SPLIT = re.compile(r'[^a-z0-9]+')
+
+
+def is_restricted_path(path: str) -> bool:
+    """Check whether a normalized path points at credential-like material.
+
+    Matching is done on whole path segments and on the words inside a segment, so a
+    file such as ``data/files/monkey.txt`` is not rejected for containing "key".
+    """
+    segments = [s for s in path.replace('\\', '/').lower().split('/') if s not in ('', '.')]
+    if not segments:
+        return False
+
+    for pattern in restricted_dir_segments:
+        span = len(pattern)
+        if any(tuple(segments[i:i + span]) == pattern for i in range(len(segments) - span + 1)):
+            return True
+
+    for segment in segments:
+        if Path(segment).suffix in restricted_extensions:
+            return True
+        words = {w for w in _NAME_WORD_SPLIT.split(segment) if w}
+        if words & restricted_name_words:
+            return True
+
+    return False
+
 
 blocked_extensions = {'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg',
                       '.mp3', '.mp4', '.wav', '.ogg', '.flac', '.aac', '.silk', '.slk',
@@ -140,25 +174,72 @@ class FilePlugin(BasePlugin):
         self._background_notice_tasks.clear()
 
     @staticmethod
+    def _kill_process_group(process: subprocess.Popen) -> None:
+        """Kill the shell and everything it spawned, mirroring the background path."""
+        if process.returncode is not None:
+            return
+
+        try:
+            if os.name == "nt":
+                killer = subprocess.run(
+                    ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=PROCESS_TERMINATION_GRACE_SECONDS,
+                )
+                if killer.returncode != 0 and process.returncode is None:
+                    logger.warning(
+                        f"taskkill failed for shell process {process.pid} with exit code "
+                        f"{killer.returncode}; killing the shell process"
+                    )
+                    process.kill()
+            else:
+                os.killpg(process.pid, signal.SIGTERM)
+                try:
+                    process.wait(timeout=PROCESS_TERMINATION_GRACE_SECONDS)
+                except subprocess.TimeoutExpired:
+                    os.killpg(process.pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError, subprocess.SubprocessError):
+            if process.returncode is None:
+                process.kill()
+
+    @staticmethod
     def _run_shell_command(
         shell_command: str,
         exec_timeout: int,
         env: dict[str, str],
         exec_work_dir: Path,
     ) -> str:
+        process_kwargs: dict = {}
+        if os.name == "nt":
+            process_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            process_kwargs["start_new_session"] = True
+
         try:
-            result = subprocess.run(
-                shell_command, shell=True, capture_output=True,
+            with subprocess.Popen(
+                shell_command, shell=True,
                 stdin=subprocess.DEVNULL,
-                timeout=exec_timeout, env=env, cwd=exec_work_dir,
-                encoding='utf-8', errors='replace'
-            )
-            output = (result.stdout or '') + (result.stderr or '')
-            if result.returncode == 0:
-                return f'Shell command output:\n{output}'
-            return f'Shell command failed (exit {result.returncode}):\n{output}'
-        except subprocess.TimeoutExpired:
-            return f'Shell command timed out after {exec_timeout} seconds: {shell_command}'
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                env=env, cwd=exec_work_dir,
+                encoding='utf-8', errors='replace',
+                **process_kwargs,
+            ) as process:
+                try:
+                    stdout, stderr = process.communicate(timeout=exec_timeout)
+                except subprocess.TimeoutExpired:
+                    FilePlugin._kill_process_group(process)
+                    try:
+                        process.communicate(timeout=PROCESS_TERMINATION_GRACE_SECONDS)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                    return f'Shell command timed out after {exec_timeout} seconds: {shell_command}'
+
+                output = (stdout or '') + (stderr or '')
+                if process.returncode == 0:
+                    return f'Shell command output:\n{output}'
+                return f'Shell command failed (exit {process.returncode}):\n{output}'
         except Exception as e:
             return f'Unexpected error while executing shell command: {e}'
 
@@ -372,9 +453,8 @@ class FilePlugin(BasePlugin):
         if path is None:
             return "Permission denied: Path traversal detected"
 
-        for rp in restricted_paths:
-            if rp in path:
-                return "Permission denied: Path contains restricted keywords"
+        if is_restricted_path(path):
+            return "Permission denied: Path contains restricted keywords"
 
         if not self._is_path_allowed(path, self.allowed_read_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_read_paths)}"
@@ -424,9 +504,8 @@ class FilePlugin(BasePlugin):
         if path is None:
             return "Permission denied: Path traversal detected"
 
-        for rp in restricted_paths:
-            if rp in path:
-                return "Permission denied: Path contains restricted keywords"
+        if is_restricted_path(path):
+            return "Permission denied: Path contains restricted keywords"
 
         if not self._is_path_allowed(path, self.allowed_write_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_write_paths)}"
@@ -465,9 +544,8 @@ class FilePlugin(BasePlugin):
         if path is None:
             return "Permission denied: Path traversal detected"
 
-        for rp in restricted_paths:
-            if rp in path:
-                return "Permission denied: Path contains restricted keywords"
+        if is_restricted_path(path):
+            return "Permission denied: Path contains restricted keywords"
 
         if not self._is_path_allowed(path, self.allowed_write_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_write_paths)}"
@@ -521,9 +599,8 @@ class FilePlugin(BasePlugin):
         if path is None:
             return "Permission denied: Path traversal detected"
 
-        for rp in restricted_paths:
-            if rp in path:
-                return "Permission denied: Path contains restricted keywords"
+        if is_restricted_path(path):
+            return "Permission denied: Path contains restricted keywords"
 
         if not self._is_path_allowed(path, self.allowed_read_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_read_paths)}"
@@ -570,9 +647,8 @@ class FilePlugin(BasePlugin):
         if normalized is None:
             return None, "Permission denied: Path traversal detected"
 
-        for rp in restricted_paths:
-            if rp in normalized:
-                return None, "Permission denied: Path contains restricted keywords"
+        if is_restricted_path(normalized):
+            return None, "Permission denied: Path contains restricted keywords"
 
         if not self._is_path_allowed(normalized, self.allowed_read_paths):
             return None, f"Permission denied: Path must start with one of: {', '.join(self.allowed_read_paths)}"
@@ -890,9 +966,8 @@ class FilePlugin(BasePlugin):
         if path is None:
             return "Permission denied: Path traversal detected"
 
-        for rp in restricted_paths:
-            if rp in path:
-                return "Permission denied: Path contains restricted keywords"
+        if is_restricted_path(path):
+            return "Permission denied: Path contains restricted keywords"
 
         if not self._is_path_allowed(path, self.allowed_read_paths):
             return f"Permission denied: Path must start with one of: {', '.join(self.allowed_read_paths)}"

--- a/core/plugin/builtin_plugins/search/main.py
+++ b/core/plugin/builtin_plugins/search/main.py
@@ -46,7 +46,7 @@ class SearchPlugin(BasePlugin):
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "The search query to execute with Tavily."},
-                "topic": {"type": "string", "enum": ["general", "news"], "description": "Optional. The category of the search.news is useful for retrieving real-time updates, general is for broader, more general-purpose searches that may include a wide range of sources. Defaults to general"},
+                "topic": {"type": "string", "enum": ["general", "news", "finance"], "description": "Optional. The category of the search.news is useful for retrieving real-time updates, finance is for financial and market information, general is for broader, more general-purpose searches that may include a wide range of sources. Defaults to general"},
                 "search_depth": {"type": "string", "enum": ["basic", "advanced"], "description": "Optional. Controls the latency vs relevance tradeoff.\n\nadvanced: Highest relevance, higher latency.\nbasic: Balanced relevance and latency. Defaults to basic"}
             },
             "required": ["query"]
@@ -83,8 +83,8 @@ class SearchPlugin(BasePlugin):
             return "Tavily API key not found. Please configure it in plugin config"
         client = TavilyClient(self._key)
 
-        max_results = int(str(self.plugin_cfg.get("max_results", 5)))
-
-        res = client.extract(urls=url, query=query, max_results=max_results, extract_depth=extract_depth)
+        # Tavily Extract has no max_results parameter; passing it through would end up
+        # as an unknown field in the request body.
+        res = client.extract(urls=url, query=query, extract_depth=extract_depth)
         results = res.get("results") or []
         return "".join(json.dumps(ele, ensure_ascii=False) for ele in results)

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -263,6 +263,29 @@ _plugin_components: Dict[str, PluginComponents] = {}
 def _ensure_components(plugin_id: str) -> PluginComponents:
     return _plugin_components.setdefault(plugin_id, PluginComponents())
 
+
+def _resolve_plugin_id(obj: Any, kind: str) -> Optional[str]:
+    """Resolve the plugin owning *obj*, or None when ownership cannot be determined.
+
+    An unresolved owner has no usable identity: it would collect components from
+    unrelated sources into a single empty-id bucket that ``is_plugin_enabled`` always
+    reports as disabled, so callers drop the registration instead.
+    """
+    plugin_id = get_obj_plugin_id(obj)
+    if not plugin_id:
+        logger.warning(
+            f"Skipping {kind} registration for "
+            f"'{getattr(obj, '__qualname__', obj)}': owning plugin could not be resolved"
+        )
+        return None
+    return plugin_id
+
+
+def _components_for(obj: Any, kind: str) -> Optional[PluginComponents]:
+    plugin_id = _resolve_plugin_id(obj, kind)
+    return _ensure_components(plugin_id) if plugin_id else None
+
+
 """Plugins that failed to load: {plugin_id: {"manifest": {...}, "error": "..."}}"""
 _plugin_load_errors: Dict[str, Dict[str, Any]] = {}
 
@@ -343,16 +366,18 @@ class RegisterDeco:
     @staticmethod
     def tool(name: str, description: str, params: dict):
         def decorator(func: Callable):
-            plugin_id = get_obj_plugin_id(func)
-            _ensure_components(plugin_id).register_tool(name, description, params, func)
+            comp = _components_for(func, "tool")
+            if comp is not None:
+                comp.register_tool(name, description, params, func)
             return func
         return decorator
 
     @staticmethod
     def tag(name: str, description: str, parent: Optional[str] = "msg"):
         def decorator(func: Callable):
-            plugin_id = get_obj_plugin_id(func)
-            _ensure_components(plugin_id).register_tag(name, description, func, parent)
+            comp = _components_for(func, "tag")
+            if comp is not None:
+                comp.register_tag(name, description, func, parent)
             return func
         return decorator
 
@@ -374,8 +399,9 @@ class RegisterDeco:
                    with keys ``label`` (str or locale dict), ``icon``, ``order``.
         """
         def decorator(obj):
-            plugin_id = get_obj_plugin_id(obj)
-            comp = _ensure_components(plugin_id)
+            comp = _components_for(obj, "page")
+            if comp is None:
+                return obj
 
             if isinstance(obj, PluginPage):
                 comp.register_page(route, None, auth, menu, page_obj=obj)
@@ -398,8 +424,9 @@ class RegisterDeco:
         html:      Try to serve index.html for directory requests
         """
         def decorator(func: Callable):
-            plugin_id = get_obj_plugin_id(func)
-            _ensure_components(plugin_id).register_static(path, directory, html)
+            comp = _components_for(func, "static")
+            if comp is not None:
+                comp.register_static(path, directory, html)
             return func
         return decorator
 
@@ -414,8 +441,9 @@ class RegisterDeco:
         kwargs: Forwarded to FastAPI add_api_route (response_model, summary, …)
         """
         def decorator(func: Callable):
-            plugin_id = get_obj_plugin_id(func)
-            _ensure_components(plugin_id).register_api(method, path, func, auth, **kwargs)
+            comp = _components_for(func, "api")
+            if comp is not None:
+                comp.register_api(method, path, func, auth, **kwargs)
             return func
         return decorator
 
@@ -429,8 +457,9 @@ class RegisterDeco:
               When enabled, ``ws.state.user`` is set before the endpoint runs.
         """
         def decorator(func: Callable):
-            plugin_id = get_obj_plugin_id(func)
-            _ensure_components(plugin_id).register_ws(path, func, auth)
+            comp = _components_for(func, "ws")
+            if comp is not None:
+                comp.register_ws(path, func, auth)
             return func
         return decorator
 
@@ -456,10 +485,10 @@ class RegisterDeco:
             size:  ``"small"`` (default, stat card) or ``"wide"`` (full-width).
         """
         def decorator(func: Callable):
-            plugin_id = get_obj_plugin_id(func)
-            widget_id = f"{plugin_id}:{func.__name__}"
-            _ensure_components(plugin_id).register_widget(
-                widget_id, label, icon, color, order, size, func)
+            plugin_id = _resolve_plugin_id(func, "widget")
+            if plugin_id:
+                _ensure_components(plugin_id).register_widget(
+                    f"{plugin_id}:{func.__name__}", label, icon, color, order, size, func)
             return func
         return decorator
 
@@ -468,8 +497,9 @@ class OnEventDeco:
 
     @staticmethod
     def _register_hook(func: Callable, priority: Union[Priority, int], event_type: EventType):
-        plugin_id = get_obj_plugin_id(func)
-        _ensure_components(plugin_id).register_hook(func, priority, event_type)
+        comp = _components_for(func, "hook")
+        if comp is not None:
+            comp.register_hook(func, priority, event_type)
 
     def im_message(self, priority: Union[Priority, int] = Priority.MEDIUM):
         def decorator(func: Callable):
@@ -2086,6 +2116,11 @@ class PluginManager:
         registered = self._register_plugin_class(plugin_id, module, plugin_root)
         if not registered:
             logger.warning(f"No BasePlugin subclass found in {plugin_root}")
+            # The module already executed, so drop it together with whatever its
+            # decorators registered.
+            sys.modules.pop(module_name, None)
+            _module_to_plugin.pop(module_name, None)
+            _plugin_components.pop(plugin_id, None)
             _plugin_load_errors[plugin_id] = {
                 "manifest": _plugin_manifests.get(plugin_id, {}),
                 "error": "No BasePlugin subclass found",

--- a/core/provider/provider.py
+++ b/core/provider/provider.py
@@ -200,7 +200,7 @@ class BaseProvider(ABC):
         self.provider_name: str = provider_name
         self.provider_config: dict = provider_config
 
-    def get_model_client(self, model_type: ModelType) -> BaseModelClient:
+    def get_model_client(self, model_type: ModelType) -> type[BaseModelClient]:
         if model_type not in self.models:
             raise ValueError(f"Model type {model_type.value} not implemented")
         return self.models[model_type]

--- a/core/provider/provider_manager.py
+++ b/core/provider/provider_manager.py
@@ -91,10 +91,15 @@ class ProviderManager:
         model_id: str,
         model_type: Optional[ModelType | str] = None,
     ) -> Optional[BaseModelClient]:
-        provider = self.get_provider(provider_id)
         model_info = self.get_model_info(provider_id, model_id, model_type)
         if not model_info:
             return
+        provider = self.get_provider(provider_id)
+        if provider is None:
+            raise ValueError(
+                f"Provider {provider_id} is configured but not loaded, "
+                f"check the startup logs for its instantiation error"
+            )
         model_type_enum = model_info.model_type
 
         if model_type_enum not in provider.models:
@@ -211,35 +216,39 @@ class ProviderManager:
         default_model = self.kira_config.get_config(f"models.{model_key}")
         if not default_model:
             raise ValueError(f"{model_key} not set")
-        if default_model and ":" in default_model:
-            model_provider = default_model.split(":")[0]
-            model_id = ":".join(default_model.split(":")[1:])
-
-            model_type_mapping = {
-                "default_llm": "llm",
-                "default_fast_llm": "llm",
-                "default_vlm": "llm",
-                "default_tts": "tts",
-                "default_stt": "stt",
-                "default_image": "image",
-                "default_embedding": "embedding",
-                "default_rerank": "rerank",
-                "default_video": "video"
-            }
-            model_type = model_type_mapping[model_key]
-            model_type_enum = ModelType(model_type)
-
-            model_info = ModelInfo(
-                model_type_enum,
-                model_id,
-                model_provider,
-                self.kira_config.get_config(f"providers.{model_provider}.name"),
-                self.kira_config.get_config(f"providers.{model_provider}.provider_config"),
-                # When the model ID has a dot, kira_config.get_config would return unexpected value.
-                # Guard against a missing model_config section (get_config returns None).
-                (self.kira_config.get_config(f"providers.{model_provider}.model_config.{model_type}") or {}).get(model_id)
+        if ":" not in default_model:
+            raise ValueError(
+                f"{model_key} is malformed: expected 'provider_id:model_id', "
+                f"got {default_model!r}"
             )
-            return model_info
+        model_provider = default_model.split(":")[0]
+        model_id = ":".join(default_model.split(":")[1:])
+
+        model_type_mapping = {
+            "default_llm": "llm",
+            "default_fast_llm": "llm",
+            "default_vlm": "llm",
+            "default_tts": "tts",
+            "default_stt": "stt",
+            "default_image": "image",
+            "default_embedding": "embedding",
+            "default_rerank": "rerank",
+            "default_video": "video"
+        }
+        model_type = model_type_mapping[model_key]
+        model_type_enum = ModelType(model_type)
+
+        model_info = ModelInfo(
+            model_type_enum,
+            model_id,
+            model_provider,
+            self.kira_config.get_config(f"providers.{model_provider}.name"),
+            self.kira_config.get_config(f"providers.{model_provider}.provider_config"),
+            # When the model ID has a dot, kira_config.get_config would return unexpected value.
+            # Guard against a missing model_config section (get_config returns None).
+            (self.kira_config.get_config(f"providers.{model_provider}.model_config.{model_type}") or {}).get(model_id)
+        )
+        return model_info
 
     def get_provider_info(self, provider_id: str) -> Optional[ProviderInfo]:
         providers_config = self.kira_config.get("providers", {})
@@ -806,15 +815,24 @@ class ProviderManager:
 
     async def fetch_remote_models(self, provider_id: str, model_type: str = "llm") -> list[dict]:
         """
-        Fetch available models from a provider's remote API.
+        Fetch available models of the given type from a provider's remote API.
         Returns a list of model info dicts.
         """
         provider = self.get_provider(provider_id)
         if not provider:
             raise ValueError(f"Provider {provider_id} not found")
         try:
-            models = await provider.get_llm_list()
+            model_type = ModelType(model_type).value
+        except ValueError as e:
+            raise ValueError(f"Unknown model type {model_type!r}") from e
+        list_method = getattr(provider, f"get_{model_type}_list", None)
+        if not callable(list_method):
+            raise ValueError(
+                f"Provider {provider_id} does not support listing remote {model_type} models"
+            )
+        try:
+            models = await list_method()
             return models
         except Exception as e:
-            logger.error(f"Failed to fetch remote models for provider {provider_id}: {e}")
+            logger.error(f"Failed to fetch remote {model_type} models for provider {provider_id}: {e}")
             raise

--- a/core/provider/src/aliyun_bailian/model_clients.py
+++ b/core/provider/src/aliyun_bailian/model_clients.py
@@ -17,6 +17,7 @@ from openai import AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionEr
 
 from core.provider import (
     ModelInfo,
+    ProviderAPIError,
     TTSModelClient,
     STTModelClient,
     ImageModelClient,
@@ -34,8 +35,9 @@ logger = get_logger("provider", "purple")
 # CosyVoice non-streaming call limit (characters)
 _MAX_TEXT_CHARS = 20000
 
-# Protect dashscope global api_key / websocket url mutation across concurrent calls
-_DASHSCOPE_LOCK = threading.Lock()
+# Cap concurrent CosyVoice child processes without serialising synthesis
+_COSYVOICE_MAX_CONCURRENCY = 3
+_COSYVOICE_SLOTS = threading.BoundedSemaphore(_COSYVOICE_MAX_CONCURRENCY)
 
 
 def _cosyvoice_synth_worker(payload: dict, result_queue: multiprocessing.Queue) -> None:
@@ -257,10 +259,10 @@ class BailianEmbeddingClient(EmbeddingModelClient):
             return [item.embedding for item in response.data]
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:
             logger.error(f"Bailian Embedding API error: {e}")
-            return []
+            raise ProviderAPIError(f"Bailian embedding request failed: {e}") from e
         except Exception as e:
             logger.error(f"Bailian Embedding error: {e}")
-            return []
+            raise ProviderAPIError(f"Bailian embedding request failed: {e}") from e
 
 
 # ───────────────────────────── Rerank ─────────────────────────────
@@ -285,7 +287,7 @@ class BailianRerankClient(RerankModelClient):
         api_key = (mp.get("api_key") or "").strip()
         if not api_key:
             logger.error("Bailian Rerank: api_key is not configured")
-            return []
+            raise ProviderAPIError("Bailian rerank: api_key is not configured")
 
         model_id = self.model.model_id
         timeout = int(mc.get("timeout", 30) or 30)
@@ -347,7 +349,7 @@ class BailianRerankClient(RerankModelClient):
                 data = resp.json()
         except Exception as e:
             logger.error(f"Bailian Rerank failed: {e}")
-            return []
+            raise ProviderAPIError(f"Bailian rerank request failed: {e}") from e
 
         # Normalize results from different response shapes
         raw_results = []
@@ -1614,7 +1616,7 @@ class BailianSTTClient(STTModelClient):
         api_key = (mp.get("api_key") or "").strip()
         if not api_key:
             logger.error("Bailian STT: api_key is not configured")
-            return ""
+            raise ProviderAPIError("Bailian STT: api_key is not configured")
 
         model_id = self.model.model_id or "paraformer-realtime-v2"
         sample_rate = int(mc.get("sample_rate", 16000) or 16000)
@@ -1670,12 +1672,14 @@ class BailianSTTClient(STTModelClient):
                 timeout=timeout,
             )
             return text or ""
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             logger.error(f"Bailian STT timed out after {timeout}s (model={model_id})")
-            return ""
+            raise ProviderAPIError(
+                f"Bailian STT timed out after {timeout}s (model={model_id})"
+            ) from e
         except Exception as e:
             logger.error(f"Bailian STT failed: {e}")
-            return ""
+            raise ProviderAPIError(f"Bailian STT failed: {e}") from e
         finally:
             if tmp_path and os.path.exists(tmp_path):
                 try:
@@ -2043,12 +2047,12 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
         api_key = (mp.get("api_key") or "").strip()
         if not api_key:
             logger.error("Bailian CosyVoice TTS: api_key is not configured")
-            return None
+            raise ProviderAPIError("Bailian CosyVoice TTS: api_key is not configured")
 
         voice = (mc.get("voice") or "").strip()
         if not voice:
             logger.error("Bailian CosyVoice TTS: voice is not configured")
-            return None
+            raise ProviderAPIError("Bailian CosyVoice TTS: voice is not configured")
 
         model_id = self.model.model_id
         region = _region(mp)
@@ -2104,13 +2108,15 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
                 logger.error(
                     f"Bailian CosyVoice TTS timed out after {timeout}s (model={model_id})"
                 )
-            else:
-                logger.error(f"Bailian CosyVoice TTS failed: {e}")
-            return None
+                raise ProviderAPIError(
+                    f"Bailian CosyVoice TTS timed out after {timeout}s (model={model_id})"
+                ) from e
+            logger.error(f"Bailian CosyVoice TTS failed: {e}")
+            raise ProviderAPIError(f"Bailian CosyVoice TTS failed: {e}") from e
 
         if not audio_bytes:
             logger.error("Bailian CosyVoice TTS returned empty audio")
-            return None
+            raise ProviderAPIError("Bailian CosyVoice TTS returned empty audio")
 
         b64_str = base64.b64encode(audio_bytes).decode("utf-8")
         return Record(record=b64_str, mime=_resolve_mime(audio_format))
@@ -2148,11 +2154,11 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
             )
         timeout_ms = max(1, int(remaining * 1000))
 
-        # Serialize CosyVoice workers so we do not spawn unbounded processes.
-        # Unlike the old lock-around-in-process-call path, parent api_key is not
-        # mutated; the lock only limits concurrent child processes.
-        lock_budget = max(0.01, deadline - time.monotonic())
-        acquired = _DASHSCOPE_LOCK.acquire(timeout=lock_budget)
+        # Bound the number of concurrent CosyVoice workers so we do not spawn
+        # unbounded processes. Parent api_key is never mutated, so slots only
+        # limit concurrency and do not need to serialise synthesis.
+        slot_budget = max(0.01, deadline - time.monotonic())
+        acquired = _COSYVOICE_SLOTS.acquire(timeout=slot_budget)
         if not acquired:
             raise TimeoutError(
                 f"CosyVoice waiting for synthesis slot timed out after {call_timeout}s"
@@ -2237,7 +2243,7 @@ class BailianCosyVoiceTTSClient(TTSModelClient):
             finally:
                 if proc is not None and proc.is_alive():
                     self._terminate_cosyvoice_worker(proc)
-                _DASHSCOPE_LOCK.release()
+                _COSYVOICE_SLOTS.release()
 
     @staticmethod
     def _terminate_cosyvoice_worker(proc: multiprocessing.Process | None) -> None:

--- a/core/provider/src/deepseek/model_clients.py
+++ b/core/provider/src/deepseek/model_clients.py
@@ -6,12 +6,16 @@ from openai import (
     NOT_GIVEN,
 )
 import time
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Optional
 
 from core.provider import ModelInfo, LLMModelClient
 from core.provider.llm_model import LLMRequest, LLMResponse, LLMStreamChunk
 from core.logging_manager import get_logger
-from core.utils.model_clients import build_llm_default_headers
+from core.utils.model_clients import (
+    apply_stream_options,
+    build_llm_default_headers,
+    create_chat_stream,
+)
 from core.utils.media_refs import resolve_media_references
 
 logger = get_logger("provider", "purple")
@@ -47,6 +51,7 @@ class DeepSeekLLMClient(LLMModelClient):
         model_config = self.model.model_config or {}
         thinking_enabled = model_config.get("thinking_enabled", True)
         reasoning_effort = model_config.get("reasoning_effort", "high")
+        timeout = model_config.get("timeout")
         section_advanced = model_config.get("section_advanced") or {}
         user_extra_body = section_advanced.get("extra_body")
 
@@ -65,6 +70,7 @@ class DeepSeekLLMClient(LLMModelClient):
             messages=[m if isinstance(m, dict) else m.to_dict() for m in request.messages],
             tools=request.tools if request.tools else NOT_GIVEN,
             tool_choice=request.tool_choice if request.tool_choice != "none" else NOT_GIVEN,
+            timeout=timeout if timeout is not None else NOT_GIVEN,
         )
 
         if thinking_enabled:
@@ -80,13 +86,13 @@ class DeepSeekLLMClient(LLMModelClient):
         return kwargs
 
     async def chat(self, request: LLMRequest, **kwargs) -> LLMResponse:
-        client = self._build_client()
         messages = await resolve_media_references(request.messages)
         request_kwargs = self._build_request_kwargs(request, messages=messages, **kwargs)
 
         try:
             start_time = time.perf_counter()
-            response = await client.chat.completions.create(**request_kwargs)
+            async with self._build_client() as client:
+                response = await client.chat.completions.create(**request_kwargs)
             end_time = time.perf_counter()
 
             llm_resp = LLMResponse("")
@@ -132,64 +138,74 @@ class DeepSeekLLMClient(LLMModelClient):
             raise
 
     async def chat_stream(self, request: LLMRequest, **kwargs) -> AsyncGenerator[LLMStreamChunk, None]:
-        client = self._build_client()
         messages = await resolve_media_references(request.messages)
         request_kwargs = self._build_request_kwargs(
             request, messages=messages, stream=True, **kwargs
         )
-        request_kwargs["stream_options"] = {"include_usage": True}
+        apply_stream_options(request_kwargs)
+
+        # The final chunk is held back until the stream ends so that
+        # finish_reason and token usage are reported together, exactly once.
+        pending_final: Optional[LLMStreamChunk] = None
+        usage: Optional[dict] = None
 
         try:
-            stream = await client.chat.completions.create(**request_kwargs)
-            async for event in stream:
-                # Usage-only event (sent by OpenAI API after the final choice chunk)
-                if not event.choices:
-                    if event.usage:
-                        yield LLMStreamChunk(
-                            is_final=True,
-                            usage={
+            async with self._build_client() as client:
+                stream = await create_chat_stream(client, request_kwargs)
+                async for event in stream:
+                    # Usage-only event (sent by OpenAI API after the final choice chunk)
+                    if not event.choices:
+                        if event.usage:
+                            usage = {
                                 "input_tokens": event.usage.prompt_tokens,
                                 "output_tokens": event.usage.completion_tokens,
                                 "cached_tokens": getattr(event.usage, "prompt_cache_hit_tokens", None),
-                            },
-                        )
-                    continue
+                            }
+                        continue
 
-                choice = event.choices[0]
-                delta = choice.delta
+                    choice = event.choices[0]
+                    delta = choice.delta
 
-                chunk = LLMStreamChunk()
+                    chunk = LLMStreamChunk()
 
-                # Text content
-                if delta.content:
-                    chunk.delta_text = delta.content
+                    # Text content
+                    if delta.content:
+                        chunk.delta_text = delta.content
 
-                # DeepSeek reasoning_content
-                reasoning = getattr(delta, "reasoning_content", "") or ""
-                if reasoning:
-                    chunk.delta_reasoning = reasoning
+                    # DeepSeek reasoning_content
+                    reasoning = getattr(delta, "reasoning_content", "") or ""
+                    if reasoning:
+                        chunk.delta_reasoning = reasoning
 
-                # Tool calls — pass through raw incremental deltas from SDK
-                if delta.tool_calls:
-                    for tc in delta.tool_calls:
-                        fragment = {
-                            "index": tc.index,
-                            "id": tc.id or "",
-                            "type": "function",
-                            "function": {
-                                "name": tc.function.name if tc.function and tc.function.name else "",
-                                "arguments": tc.function.arguments if tc.function and tc.function.arguments else "",
-                            },
-                        }
-                        chunk.tool_calls_delta.append(fragment)
+                    # Tool calls — pass through raw incremental deltas from SDK
+                    if delta.tool_calls:
+                        for tc in delta.tool_calls:
+                            fragment = {
+                                "index": tc.index,
+                                "id": tc.id or "",
+                                "type": "function",
+                                "function": {
+                                    "name": tc.function.name if tc.function and tc.function.name else "",
+                                    "arguments": tc.function.arguments if tc.function and tc.function.arguments else "",
+                                },
+                            }
+                            chunk.tool_calls_delta.append(fragment)
 
-                # Finish reason
-                finish_reason = choice.finish_reason
-                if finish_reason:
-                    chunk.is_final = True
-                    chunk.finish_reason = finish_reason
+                    # Finish reason
+                    finish_reason = choice.finish_reason
+                    if finish_reason:
+                        chunk.is_final = True
+                        chunk.finish_reason = finish_reason
+                        pending_final = chunk
+                        continue
 
-                yield chunk
+                    yield chunk
+
+                if pending_final is not None:
+                    pending_final.usage = usage
+                    yield pending_final
+                elif usage is not None:
+                    yield LLMStreamChunk(is_final=True, usage=usage)
 
         except APIStatusError:
             raise

--- a/core/provider/src/gptsovits/model_clients.py
+++ b/core/provider/src/gptsovits/model_clients.py
@@ -4,7 +4,7 @@ import aiohttp
 
 from typing import Optional
 
-from core.provider import ModelInfo, TTSModelClient
+from core.provider import ModelInfo, TTSModelClient, ProviderAPIError
 from core.chat.message_elements import Record
 from core.logging_manager import get_logger
 
@@ -86,18 +86,25 @@ class GptSovitsTTSClient(TTSModelClient):
                             audio_bytes += chunk
                     else:
                         logger.error(f"GPT-Sovits TTS Request failed: {response.status}")
+                        error_detail = ""
                         try:
                             error_info = await response.json()
                             logger.error(f"GPT-Sovits Error: {error_info}")
+                            error_detail = f": {error_info}"
                         except (aiohttp.ContentTypeError, ValueError):
                             logger.error("GPT-Sovits error response was not valid JSON")
-                        return None
-            except asyncio.TimeoutError:
+                        raise ProviderAPIError(
+                            f"GPT-SoVITS TTS request failed with status {response.status}{error_detail}"
+                        )
+            except asyncio.TimeoutError as e:
                 logger.error(f"GPT-Sovits TTS request timed out after {timeout}s")
-                return None
+                raise ProviderAPIError(f"GPT-SoVITS TTS request timed out after {timeout}s") from e
             except aiohttp.ClientError as e:
                 logger.error(f"GPT-Sovits TTS network error: {e}")
-                return None
+                raise ProviderAPIError(f"GPT-SoVITS TTS network error: {e}") from e
+
+        if not audio_bytes:
+            raise ProviderAPIError("GPT-SoVITS TTS returned empty audio")
 
         b64_str = base64.b64encode(audio_bytes).decode("utf-8")
         return Record(record=b64_str)

--- a/core/provider/src/modelscope/model_clients.py
+++ b/core/provider/src/modelscope/model_clients.py
@@ -4,7 +4,7 @@ import asyncio
 import httpx
 import base64
 
-from core.provider import ModelInfo
+from core.provider import ModelInfo, ProviderAPIError
 from core.provider import LLMModelClient, ImageModelClient, EmbeddingModelClient
 from core.provider.llm_model import LLMRequest, LLMResponse
 from core.logging_manager import get_logger
@@ -102,24 +102,24 @@ class ModelScopeEmbeddingClient(EmbeddingModelClient):
             model_cfg.get("slow_request_threshold", None) if isinstance(model_cfg, dict) else None
         )
 
-        client = AsyncOpenAI(
-            api_key=self.model.provider_config.get("api_key", ""),
-            base_url="https://api-inference.modelscope.cn/v1",
-            timeout=timeout_sec
-        )
         try:
             start_time = time.perf_counter()
-            response = await client.embeddings.create(
-                model=self.model.model_id,
-                input=texts
-            )
+            async with AsyncOpenAI(
+                api_key=self.model.provider_config.get("api_key", ""),
+                base_url="https://api-inference.modelscope.cn/v1",
+                timeout=timeout_sec
+            ) as client:
+                response = await client.embeddings.create(
+                    model=self.model.model_id,
+                    input=texts
+                )
             elapsed = round(time.perf_counter() - start_time, 2)
             if slow_threshold is not None and elapsed > slow_threshold:
                 logger.warning(f"Slow embedding request: {elapsed}s (threshold: {slow_threshold}s, model: {self.model.model_id})")
             return [item.embedding for item in response.data]
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:
             logger.error(f"Embedding API error: {e}")
-            return []
+            raise ProviderAPIError(f"Embedding request failed: {e}") from e
         except Exception as e:
             logger.error(f"Embedding error: {e}")
-            return []
+            raise ProviderAPIError(f"Embedding request failed: {e}") from e

--- a/core/provider/src/openai/model_clients.py
+++ b/core/provider/src/openai/model_clients.py
@@ -3,7 +3,7 @@ import re
 import time
 from typing import Optional, Union
 
-from core.provider import ModelInfo
+from core.provider import ModelInfo, ProviderAPIError
 from core.provider import LLMModelClient, ImageModelClient, EmbeddingModelClient
 from core.provider.llm_model import LLMRequest, LLMResponse
 from core.logging_manager import get_logger
@@ -67,16 +67,16 @@ class OpenAIImageClient(ImageModelClient):
     # ──────── Mode A: /v1/images/generations ────────
 
     async def _text_to_image_via_generations(self, prompt: str) -> Image:
-        client = self._build_client()
         image_size = self.model.model_config.get("size", None)
         try:
-            images_response = await client.images.generate(
-                model=self.model.model_id,
-                prompt=prompt,
-                size=image_size if image_size else None,
-                response_format="url",
-                extra_body={"watermark": False},
-            )
+            async with self._build_client() as client:
+                images_response = await client.images.generate(
+                    model=self.model.model_id,
+                    prompt=prompt,
+                    size=image_size if image_size else None,
+                    response_format="url",
+                    extra_body={"watermark": False},
+                )
             if not images_response.data:
                 raise ValueError("Image generation API returned empty data")
             return Image(image=images_response.data[0].url)
@@ -90,14 +90,14 @@ class OpenAIImageClient(ImageModelClient):
     # ──────── Mode B: /v1/chat/completions (non-stream) ────────
 
     async def _text_to_image_via_chat(self, prompt: str) -> Image:
-        client = self._build_client()
         messages = [{"role": "user", "content": prompt}]
 
         try:
-            response = await client.chat.completions.create(
-                model=self.model.model_id,
-                messages=messages,
-            )
+            async with self._build_client() as client:
+                response = await client.chat.completions.create(
+                    model=self.model.model_id,
+                    messages=messages,
+                )
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:
             logger.error(f"Image generation (chat) API error: {e}")
             raise
@@ -247,17 +247,17 @@ class OpenAIImageClient(ImageModelClient):
     # ──────── image-to-image Mode A: /v1/images/generations ────────
 
     async def _image_to_image_via_generations(self, prompt: str, images: list[Image]) -> Image:
-        client = self._build_client()
         image_size = self.model.model_config.get("size", None)
         image_data_urls = [await img.to_data_url() for img in images]
         try:
-            images_response = await client.images.generate(
-                model=self.model.model_id,
-                prompt=prompt,
-                size=image_size if image_size else None,
-                response_format="url",
-                extra_body={"watermark": False, "image": image_data_urls},
-            )
+            async with self._build_client() as client:
+                images_response = await client.images.generate(
+                    model=self.model.model_id,
+                    prompt=prompt,
+                    size=image_size if image_size else None,
+                    response_format="url",
+                    extra_body={"watermark": False, "image": image_data_urls},
+                )
             if not images_response.data:
                 raise ValueError("Image-to-image generation API returned empty data")
             return Image(image=images_response.data[0].url)
@@ -271,17 +271,17 @@ class OpenAIImageClient(ImageModelClient):
     # ──────── image-to-image Mode B: /v1/chat/completions ────────
 
     async def _image_to_image_via_chat(self, prompt: str, images: list[Image]) -> Image:
-        client = self._build_client()
         content = [{"type": "text", "text": prompt}]
         for img in images:
             image_data_url = await img.to_data_url()
             content.append({"type": "image_url", "image_url": {"url": image_data_url}})
         messages = [{"role": "user", "content": content}]
         try:
-            response = await client.chat.completions.create(
-                model=self.model.model_id,
-                messages=messages,
-            )
+            async with self._build_client() as client:
+                response = await client.chat.completions.create(
+                    model=self.model.model_id,
+                    messages=messages,
+                )
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:
             logger.error(f"Image-to-image (chat) API error: {e}")
             raise
@@ -316,26 +316,26 @@ class OpenAIEmbeddingClient(EmbeddingModelClient):
         if not isinstance(default_headers, dict) or not default_headers:
             default_headers = None
 
-        client = AsyncOpenAI(
-            api_key=self.model.provider_config.get("api_key", ""),
-            base_url=self.model.provider_config.get("base_url", ""),
-            timeout=timeout_sec,
-            default_headers=default_headers
-        )
         try:
             start_time = time.perf_counter()
-            response = await client.embeddings.create(
-                model=self.model.model_id,
-                input=texts
-            )
+            async with AsyncOpenAI(
+                api_key=self.model.provider_config.get("api_key", ""),
+                base_url=self.model.provider_config.get("base_url", ""),
+                timeout=timeout_sec,
+                default_headers=default_headers
+            ) as client:
+                response = await client.embeddings.create(
+                    model=self.model.model_id,
+                    input=texts
+                )
             elapsed = round(time.perf_counter() - start_time, 2)
             if elapsed > slow_threshold:
                 logger.warning(f"Slow embedding request: {elapsed}s (threshold: {slow_threshold}s, model: {self.model.model_id})")
             return [item.embedding for item in response.data]
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:
             logger.error(f"Embedding API error: {e}")
-            return []
+            raise ProviderAPIError(f"Embedding request failed: {e}") from e
         except Exception as e:
             logger.error(f"Embedding error: {e}")
-            return []
+            raise ProviderAPIError(f"Embedding request failed: {e}") from e
 

--- a/core/provider/src/siliconflow_cn/model_clients.py
+++ b/core/provider/src/siliconflow_cn/model_clients.py
@@ -3,9 +3,11 @@ from io import BytesIO
 from typing import Optional
 import httpx
 import base64
+import mimetypes
+import os
 import time
 
-from core.provider import ModelInfo
+from core.provider import ModelInfo, ProviderAPIError
 from core.provider import (ImageModelClient, TTSModelClient,
                            STTModelClient, EmbeddingModelClient, RerankModelClient)
 from core.logging_manager import get_logger
@@ -15,6 +17,73 @@ from core.chat.message_elements import Record, Image
 from core.utils.model_clients import OpenAICompatibleLLMClient, OpenAICompatibleTTSClient
 
 logger = get_logger("provider", "purple")
+
+_AUDIO_EXTENSIONS = {
+    "wav", "mp3", "amr", "silk", "ogg", "opus", "m4a", "aac", "flac", "pcm", "webm",
+}
+
+_AUDIO_MIME_EXTENSIONS = {
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/wave": "wav",
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/amr": "amr",
+    "audio/silk": "silk",
+    "audio/ogg": "ogg",
+    "audio/opus": "opus",
+    "audio/webm": "webm",
+    "audio/mp4": "m4a",
+    "audio/x-m4a": "m4a",
+    "audio/aac": "aac",
+    "audio/flac": "flac",
+    "audio/x-flac": "flac",
+}
+
+
+def _sniff_audio_extension(data: bytes) -> Optional[str]:
+    """Detect the container of an audio payload from its magic bytes."""
+    if len(data) < 8:
+        return None
+    if data[:4] == b"RIFF" and data[8:12] == b"WAVE":
+        return "wav"
+    if data[:4] == b"OggS":
+        return "ogg"
+    if data[:4] == b"fLaC":
+        return "flac"
+    if data[:5] == b"#!AMR":
+        return "amr"
+    if b"#!SILK" in data[:10]:
+        return "silk"
+    if data[4:8] == b"ftyp":
+        return "m4a"
+    if data[:3] == b"ID3" or (data[0] == 0xFF and data[1] & 0xE0 == 0xE0):
+        return "mp3"
+    return None
+
+
+def resolve_audio_filename(record: Record, audio_data: bytes) -> str:
+    """Derive an upload filename whose extension matches the actual audio.
+
+    IM voice messages are commonly amr/silk/ogg/mp3; sending them as .wav
+    makes the server misparse the payload or degrade transcription.
+    """
+    ext = _sniff_audio_extension(audio_data)
+    if not ext:
+        for candidate in (record.name, record.guess_name()):
+            if not candidate:
+                continue
+            suffix = os.path.splitext(candidate)[1].lstrip(".").lower()
+            if suffix in _AUDIO_EXTENSIONS:
+                ext = suffix
+                break
+    if not ext:
+        mime = (record.mime or "").split(";")[0].strip().lower()
+        ext = _AUDIO_MIME_EXTENSIONS.get(mime)
+        if not ext and mime.startswith("audio/"):
+            guessed = (mimetypes.guess_extension(mime) or "").lstrip(".").lower()
+            ext = guessed if guessed in _AUDIO_EXTENSIONS else None
+    return f"audio.{ext or 'wav'}"
 
 
 class SiliconflowLLMClient(OpenAICompatibleLLMClient):
@@ -43,7 +112,11 @@ class SiliconflowImageClient(ImageModelClient):
         async with httpx.AsyncClient(timeout=30) as client:
             response = await client.post(url, json=payload, headers=headers)
             response.raise_for_status()
-        image_url = response.json().get("images")[0].get("url")
+        data = response.json()
+        images = data.get("images") if isinstance(data, dict) else None
+        image_url = images[0].get("url") if isinstance(images, list) and images else None
+        if not image_url:
+            raise ValueError(f"Siliconflow image generation returned no image url: {data}")
         return Image(image=image_url)
 
 
@@ -62,7 +135,7 @@ class SiliconflowSTTClient(STTModelClient):
 
         audio_data = base64.b64decode(audio_base64)
         audio_file = BytesIO(audio_data)
-        audio_file.name = "audio.wav"
+        audio_file.name = resolve_audio_filename(record, audio_data)
 
         files = {"file": audio_file}
         payload = {"model": self.model.model_id}
@@ -91,27 +164,27 @@ class SiliconflowEmbeddingClient(EmbeddingModelClient):
         timeout_sec = self.model.model_config.get("timeout", 60) if self.model.model_config else 60
         slow_threshold = self.model.model_config.get("slow_request_threshold", 5.0) if self.model.model_config else 5.0
 
-        client = AsyncOpenAI(
-            api_key=self.model.provider_config.get("api_key", ""),
-            base_url="https://api.siliconflow.cn/v1",
-            timeout=timeout_sec
-        )
         try:
             start_time = time.perf_counter()
-            response = await client.embeddings.create(
-                model=self.model.model_id,
-                input=texts
-            )
+            async with AsyncOpenAI(
+                api_key=self.model.provider_config.get("api_key", ""),
+                base_url="https://api.siliconflow.cn/v1",
+                timeout=timeout_sec
+            ) as client:
+                response = await client.embeddings.create(
+                    model=self.model.model_id,
+                    input=texts
+                )
             elapsed = round(time.perf_counter() - start_time, 2)
             if elapsed > slow_threshold:
                 logger.warning(f"Slow embedding request: {elapsed}s (threshold: {slow_threshold}s, model: {self.model.model_id})")
             return [item.embedding for item in response.data]
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:
             logger.error(f"Embedding API error: {e}")
-            return []
+            raise ProviderAPIError(f"Embedding request failed: {e}") from e
         except Exception as e:
             logger.error(f"Embedding error: {e}")
-            return []
+            raise ProviderAPIError(f"Embedding request failed: {e}") from e
 
 
 class SiliconflowRerankClient(RerankModelClient):
@@ -156,13 +229,21 @@ class SiliconflowRerankClient(RerankModelClient):
         resp.raise_for_status()
         data = resp.json()
 
-        results = [
-            RerankResult(
-                index=item["index"],
-                score=item["relevance_score"],
-                text=documents[item["index"]]
-            )
-            for item in data.get("results", [])
-        ]
+        results: list[RerankResult] = []
+        for item in data.get("results", []):
+            if not isinstance(item, dict):
+                continue
+            try:
+                idx = int(item["index"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if not 0 <= idx < len(documents):
+                logger.warning(f"Siliconflow rerank returned out-of-range index {idx}, skipping")
+                continue
+            try:
+                score = float(item.get("relevance_score", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                score = 0.0
+            results.append(RerankResult(index=idx, score=score, text=documents[idx]))
 
         return results

--- a/core/provider/src/volcengine/model_clients.py
+++ b/core/provider/src/volcengine/model_clients.py
@@ -4,13 +4,27 @@ import time
 import httpx
 from typing import Optional, Union
 
-from core.provider import ModelInfo, ImageModelClient, VideoModelClient, EmbeddingModelClient
+from core.provider import ModelInfo, ImageModelClient, VideoModelClient, EmbeddingModelClient, ProviderAPIError
 from core.logging_manager import get_logger
 from core.provider.llm_model import LLMRequest, LLMResponse
 from core.chat.message_elements import Image, Video
 from core.utils.model_clients import OpenAICompatibleLLMClient
 
 logger = get_logger("provider", "purple")
+
+# Volcengine video jobs (Seedance etc.) usually take 1-5 minutes
+DEFAULT_VIDEO_TIMEOUT = 300
+DEFAULT_VIDEO_RATIO = "16:9"
+VIDEO_POLL_INTERVAL = 2
+
+
+def _first_image_url(images_response, label: str) -> str:
+    """Read the first image URL, surfacing empty responses instead of TypeError."""
+    data = getattr(images_response, "data", None)
+    url = data[0].url if data else None
+    if not url:
+        raise ValueError(f"{label} API returned no image url: {images_response}")
+    return url
 
 
 class VolcengineLLMClient(OpenAICompatibleLLMClient):
@@ -22,60 +36,76 @@ class VolcengineImageClient(ImageModelClient):
         super().__init__(model)
 
     async def text_to_image(self, prompt) -> Image:
-        client = AsyncOpenAI(
+        image_size = self.model.model_config.get("size", None)
+        async with AsyncOpenAI(
             base_url=self.model.provider_config.get("base_url", ""),
             api_key=self.model.provider_config.get("api_key", ""),
-        )
-        image_size = self.model.model_config.get("size", None)
-        images_response = await client.images.generate(
-            model=self.model.model_id,
-            prompt=prompt,
-            size=image_size if image_size else None,
-            response_format="url",
-            extra_body={
-                "watermark": False,
-            },
-        )
+        ) as client:
+            images_response = await client.images.generate(
+                model=self.model.model_id,
+                prompt=prompt,
+                size=image_size if image_size else None,
+                response_format="url",
+                extra_body={
+                    "watermark": False,
+                },
+            )
 
-        return Image(image=images_response.data[0].url)
+        return Image(image=_first_image_url(images_response, "Image generation"))
 
     async def image_to_image(self, prompt: str, image: Union[Image, list[Image]]) -> Image:
         if isinstance(image, Image):
             image = [image]
         ref_imgs = [await img.to_data_url() for img in image]
 
-        client = AsyncOpenAI(
+        image_size = self.model.model_config.get("size", None)
+        async with AsyncOpenAI(
             base_url=self.model.provider_config.get("base_url", "https://ark.cn-beijing.volces.com/api/v3"),
             api_key=self.model.provider_config.get("api_key", ""),
-        )
-        image_size = self.model.model_config.get("size", None)
-        images_response = await client.images.generate(
-            model=self.model.model_id,
-            prompt=prompt,
-            size=image_size if image_size else None,
-            response_format="url",
-            extra_body={
-                "image": ref_imgs,
-                "watermark": False
-            }
-        )
-        return Image(image=images_response.data[0].url)
+        ) as client:
+            images_response = await client.images.generate(
+                model=self.model.model_id,
+                prompt=prompt,
+                size=image_size if image_size else None,
+                response_format="url",
+                extra_body={
+                    "image": ref_imgs,
+                    "watermark": False
+                }
+            )
+        return Image(image=_first_image_url(images_response, "Image-to-image generation"))
 
 
 class VolcengineVideoClient(VideoModelClient):
     def __init__(self, model: ModelInfo):
         super().__init__(model)
 
+    def _poll_timeout(self) -> float:
+        """Resolve the total polling budget (seconds) from model config."""
+        model_cfg = self.model.model_config or {}
+        raw = model_cfg.get("timeout", DEFAULT_VIDEO_TIMEOUT)
+        try:
+            timeout = float(raw)
+        except (TypeError, ValueError):
+            logger.warning(f"Invalid video timeout '{raw}', fallback to {DEFAULT_VIDEO_TIMEOUT}")
+            return float(DEFAULT_VIDEO_TIMEOUT)
+        if timeout <= 0:
+            logger.warning(f"Invalid non-positive video timeout '{raw}', fallback to {DEFAULT_VIDEO_TIMEOUT}")
+            return float(DEFAULT_VIDEO_TIMEOUT)
+        return timeout
+
     async def generate_video(self, prompt: str, ref: list[Image] = None, duration: int = 5, **kwargs) -> Video:
+        timeout = self._poll_timeout()
+
         # Use a context-managed client so the connection is always closed.
-        async with httpx.AsyncClient(timeout=30) as client:
+        async with httpx.AsyncClient(timeout=timeout) as client:
             task_id = await self._create_task(client=client, text=prompt, ref=ref, duration=duration)
 
             start_ts = time.time()
 
             data = None
 
-            while time.time() - start_ts < 30:
+            while time.time() - start_ts < timeout:
                 data = await self._get_task(client=client, task_id=task_id)
 
                 status = data.get("status")
@@ -94,10 +124,31 @@ class VolcengineVideoClient(VideoModelClient):
                     raise RuntimeError(f"Volcengine video generation failed with status: {status}")
 
                 # Avoid busy-spinning: wait before polling the task status again.
-                await asyncio.sleep(2)
+                await asyncio.sleep(VIDEO_POLL_INTERVAL)
 
-            logger.error(f"Timeout while generating video: {data}")
-            raise TimeoutError("Volcengine video generation timed out")
+            logger.error(f"Timeout while generating video after {timeout}s: {data}")
+            raise TimeoutError(f"Volcengine video generation timed out after {timeout}s")
+
+    @staticmethod
+    async def _image_content_parts(ref: list[Image]) -> list[dict]:
+        """Serialise reference images into Volcengine ``image_url`` content parts.
+
+        A single image is the conventional first frame and carries no role.
+        Multiple images are sent as reference images, which is the only role
+        that accepts more than two inputs.
+        """
+        images = [img for img in (ref or []) if img is not None]
+        if not images:
+            return []
+        role = None if len(images) == 1 else "reference_image"
+        parts = []
+        for img in images:
+            url = img.image if img.image_type == "url" else await img.to_data_url()
+            part = {"type": "image_url", "image_url": {"url": url}}
+            if role:
+                part["role"] = role
+            parts.append(part)
+        return parts
 
     async def _create_task(self, client: httpx.AsyncClient, text: str, ref: list[Image] = None, duration: int = 5) -> str:
         url = "https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks"
@@ -105,15 +156,19 @@ class VolcengineVideoClient(VideoModelClient):
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.model.provider_config.get('api_key', '')}",
         }
+        model_cfg = self.model.model_config or {}
+        ratio = model_cfg.get("ratio") or DEFAULT_VIDEO_RATIO
+        content = [
+            {
+                "type": "text",
+                "text": text
+            }
+        ]
+        content.extend(await self._image_content_parts(ref))
         json_data = {
             "model": self.model.model_id,
-            "content": [
-                {
-                    "type": "text",
-                    "text": text
-                }
-            ],
-            "ratio": "16:9",
+            "content": content,
+            "ratio": ratio,
             "duration": duration,
             "watermark": False
         }
@@ -124,6 +179,8 @@ class VolcengineVideoClient(VideoModelClient):
         data = resp.json()
 
         task_id = data.get("id")
+        if not task_id:
+            raise RuntimeError(f"Volcengine video task creation returned no id: {data}")
         return task_id
 
     async def _get_task(self, client: httpx.AsyncClient, task_id: str):
@@ -171,24 +228,24 @@ class VolcengineEmbeddingClient(EmbeddingModelClient):
         except (TypeError, ValueError):
             slow_threshold = None
 
-        client = AsyncOpenAI(
-            api_key=self.model.provider_config.get("api_key", ""),
-            base_url=self.model.provider_config.get("base_url", ""),
-            timeout=validated_timeout
-        )
         try:
             start_time = time.perf_counter()
-            response = await client.embeddings.create(
-                model=self.model.model_id,
-                input=texts
-            )
+            async with AsyncOpenAI(
+                api_key=self.model.provider_config.get("api_key", ""),
+                base_url=self.model.provider_config.get("base_url", ""),
+                timeout=validated_timeout
+            ) as client:
+                response = await client.embeddings.create(
+                    model=self.model.model_id,
+                    input=texts
+                )
             elapsed = round(time.perf_counter() - start_time, 2)
             if slow_threshold is not None and elapsed > slow_threshold:
                 logger.warning(f"Slow embedding request: {elapsed}s (threshold: {slow_threshold}s, model: {self.model.model_id})")
             return [item.embedding for item in response.data]
         except (APIStatusError, APITimeoutError, APIConnectionError) as e:
             logger.error(f"Embedding API error: {e}")
-            return []
+            raise ProviderAPIError(f"Embedding request failed: {e}") from e
         except Exception as e:
             logger.error(f"Embedding error: {e}")
-            return []
+            raise ProviderAPIError(f"Embedding request failed: {e}") from e

--- a/core/provider/src/volcengine/schema.json
+++ b/core/provider/src/volcengine/schema.json
@@ -74,7 +74,27 @@
         }
       }
     },
-    "video": {},
+    "video": {
+      "timeout": {
+        "name": "超时",
+        "type": "integer",
+        "default": 300,
+        "min": 1,
+        "hint": "视频生成任务的总等待时间（秒），火山方舟视频生成通常需要 1-5 分钟",
+        "locales": {
+          "en": { "name": "Timeout", "hint": "Total wait time for a video generation task in seconds; Volcengine video generation usually takes 1-5 minutes" }
+        }
+      },
+      "ratio": {
+        "name": "画面比例",
+        "type": "string",
+        "default": "16:9",
+        "hint": "视频画面比例，如 16:9、9:16、1:1、adaptive（使用参考图比例）",
+        "locales": {
+          "en": { "name": "Aspect Ratio", "hint": "Video aspect ratio, e.g. 16:9, 9:16, 1:1, adaptive (follow the reference image)" }
+        }
+      }
+    },
     "embedding": {
       "timeout": {
         "name": "超时",

--- a/core/sticker_manager.py
+++ b/core/sticker_manager.py
@@ -22,6 +22,8 @@ class StickerManager:
         self._sticker_paths: list = []
         self._sticker_index: int = 0
         self._on_registered_callbacks: list[Callable] = []
+        self._index_lock = asyncio.Lock()
+        self._callback_tasks: set[asyncio.Task] = set()
 
     async def init(self):
         """Load stickers from database into memory cache."""
@@ -90,15 +92,19 @@ class StickerManager:
         if sticker_id:
             sid = str(sticker_id)
         else:
-            self._sticker_index += 1
-            sid = str(self._sticker_index)
+            async with self._index_lock:
+                self._sticker_index += 1
+                sid = str(self._sticker_index)
 
         await self.db.add_sticker(sid, desc, filename, extra={})
 
         self._sticker_cache[sid] = {"desc": desc, "path": filename, "extra": {}}
         self._sticker_paths.append(filename)
 
-        asyncio.create_task(self._fire_registered(sid, {"desc": desc, "path": filename}))
+        # Keep a reference so the callback task is not garbage collected mid-flight.
+        task = asyncio.create_task(self._fire_registered(sid, {"desc": desc, "path": filename}))
+        self._callback_tasks.add(task)
+        task.add_done_callback(self._callback_tasks.discard)
 
     async def update_sticker_desc(self, sticker_id: str, desc: str):
         sid = str(sticker_id)
@@ -159,20 +165,21 @@ class StickerManager:
         final_desc = desc or ""
         # Resolve the sticker id before building the stored filename so the id
         # can be used to keep filenames unique.
-        if sticker_id and str(sticker_id).strip():
-            sid = str(sticker_id).strip()
-            if sid in self._sticker_cache:
-                raise ValueError(f"Sticker id {sid} already exists")
-            if sid.isdigit():
-                try:
-                    numeric_id = int(sid)
-                    if numeric_id > self._sticker_index:
-                        self._sticker_index = numeric_id
-                except Exception:
-                    pass
-        else:
-            self._sticker_index += 1
-            sid = str(self._sticker_index)
+        async with self._index_lock:
+            if sticker_id and str(sticker_id).strip():
+                sid = str(sticker_id).strip()
+                if sid in self._sticker_cache:
+                    raise ValueError(f"Sticker id {sid} already exists")
+                if sid.isdigit():
+                    try:
+                        numeric_id = int(sid)
+                        if numeric_id > self._sticker_index:
+                            self._sticker_index = numeric_id
+                    except Exception:
+                        pass
+            else:
+                self._sticker_index += 1
+                sid = str(self._sticker_index)
         # Sanitize the name to prevent path traversal (e.g. "../secret")
         safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", name_only)
         if not safe_name or safe_name in (".", ".."):

--- a/core/telemetry/client.py
+++ b/core/telemetry/client.py
@@ -59,6 +59,11 @@ class TelemetryClient:
         self._shutdown_event = asyncio.Event()
         self._report_lock = asyncio.Lock()
         self._init_task: Optional[asyncio.Task] = None
+        # Row ids already queued for sending. They stay unreported in the DB until the
+        # server accepts the event, so they must be skipped by later aggregation runs to
+        # avoid queueing the same counts twice.
+        self._inflight_message_ids: set[str] = set()
+        self._inflight_llm_ids: set[str] = set()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -122,8 +127,8 @@ class TelemetryClient:
                 except (asyncio.CancelledError, Exception):
                     pass
 
-            # Cancel stats/heartbeat first — stats_loop finally block
-            # guarantees _report_lock is released on cancellation.
+            # Cancel stats/heartbeat first so the final _report_stats below is not
+            # racing a scheduled run for the same rows.
             for task in (self._heartbeat_task, self._stats_task):
                 if task and not task.done():
                     task.cancel()
@@ -134,7 +139,6 @@ class TelemetryClient:
                     except Exception as e:
                         logger.debug(f"Telemetry task {task.get_name()} raised on shutdown: {e}")
 
-            # Now safe — lock is guaranteed free
             await self._report_stats()
 
             started_ts = self.stats.get_stats("started_ts") if self.stats else None
@@ -176,16 +180,20 @@ class TelemetryClient:
     def send_event(
         self, event_type: str, data: dict[str, Any],
         force: bool = False, on_success: Optional[Any] = None,
-    ) -> None:
+        on_failure: Optional[Any] = None,
+    ) -> bool:
         """
         Fire-and-forget event submission.
         If the worker is not running, the event is silently dropped.
         Use ``force=True`` to bypass the local enabled check (used for
         telemetry state-change events themselves).
         ``on_success`` is an async callback invoked after the server accepts the event.
+        ``on_failure`` is an async callback invoked when the event could not be delivered.
+
+        Returns True when the event was queued.
         """
         if not force and not self.is_enabled():
-            return
+            return False
 
         event = TelemetryEvent(
             event_type=event_type,
@@ -193,11 +201,14 @@ class TelemetryClient:
             client_uuid=self.client_uuid,
             timestamp=datetime.now(timezone.utc).isoformat(),
             _on_success=on_success,
+            _on_failure=on_failure,
         )
         try:
             self._send_queue.put_nowait(event)
         except asyncio.QueueFull:
             logger.warning("Telemetry send queue is full; dropping event.")
+            return False
+        return True
 
     async def toggle_telemetry(self, enabled: bool) -> bool:
         """
@@ -362,6 +373,7 @@ class TelemetryClient:
                 payload["signature"] = self._sign_payload(payload)
             except Exception as e:
                 logger.error(f"Failed to sign telemetry event: {e}")
+                await self._run_failure_callback(event)
                 continue
 
             try:
@@ -384,23 +396,37 @@ class TelemetryClient:
                     logger.warning("Telemetry rejected by server (disabled or bad signature).")
                 else:
                     logger.warning(f"Telemetry server returned {e.response.status_code}: {e}")
+                await self._run_failure_callback(event)
             except Exception as e:
                 logger.warning(f"Failed to send telemetry event: {type(e).__name__}: {e}")
+                await self._run_failure_callback(event)
+
+    @staticmethod
+    async def _run_failure_callback(event: TelemetryEvent) -> None:
+        if not event._on_failure:
+            return
+        try:
+            await event._on_failure()
+        except Exception as e:
+            logger.warning(f"Telemetry on_failure callback failed: {e}")
 
     # ------------------------------------------------------------------
     # Geo lookup
     # ------------------------------------------------------------------
     async def _fetch_country_code(self) -> Optional[str]:
         """
-        Fetch country code from public IP via ip-api.com.
+        Fetch country code from public IP over HTTPS.
         Uses a dedicated client with proxy explicitly disabled.
+
+        api.country.is is used because ip-api.com only serves plaintext HTTP on its free
+        tier, which would expose the client's public IP to on-path observers.
         """
         transport = httpx.AsyncHTTPTransport(proxy=None)
         try:
             async with httpx.AsyncClient(timeout=5.0, transport=transport) as client:
-                resp = await client.get("http://ip-api.com/json/?fields=countryCode")
+                resp = await client.get("https://api.country.is/")
                 resp.raise_for_status()
-                code = resp.json().get("countryCode")
+                code = resp.json().get("country")
                 if code:
                     logger.debug(f"Country code detected: {code}")
                     return code
@@ -440,24 +466,40 @@ class TelemetryClient:
     # ------------------------------------------------------------------
     async def _stats_loop(self) -> None:
         """Background loop that aggregates and reports telemetry data every 30 minutes."""
-        try:
-            while not self._shutdown_event.is_set():
-                try:
-                    await asyncio.wait_for(self._shutdown_event.wait(), timeout=1800.0)
-                except asyncio.TimeoutError:
-                    pass
-                else:
-                    break
+        while not self._shutdown_event.is_set():
+            try:
+                await asyncio.wait_for(self._shutdown_event.wait(), timeout=1800.0)
+            except asyncio.TimeoutError:
+                pass
+            else:
+                break
 
-                await self._report_stats()
-        finally:
-            # Guarantee the lock is released if this task is cancelled while inside _report_stats
-            if self._report_lock.locked():
-                self._report_lock.release()
+            await self._report_stats()
+
+    @staticmethod
+    def _inflight_callbacks(tracker: set[str], mark: Any, ids: list[str]) -> tuple[Any, Any]:
+        """Build the (on_success, on_failure) pair for one batch of reserved row ids.
+
+        Success marks the rows reported and releases them; failure only releases them, so
+        the rows are picked up again by a later aggregation run instead of being lost.
+        """
+        async def on_success() -> None:
+            try:
+                await mark(ids)
+            finally:
+                tracker.difference_update(ids)
+
+        async def on_failure() -> None:
+            tracker.difference_update(ids)
+
+        return on_success, on_failure
 
     async def _report_stats(self) -> None:
         """Aggregate unreported records and queue for sending. Marking is done by the worker on success."""
-        await self._report_lock.acquire()
+        async with self._report_lock:
+            await self._aggregate_and_queue_stats()
+
+    async def _aggregate_and_queue_stats(self) -> None:
         try:
             since_ts = int(time.time()) - 12 * 3600
             event_count = 0
@@ -466,7 +508,10 @@ class TelemetryClient:
             # Counts and the id set to mark are derived from a SINGLE per-row
             # snapshot, so they cannot diverge (a row counted but never marked, or
             # marked but never counted, as the prior two-query read allowed).
-            msg_rows = await self.db.get_unreported_telemetry_message_rows(since_ts)
+            msg_rows = [
+                row for row in await self.db.get_unreported_telemetry_message_rows(since_ts)
+                if row["id"] not in self._inflight_message_ids
+            ]
             if msg_rows:
                 by_hour: dict[int, dict[str, int]] = {}
                 msg_ids_by_hour: dict[int, list[str]] = {}
@@ -478,17 +523,27 @@ class TelemetryClient:
                     ids = msg_ids_by_hour.get(hour_ts, [])
                     if not ids:
                         continue
-                    self.send_event(TelemetryEventType.MESSAGE_STATS, {
+                    on_success, on_failure = self._inflight_callbacks(
+                        self._inflight_message_ids, self.db.mark_telemetry_messages_by_ids, ids,
+                    )
+                    self._inflight_message_ids.update(ids)
+                    queued = self.send_event(TelemetryEventType.MESSAGE_STATS, {
                         "hour": datetime.fromtimestamp(hour_ts, tz=timezone.utc).isoformat(),
                         "total_messages": sum(platforms.values()),
                         "messages_by_platform": platforms,
                         "time_window_minutes": 60,
-                    }, on_success=lambda ids=ids: self.db.mark_telemetry_messages_by_ids(ids))
+                    }, on_success=on_success, on_failure=on_failure)
+                    if not queued:
+                        self._inflight_message_ids.difference_update(ids)
+                        continue
                     event_count += 1
 
             # LLM usage stats — one event per hour, models nested. Same single-snapshot
             # approach: aggregate measures and collect ids from the same rows.
-            llm_rows = await self.db.get_unreported_telemetry_llm_usage_rows(since_ts)
+            llm_rows = [
+                row for row in await self.db.get_unreported_telemetry_llm_usage_rows(since_ts)
+                if row["id"] not in self._inflight_llm_ids
+            ]
             if llm_rows:
                 llm_by_hour: dict[int, list[dict]] = {}
                 llm_ids_by_hour: dict[int, list[str]] = {}
@@ -529,7 +584,11 @@ class TelemetryClient:
                         }
                         for model, m in per_model.items()
                     }
-                    self.send_event(TelemetryEventType.LLM_USAGE, {
+                    on_success, on_failure = self._inflight_callbacks(
+                        self._inflight_llm_ids, self.db.mark_telemetry_llm_by_ids, ids,
+                    )
+                    self._inflight_llm_ids.update(ids)
+                    queued = self.send_event(TelemetryEventType.LLM_USAGE, {
                         "hour": datetime.fromtimestamp(hour_ts, tz=timezone.utc).isoformat(),
                         "total_calls": total_calls,
                         "success_calls": total_success,
@@ -539,7 +598,10 @@ class TelemetryClient:
                         "total_cached_tokens": total_cached,
                         "avg_response_time_ms": int(total_resp_ms / total_calls) if total_calls else 0,
                         "models": models,
-                    }, on_success=lambda ids=ids: self.db.mark_telemetry_llm_by_ids(ids))
+                    }, on_success=on_success, on_failure=on_failure)
+                    if not queued:
+                        self._inflight_llm_ids.difference_update(ids)
+                        continue
                     event_count += 1
 
             if event_count:
@@ -551,6 +613,3 @@ class TelemetryClient:
 
         except Exception as e:
             logger.warning(f"Failed to report hourly stats: {e}")
-        finally:
-            if self._report_lock.locked():
-                self._report_lock.release()

--- a/core/telemetry/models.py
+++ b/core/telemetry/models.py
@@ -24,6 +24,7 @@ class TelemetryEvent:
     client_uuid: Optional[str] = None
     signature: Optional[str] = None
     _on_success: Optional[Callable[[], Any]] = field(default=None, repr=False)
+    _on_failure: Optional[Callable[[], Any]] = field(default=None, repr=False)
 
     def to_payload(self) -> dict[str, Any]:
         payload = {

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -8,8 +8,11 @@ from core.provider import LLMModelClient, TTSModelClient, ImageModelClient, Embe
 from core.provider.llm_model import LLMRequest, LLMResponse, LLMStreamChunk
 from core.chat.message_elements import Record
 from core.config.default import VERSION
+from core.logging_manager import get_logger
 from core.utils.media_refs import resolve_media_references
 
+
+logger = get_logger("provider", "purple")
 
 DEFAULT_USER_AGENT = f"kira-ai/{VERSION.removeprefix('v')}"
 
@@ -35,6 +38,34 @@ def build_llm_default_headers(provider_config: dict | None) -> dict[str, str]:
     if not has_user_agent:
         headers["User-Agent"] = DEFAULT_USER_AGENT
     return headers
+
+
+def apply_stream_options(request_kwargs: dict) -> None:
+    """Ask for token usage by default; a falsy override opts out entirely."""
+    request_kwargs.setdefault("stream_options", {"include_usage": True})
+    if not request_kwargs["stream_options"]:
+        request_kwargs.pop("stream_options")
+
+
+async def create_chat_stream(client: AsyncOpenAI, request_kwargs: dict):
+    """Open a streaming chat completion tolerating gateways without stream_options.
+
+    Some self-described OpenAI-compatible endpoints reject ``stream_options``
+    with a 4xx while accepting the rest of the request. Retry once without it
+    so streaming degrades to "no usage reporting" instead of failing.
+    """
+    try:
+        return await client.chat.completions.create(**request_kwargs)
+    except APIStatusError as e:
+        if not request_kwargs.get("stream_options"):
+            raise
+        logger.warning(
+            f"Stream request rejected with stream_options ({e}); "
+            f"retrying without token usage reporting"
+        )
+        request_kwargs.pop("stream_options", None)
+        return await client.chat.completions.create(**request_kwargs)
+
 
 class OpenAICompatibleLLMClient(LLMModelClient):
     def __init__(self, model: ModelInfo):
@@ -74,12 +105,12 @@ class OpenAICompatibleLLMClient(LLMModelClient):
         return kwargs
 
     async def chat(self, request: LLMRequest, **kwargs) -> LLMResponse:
-        client = self._build_client()
         messages = await resolve_media_references(request.messages)
         request_kwargs = self._build_request_kwargs(request, messages=messages, **kwargs)
         try:
             start_time = time.perf_counter()
-            response = await client.chat.completions.create(**request_kwargs)
+            async with self._build_client() as client:
+                response = await client.chat.completions.create(**request_kwargs)
             end_time = time.perf_counter()
             llm_resp = LLMResponse("")
             llm_resp.time_consumed = round(end_time - start_time, 2)
@@ -126,66 +157,76 @@ class OpenAICompatibleLLMClient(LLMModelClient):
             raise
 
     async def chat_stream(self, request: LLMRequest, **kwargs) -> AsyncGenerator[LLMStreamChunk, None]:
-        client = self._build_client()
         messages = await resolve_media_references(request.messages)
         request_kwargs = self._build_request_kwargs(
             request, messages=messages, stream=True, **kwargs
         )
-        request_kwargs["stream_options"] = {"include_usage": True}
+        apply_stream_options(request_kwargs)
+
+        # The final chunk is held back until the stream ends so that
+        # finish_reason and token usage are reported together, exactly once.
+        pending_final: Optional[LLMStreamChunk] = None
+        usage: Optional[dict] = None
 
         try:
-            stream = await client.chat.completions.create(**request_kwargs)
-            async for event in stream:
-                # Usage-only event (sent by OpenAI API after the final choice chunk)
-                if not event.choices:
-                    if event.usage:
-                        prompt_details = getattr(event.usage, "prompt_tokens_details", None)
-                        cached = getattr(prompt_details, "cached_tokens", None) if prompt_details else None
-                        yield LLMStreamChunk(
-                            is_final=True,
-                            usage={
+            async with self._build_client() as client:
+                stream = await create_chat_stream(client, request_kwargs)
+                async for event in stream:
+                    # Usage-only event (sent by OpenAI API after the final choice chunk)
+                    if not event.choices:
+                        if event.usage:
+                            prompt_details = getattr(event.usage, "prompt_tokens_details", None)
+                            cached = getattr(prompt_details, "cached_tokens", None) if prompt_details else None
+                            usage = {
                                 "input_tokens": event.usage.prompt_tokens,
                                 "output_tokens": event.usage.completion_tokens,
                                 "cached_tokens": cached,
-                            },
-                        )
-                    continue
+                            }
+                        continue
 
-                choice = event.choices[0]
-                delta = choice.delta
+                    choice = event.choices[0]
+                    delta = choice.delta
 
-                chunk = LLMStreamChunk()
+                    chunk = LLMStreamChunk()
 
-                # Text content
-                if delta.content:
-                    chunk.delta_text = delta.content
+                    # Text content
+                    if delta.content:
+                        chunk.delta_text = delta.content
 
-                # Reasoning content (DeepSeek / extended models)
-                reasoning = getattr(delta, "reasoning_content", "") or ""
-                if reasoning:
-                    chunk.delta_reasoning = reasoning
+                    # Reasoning content (DeepSeek / extended models)
+                    reasoning = getattr(delta, "reasoning_content", "") or ""
+                    if reasoning:
+                        chunk.delta_reasoning = reasoning
 
-                # Tool calls — pass through raw incremental deltas from SDK
-                if delta.tool_calls:
-                    for tc in delta.tool_calls:
-                        fragment = {
-                            "index": tc.index,
-                            "id": tc.id or "",
-                            "type": "function",
-                            "function": {
-                                "name": tc.function.name if tc.function and tc.function.name else "",
-                                "arguments": tc.function.arguments if tc.function and tc.function.arguments else "",
-                            },
-                        }
-                        chunk.tool_calls_delta.append(fragment)
+                    # Tool calls — pass through raw incremental deltas from SDK
+                    if delta.tool_calls:
+                        for tc in delta.tool_calls:
+                            fragment = {
+                                "index": tc.index,
+                                "id": tc.id or "",
+                                "type": "function",
+                                "function": {
+                                    "name": tc.function.name if tc.function and tc.function.name else "",
+                                    "arguments": tc.function.arguments if tc.function and tc.function.arguments else "",
+                                },
+                            }
+                            chunk.tool_calls_delta.append(fragment)
 
-                # Finish reason
-                finish_reason = choice.finish_reason
-                if finish_reason:
-                    chunk.is_final = True
-                    chunk.finish_reason = finish_reason
+                    # Finish reason
+                    finish_reason = choice.finish_reason
+                    if finish_reason:
+                        chunk.is_final = True
+                        chunk.finish_reason = finish_reason
+                        pending_final = chunk
+                        continue
 
-                yield chunk
+                    yield chunk
+
+                if pending_final is not None:
+                    pending_final.usage = usage
+                    yield pending_final
+                elif usage is not None:
+                    yield LLMStreamChunk(is_final=True, usage=usage)
 
         except APIStatusError:
             raise
@@ -206,21 +247,20 @@ class OpenAICompatibleTTSClient(TTSModelClient):
         default_headers = section_advanced.get("headers", {}) if isinstance(section_advanced, dict) else {}
         if not isinstance(default_headers, dict) or not default_headers:
             default_headers = None
-        client = AsyncOpenAI(
+        async with AsyncOpenAI(
             api_key=self.model.provider_config.get("api_key", ""),
             base_url=self.model.provider_config.get("base_url", ""),
             default_headers=default_headers,
-        )
-
-        async with client.audio.speech.with_streaming_response.create(
-                model=self.model.model_id,
-                voice=self.model.model_config.get("voice_name", ""),
-                input=text,
-                response_format="mp3"
-        ) as response:
-            audio_bytes = b""
-            async for chunk in response.iter_bytes():
-                audio_bytes += chunk
+        ) as client:
+            async with client.audio.speech.with_streaming_response.create(
+                    model=self.model.model_id,
+                    voice=self.model.model_config.get("voice_name", ""),
+                    input=text,
+                    response_format="mp3"
+            ) as response:
+                audio_bytes = b""
+                async for chunk in response.iter_bytes():
+                    audio_bytes += chunk
 
         b64_str = base64.b64encode(audio_bytes).decode("utf-8")
         return Record(record=b64_str)

--- a/tests/test_adapter_permission_lists.py
+++ b/tests/test_adapter_permission_lists.py
@@ -1,0 +1,77 @@
+import asyncio
+
+import pytest
+
+from core.adapter.adapter_info import AdapterInfo
+from core.adapter.adapter_utils import IMAdapter
+
+
+class DummyAdapter(IMAdapter):
+    async def start(self):
+        pass
+
+    async def stop(self):
+        pass
+
+    def get_client(self):
+        return None
+
+    async def send_group_message(self, group_id, send_message_obj):
+        return None
+
+    async def send_direct_message(self, user_id, send_message_obj):
+        return None
+
+
+def build_adapter(config: dict) -> DummyAdapter:
+    info = AdapterInfo(
+        enabled=True,
+        adapter_id="dummy-id",
+        name="dummy",
+        platform="Dummy",
+        config=config,
+    )
+    return DummyAdapter(info, asyncio.Queue())
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ([123456, 789], ["123456", "789"]),
+        (["123456", 789], ["123456", "789"]),
+        ([" 123456 "], ["123456"]),
+        ([123456, None, ""], ["123456"]),
+        ([], []),
+        ("", []),
+        (None, []),
+    ],
+)
+def test_normalize_id_list(raw, expected):
+    assert IMAdapter._normalize_id_list(raw) == expected
+
+
+def test_allow_list_matches_integer_config_entries():
+    adapter = build_adapter({
+        "permission_mode": "allow_list",
+        "group_allow_list": [123456],
+        "user_allow_list": [7890],
+    })
+    assert "123456" in adapter.group_list
+    assert "7890" in adapter.user_list
+
+
+def test_deny_list_matches_integer_config_entries():
+    adapter = build_adapter({
+        "permission_mode": "deny_list",
+        "group_deny_list": [123456],
+        "user_deny_list": [7890],
+    })
+    assert "123456" in adapter.group_list
+    assert "7890" in adapter.user_list
+
+
+def test_unknown_permission_mode_falls_back_to_allow_list():
+    adapter = build_adapter({"permission_mode": "whatever"})
+    assert adapter.permission_mode == "allow_list"
+    assert adapter.group_list == []
+    assert adapter.user_list == []

--- a/tests/test_bilibili_comment_cursor.py
+++ b/tests/test_bilibili_comment_cursor.py
@@ -1,0 +1,164 @@
+import asyncio
+import sys
+import types
+
+import pytest
+
+from core.adapter.adapter_info import AdapterInfo
+
+
+def _install_bilibili_api_stub() -> None:
+    """Provide the minimal bilibili_api surface the adapter imports at module level"""
+    package = types.ModuleType("bilibili_api")
+
+    class Credential:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class CommentResourceType:
+        VIDEO = "video"
+
+    comment = types.ModuleType("bilibili_api.comment")
+    comment.CommentResourceType = CommentResourceType
+
+    utils = types.ModuleType("bilibili_api.utils")
+    transformer = types.ModuleType("bilibili_api.utils.aid_bvid_transformer")
+    transformer.bvid2aid = lambda bvid: 0
+    utils.aid_bvid_transformer = transformer
+
+    package.Credential = Credential
+    package.comment = comment
+    package.homepage = types.ModuleType("bilibili_api.homepage")
+    package.search = types.ModuleType("bilibili_api.search")
+    package.utils = utils
+
+    sys.modules["bilibili_api"] = package
+    sys.modules["bilibili_api.comment"] = comment
+    sys.modules["bilibili_api.utils"] = utils
+    sys.modules["bilibili_api.utils.aid_bvid_transformer"] = transformer
+
+
+try:  # pragma: no cover - depends on the local environment
+    import bilibili_api  # noqa: F401
+except ModuleNotFoundError:
+    _install_bilibili_api_stub()
+
+from core.adapter.src.bilibili.bilibili import BiliBiliAdapter, PROCESSED_COMMENT_ID_LIMIT
+
+
+BOT_UID = "1"
+
+
+def build_adapter(last_process_ts: int):
+    info = AdapterInfo(
+        enabled=True,
+        adapter_id="bili-id",
+        name="bili-test",
+        platform="Bilibili",
+        config={"bot_uid": BOT_UID, "message_process_interval": 0},
+    )
+    queue = asyncio.Queue()
+    adapter = BiliBiliAdapter(info, queue)
+    adapter.last_process_ts = last_process_ts
+    return adapter, queue
+
+
+def make_comment(cmt_id: int, uid: str, ctime: int, sub_replies=None) -> dict:
+    return {
+        "comment_id": cmt_id,
+        "user": f"user-{uid}",
+        "uid": uid,
+        "message": f"message-{cmt_id}",
+        "ctime": ctime,
+        "like": 0,
+        "sub_replies": sub_replies or [],
+    }
+
+
+def drain(queue: asyncio.Queue) -> list:
+    events = []
+    while not queue.empty():
+        events.append(queue.get_nowait())
+    return events
+
+
+@pytest.mark.anyio
+async def test_sub_reply_does_not_hide_older_top_level_comment():
+    adapter, queue = build_adapter(last_process_ts=90)
+
+    bot_thread = make_comment(
+        1, BOT_UID, 100,
+        sub_replies=[make_comment(3, "3", 115)],
+    )
+    comments = [bot_thread, make_comment(2, "2", 110)]
+
+    await adapter._handle_new_comment(comments)
+
+    events = drain(queue)
+    assert [(e.cmt_id, e.sub_cmt_id) for e in events] == [(2, None), (1, 3)]
+
+
+@pytest.mark.anyio
+async def test_comments_are_published_only_once():
+    adapter, queue = build_adapter(last_process_ts=90)
+
+    comments = [
+        make_comment(1, BOT_UID, 100, sub_replies=[make_comment(3, "3", 115)]),
+        make_comment(2, "2", 110),
+    ]
+
+    await adapter._handle_new_comment(comments)
+    assert len(drain(queue)) == 2
+
+    await adapter._handle_new_comment(comments)
+    assert drain(queue) == []
+
+
+@pytest.mark.anyio
+async def test_second_comment_in_the_same_second_is_not_lost():
+    adapter, queue = build_adapter(last_process_ts=90)
+
+    await adapter._handle_new_comment([make_comment(1, "2", 100)])
+    assert [e.cmt_id for e in drain(queue)] == [1]
+    assert adapter.last_process_ts == 100
+
+    await adapter._handle_new_comment([
+        make_comment(1, "2", 100),
+        make_comment(2, "3", 100),
+    ])
+    assert [e.cmt_id for e in drain(queue)] == [2]
+
+
+@pytest.mark.anyio
+async def test_comments_older_than_cursor_are_ignored():
+    adapter, queue = build_adapter(last_process_ts=200)
+
+    comments = [
+        make_comment(1, BOT_UID, 100, sub_replies=[make_comment(3, "3", 120)]),
+        make_comment(2, "2", 110),
+    ]
+
+    await adapter._handle_new_comment(comments)
+    assert drain(queue) == []
+    assert adapter.last_process_ts == 200
+
+
+@pytest.mark.anyio
+async def test_bot_own_comments_are_never_published():
+    adapter, queue = build_adapter(last_process_ts=90)
+
+    comments = [make_comment(1, BOT_UID, 100, sub_replies=[make_comment(2, BOT_UID, 110)])]
+
+    await adapter._handle_new_comment(comments)
+    assert drain(queue) == []
+
+
+@pytest.mark.anyio
+async def test_processed_id_cache_is_bounded():
+    adapter, queue = build_adapter(last_process_ts=0)
+
+    comments = [make_comment(i, "2", i + 1) for i in range(PROCESSED_COMMENT_ID_LIMIT + 50)]
+    await adapter._handle_new_comment(comments)
+
+    assert len(drain(queue)) == len(comments)
+    assert len(adapter._processed_cmt_ids) == PROCESSED_COMMENT_ID_LIMIT

--- a/tests/test_chat_plugin_terminate.py
+++ b/tests/test_chat_plugin_terminate.py
@@ -1,0 +1,66 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from core.plugin.builtin_plugins.chat.main import DefaultChatPlugin
+
+
+def _chat_plugin(flushed: list[str]) -> DefaultChatPlugin:
+    async def flush_session_messages(sid: str) -> None:
+        flushed.append(sid)
+
+    ctx = SimpleNamespace(
+        config={"bot_config": {"bot": {"max_message_interval": 0.01, "max_buffer_messages": 3}}},
+        message_processor=SimpleNamespace(
+            get_session_buffer_length=lambda sid: 1,
+            flush_session_messages=flush_session_messages,
+        ),
+    )
+    return DefaultChatPlugin(ctx, {})
+
+
+@pytest.mark.anyio
+async def test_terminate_cancels_debounce_tasks_and_clears_sessions():
+    flushed: list[str] = []
+    plugin = _chat_plugin(flushed)
+
+    for sid in ("test:dm:1", "test:group:2"):
+        plugin.session_events[sid] = asyncio.Event()
+        plugin.session_tasks[sid] = asyncio.create_task(plugin._debounce_loop(sid))
+    await asyncio.sleep(0)
+    tasks = list(plugin.session_tasks.values())
+
+    await plugin.terminate()
+
+    assert plugin.session_tasks == {}
+    assert plugin.session_events == {}
+    assert all(task.done() for task in tasks)
+
+
+@pytest.mark.anyio
+async def test_terminate_stops_pending_flush():
+    flushed: list[str] = []
+    plugin = _chat_plugin(flushed)
+    sid = "test:dm:1"
+    plugin.session_events[sid] = asyncio.Event()
+    plugin.session_tasks[sid] = asyncio.create_task(plugin._debounce_loop(sid))
+    plugin.session_events[sid].set()
+    await asyncio.sleep(0)
+
+    await plugin.terminate()
+    await asyncio.sleep(0.05)
+
+    assert flushed == []
+
+
+@pytest.mark.anyio
+async def test_repeated_terminate_is_safe():
+    plugin = _chat_plugin([])
+    plugin.session_events["test:dm:1"] = asyncio.Event()
+    plugin.session_tasks["test:dm:1"] = asyncio.create_task(plugin._debounce_loop("test:dm:1"))
+
+    await plugin.terminate()
+    await plugin.terminate()
+
+    assert plugin.session_tasks == {}

--- a/tests/test_deepseek_llm_client.py
+++ b/tests/test_deepseek_llm_client.py
@@ -1,0 +1,163 @@
+"""Regression tests for the DeepSeek LLM client.
+
+Covers the configured ``timeout`` reaching the request kwargs, the single
+final stream chunk carrying both finish_reason and usage, and the client
+being closed once the stream is exhausted.
+"""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import APIStatusError, NOT_GIVEN
+
+from core.provider import LLMRequest, ModelInfo, ModelType
+from core.provider.src.deepseek.model_clients import DeepSeekLLMClient
+
+
+def build_client(model_config: dict | None = None) -> DeepSeekLLMClient:
+    return DeepSeekLLMClient(
+        ModelInfo(
+            model_type=ModelType.LLM,
+            model_id="deepseek-chat",
+            provider_id="deepseek-test",
+            provider_name="DeepSeek Test",
+            provider_config={
+                "base_url": "https://api.example.com",
+                "api_key": "test-key",
+            },
+            model_config=model_config or {},
+        )
+    )
+
+
+def build_request() -> LLMRequest:
+    return LLMRequest(messages=[{"role": "user", "content": "ping"}])
+
+
+def usage_event(prompt_tokens: int, completion_tokens: int, cache_hit: int):
+    return SimpleNamespace(
+        choices=[],
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            prompt_cache_hit_tokens=cache_hit,
+        ),
+    )
+
+
+def delta_event(content: str = "", finish_reason: str | None = None):
+    delta = SimpleNamespace(content=content, tool_calls=None, reasoning_content="")
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta, finish_reason=finish_reason)],
+        usage=None,
+    )
+
+
+class FakeStream:
+    def __init__(self, events):
+        self._events = events
+
+    async def __aiter__(self):
+        for event in self._events:
+            yield event
+
+
+class FakeCompletions:
+    def __init__(self, events: list, calls: list, reject_stream_options: bool = False):
+        self._events = events
+        self._calls = calls
+        self._reject_stream_options = reject_stream_options
+
+    async def create(self, **kwargs):
+        self._calls.append(kwargs)
+        if self._reject_stream_options and kwargs.get("stream_options"):
+            raise APIStatusError(
+                "stream_options is not supported",
+                response=httpx.Response(
+                    400, request=httpx.Request("POST", "https://api.example.com")
+                ),
+                body=None,
+            )
+        return FakeStream(self._events)
+
+
+class FakeClient:
+    def __init__(self, events: list, calls: list, reject_stream_options: bool = False):
+        self.chat = SimpleNamespace(
+            completions=FakeCompletions(events, calls, reject_stream_options)
+        )
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.closed = True
+        return None
+
+
+def test_request_kwargs_pass_configured_timeout():
+    kwargs = build_client({"timeout": 45})._build_request_kwargs(build_request())
+
+    assert kwargs["timeout"] == 45
+
+
+def test_request_kwargs_omit_unset_timeout():
+    kwargs = build_client()._build_request_kwargs(build_request())
+
+    assert kwargs["timeout"] is NOT_GIVEN
+
+
+def test_request_kwargs_allow_caller_to_override_timeout():
+    kwargs = build_client({"timeout": 45})._build_request_kwargs(
+        build_request(), timeout=5
+    )
+
+    assert kwargs["timeout"] == 5
+
+
+@pytest.mark.anyio
+async def test_chat_stream_emits_a_single_final_chunk_with_usage(monkeypatch):
+    calls: list[dict] = []
+    fake_client = FakeClient(
+        [
+            delta_event("Hi"),
+            delta_event("", finish_reason="stop"),
+            usage_event(11, 5, 3),
+        ],
+        calls,
+    )
+    client = build_client()
+    monkeypatch.setattr(client, "_build_client", lambda: fake_client)
+
+    chunks = [chunk async for chunk in client.chat_stream(build_request())]
+
+    finals = [chunk for chunk in chunks if chunk.is_final]
+    assert len(finals) == 1
+    assert finals[0].finish_reason == "stop"
+    assert finals[0].usage == {
+        "input_tokens": 11,
+        "output_tokens": 5,
+        "cached_tokens": 3,
+    }
+    assert "".join(chunk.delta_text for chunk in chunks) == "Hi"
+    assert fake_client.closed is True
+
+
+@pytest.mark.anyio
+async def test_chat_stream_retries_without_stream_options(monkeypatch):
+    calls: list[dict] = []
+    fake_client = FakeClient(
+        [delta_event("Hi", finish_reason="stop")], calls, reject_stream_options=True
+    )
+    client = build_client()
+    monkeypatch.setattr(client, "_build_client", lambda: fake_client)
+
+    chunks = [chunk async for chunk in client.chat_stream(build_request())]
+
+    assert len(calls) == 2
+    assert calls[0]["stream_options"] == {"include_usage": True}
+    assert "stream_options" not in calls[1]
+    assert chunks[-1].is_final is True
+    assert chunks[-1].usage is None

--- a/tests/test_file_plugin.py
+++ b/tests/test_file_plugin.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -117,17 +119,50 @@ async def test_filter_tools_disables_background_manager_without_exec(file_plugin
 @pytest.mark.anyio
 async def test_exec_uses_resolved_work_dir(file_plugin, tmp_path):
     event = SimpleNamespace(sid="test:dm:1")
-    completed = SimpleNamespace(stdout="ok", stderr="", returncode=0)
 
-    with patch(
-        "core.plugin.builtin_plugins.file.main.subprocess.run",
-        return_value=completed,
-    ) as run:
+    with patch("core.plugin.builtin_plugins.file.main.subprocess.Popen") as popen:
+        process = popen.return_value.__enter__.return_value
+        process.communicate.return_value = ("ok", "")
+        process.returncode = 0
         result = await file_plugin.exec(event, "echo test", str(tmp_path))
 
     assert result == "Shell command output:\nok"
-    assert run.call_args.kwargs["cwd"] == tmp_path.resolve()
-    assert run.call_args.kwargs["timeout"] == 30
+    assert popen.call_args.kwargs["cwd"] == tmp_path.resolve()
+    assert process.communicate.call_args.kwargs["timeout"] == 30
+
+
+@pytest.mark.anyio
+async def test_exec_runs_shell_in_its_own_process_group(file_plugin, tmp_path):
+    event = SimpleNamespace(sid="test:dm:1")
+
+    with patch("core.plugin.builtin_plugins.file.main.subprocess.Popen") as popen:
+        process = popen.return_value.__enter__.return_value
+        process.communicate.return_value = ("ok", "")
+        process.returncode = 0
+        await file_plugin.exec(event, "echo test", str(tmp_path))
+
+    kwargs = popen.call_args.kwargs
+    if os.name == "nt":
+        assert kwargs["creationflags"] == subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        assert kwargs["start_new_session"] is True
+
+
+@pytest.mark.anyio
+async def test_exec_timeout_kills_the_whole_process_group(file_plugin, tmp_path):
+    event = SimpleNamespace(sid="test:dm:1")
+
+    with patch("core.plugin.builtin_plugins.file.main.subprocess.Popen") as popen:
+        process = popen.return_value.__enter__.return_value
+        process.pid = 4242
+        process.returncode = None
+        process.communicate.side_effect = subprocess.TimeoutExpired("echo test", 30)
+
+        with patch("core.plugin.builtin_plugins.file.main.FilePlugin._kill_process_group") as kill:
+            result = await file_plugin.exec(event, "echo test", str(tmp_path))
+
+    kill.assert_called_once_with(process)
+    assert "timed out after 30 seconds" in result
 
 
 @pytest.mark.anyio
@@ -135,11 +170,11 @@ async def test_exec_rejects_missing_work_dir(file_plugin, tmp_path):
     event = SimpleNamespace(sid="test:dm:1")
     missing_dir = tmp_path / "missing"
 
-    with patch("core.plugin.builtin_plugins.file.main.subprocess.run") as run:
+    with patch("core.plugin.builtin_plugins.file.main.subprocess.Popen") as popen:
         result = await file_plugin.exec(event, "echo test", str(missing_dir))
 
     assert result == f"Working directory not found: {missing_dir}"
-    run.assert_not_called()
+    popen.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/tests/test_file_plugin_restricted_paths.py
+++ b/tests/test_file_plugin_restricted_paths.py
@@ -1,0 +1,160 @@
+import os
+import subprocess
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from core.plugin.builtin_plugins.file import main as file_main
+from core.plugin.builtin_plugins.file.main import FilePlugin, is_restricted_path
+
+
+@pytest.fixture
+def file_plugin():
+    plugin = FilePlugin.__new__(FilePlugin)
+    plugin.allowed_sessions = ["test:dm:1"]
+    plugin.allowed_exec_sessions = ["test:dm:1"]
+    plugin.allowed_read_paths = ("data/files",)
+    plugin.allowed_write_paths = ("data/files",)
+    plugin.exec_deny_list = []
+    plugin._exec_timeout = 30
+    return plugin
+
+
+@pytest.mark.parametrize("path", [
+    "data/files/monkey.txt",
+    "data/files/tokenizer.py",
+    "data/files/keyboard_notes.md",
+    "data/files/donkey/notes.txt",
+    "data/files/passwordless_setup.txt",
+])
+def test_legitimate_paths_are_not_restricted(path):
+    assert is_restricted_path(path) is False
+
+
+@pytest.mark.parametrize("path", [
+    "~/.ssh/id_rsa",
+    "~/.gnupg/secring.gpg",
+    "~/.aws/credentials",
+    "~/.config/gh/hosts.yml",
+    "/home/user/.ssh/config",
+    "data/files/server.pem",
+    "data/files/bundle.p12",
+    "data/files/id_rsa.key",
+    "data/files/api_key.txt",
+    "data/files/secrets/db.txt",
+    "data/files/access-token.json",
+    "data/files/my.password",
+])
+def test_sensitive_paths_are_restricted(path):
+    assert is_restricted_path(path) is True
+
+
+@pytest.mark.anyio
+async def test_read_file_allows_filename_containing_key_substring(file_plugin, tmp_path, monkeypatch):
+    monkeypatch.setattr(file_main, "get_data_path", lambda: tmp_path)
+    target = tmp_path / "files" / "monkey.txt"
+    target.parent.mkdir(parents=True)
+    target.write_text("banana\n", encoding="utf-8")
+
+    result = await file_plugin.read_file(
+        SimpleNamespace(sid="test:dm:1"), "data/files/monkey.txt"
+    )
+
+    assert result == "banana\n"
+
+
+@pytest.mark.anyio
+async def test_read_file_still_denies_key_material(file_plugin, tmp_path, monkeypatch):
+    monkeypatch.setattr(file_main, "get_data_path", lambda: tmp_path)
+
+    result = await file_plugin.read_file(
+        SimpleNamespace(sid="test:dm:1"), "data/files/service_key.txt"
+    )
+
+    assert result == "Permission denied: Path contains restricted keywords"
+
+
+# ─── Foreground exec process group ───────────────────────────────────────────
+
+
+class FakeTimedOutProcess:
+    def __init__(self):
+        self.pid = 4242
+        self.returncode = None
+        self.communicate_calls = 0
+
+    def communicate(self, timeout=None):
+        self.communicate_calls += 1
+        if self.returncode is None:
+            raise subprocess.TimeoutExpired("cmd", timeout or 0)
+        return "", ""
+
+    def wait(self, timeout=None):
+        if self.returncode is None:
+            raise subprocess.TimeoutExpired("cmd", timeout or 0)
+        return self.returncode
+
+    def kill(self):
+        self.returncode = -9
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+def test_foreground_exec_creates_its_own_process_group(tmp_path):
+    with patch("core.plugin.builtin_plugins.file.main.subprocess.Popen") as popen:
+        popen.return_value.__enter__.return_value.communicate.return_value = ("ok", "")
+        popen.return_value.__enter__.return_value.returncode = 0
+
+        result = FilePlugin._run_shell_command("echo test", 30, {}, tmp_path)
+
+    assert result == "Shell command output:\nok"
+    kwargs = popen.call_args.kwargs
+    assert kwargs["cwd"] == tmp_path
+    assert kwargs.get("start_new_session") is True
+
+
+def test_foreground_exec_timeout_kills_the_whole_process_group(tmp_path, monkeypatch):
+    process = FakeTimedOutProcess()
+    killed = []
+
+    def killpg(pid, sig):
+        killed.append((pid, sig))
+        if sig == getattr(file_main.signal, "SIGKILL", 9):
+            process.returncode = -9
+
+    monkeypatch.setattr(file_main, "PROCESS_TERMINATION_GRACE_SECONDS", 0.01)
+    with patch("core.plugin.builtin_plugins.file.main.os.name", "posix"), patch(
+        "core.plugin.builtin_plugins.file.main.os.killpg", side_effect=killpg, create=True
+    ), patch(
+        "core.plugin.builtin_plugins.file.main.subprocess.Popen", return_value=process
+    ):
+        result = FilePlugin._run_shell_command("sleep 60", 1, {}, tmp_path)
+
+    assert result == "Shell command timed out after 1 seconds: sleep 60"
+    assert killed == [
+        (process.pid, file_main.signal.SIGTERM),
+        (process.pid, getattr(file_main.signal, "SIGKILL", 9)),
+    ]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups")
+def test_timeout_does_not_leave_orphaned_grandchildren(tmp_path):
+    marker = tmp_path / "alive.txt"
+    # A detached grandchild that outlives the shell unless the whole group is killed.
+    command = (
+        f'(for i in $(seq 1 100); do echo x >> "{marker}"; sleep 0.1; done) '
+        '>/dev/null 2>&1 & sleep 30'
+    )
+
+    result = FilePlugin._run_shell_command(command, 1, dict(os.environ), tmp_path)
+
+    assert "timed out after 1 seconds" in result
+    size_at_kill = marker.stat().st_size if marker.exists() else 0
+    time.sleep(0.5)
+    assert (marker.stat().st_size if marker.exists() else 0) == size_at_kill

--- a/tests/test_mcp_load_servers.py
+++ b/tests/test_mcp_load_servers.py
@@ -1,0 +1,104 @@
+"""Tests for MCPManager.load_servers() parsing of mcp.json."""
+
+import json
+
+import pytest
+
+import core.agent.mcp_mgr as mcp_mgr
+from core.agent.mcp_mgr import MCPManager
+
+
+class FakeFuncToolManager:
+    def __init__(self):
+        self.registered = {}
+
+    def register_tool(self, name, description, parameters, func):
+        self.registered[name] = func
+
+    def unregister_tool(self, name):
+        self.registered.pop(name, None)
+
+
+@pytest.fixture
+def make_manager(monkeypatch, tmp_path):
+    config_path = tmp_path / "mcp.json"
+    monkeypatch.setattr(mcp_mgr, "MCP_CONFIG_PATH", config_path)
+
+    def _make(servers: dict) -> MCPManager:
+        config_path.write_text(
+            json.dumps({"mcpServers": servers}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        manager = MCPManager(FakeFuncToolManager())
+        manager.load_servers()
+        return manager
+
+    return _make
+
+
+def test_stdio_server_keeps_env_and_timeout(make_manager):
+    """Stdio servers usually carry their API keys in env; dropping it makes
+    every tool call fail after a restart."""
+    manager = make_manager({
+        "srv1": {
+            "enabled": True,
+            "command": "uvx",
+            "args": ["some-mcp-server"],
+            "env": {"API_KEY": "secret"},
+            "timeout": 45,
+        }
+    })
+
+    server = manager.servers[0]
+    assert server.type == "stdio"
+    assert server.env == {"API_KEY": "secret"}
+    assert server.timeout == 45.0
+
+    # the env must survive into the config handed to the fastmcp client
+    server_cfg = server.to_dict()["mcpServers"]["srv1"]
+    assert server_cfg["env"] == {"API_KEY": "secret"}
+    assert server_cfg["timeout"] == 45.0
+
+
+def test_stdio_server_without_env_uses_defaults(make_manager):
+    manager = make_manager({
+        "srv1": {"enabled": True, "command": "uvx", "args": []}
+    })
+
+    server = manager.servers[0]
+    assert server.env == {}
+    assert server.timeout == 10.0
+    assert "env" not in server.to_dict()["mcpServers"]["srv1"]
+
+
+def test_remote_server_keeps_timeout_and_headers(make_manager):
+    manager = make_manager({
+        "srv1": {
+            "enabled": True,
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer x"},
+            "timeout": 3.5,
+        }
+    })
+
+    server = manager.servers[0]
+    assert server.type == "streamable_http"
+    assert server.headers == {"Authorization": "Bearer x"}
+    assert server.timeout == 3.5
+
+
+@pytest.mark.parametrize("timeout", [None, "30", True, {"seconds": 5}])
+def test_invalid_timeout_falls_back_to_default(make_manager, timeout):
+    manager = make_manager({
+        "srv1": {"enabled": True, "command": "uvx", "timeout": timeout}
+    })
+
+    assert manager.servers[0].timeout == 10.0
+
+
+def test_invalid_env_falls_back_to_empty_dict(make_manager):
+    manager = make_manager({
+        "srv1": {"enabled": True, "command": "uvx", "env": "API_KEY=secret"}
+    })
+
+    assert manager.servers[0].env == {}

--- a/tests/test_openai_compatible_stream.py
+++ b/tests/test_openai_compatible_stream.py
@@ -1,0 +1,220 @@
+"""Regression tests for the shared OpenAI-compatible streaming client.
+
+A consumer stopping at the first ``is_final`` chunk used to lose token usage,
+and gateways rejecting ``stream_options`` used to fail streaming outright.
+"""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import APIStatusError
+
+from core.provider import LLMRequest, ModelInfo, ModelType
+from core.utils.model_clients import (
+    OpenAICompatibleLLMClient,
+    apply_stream_options,
+    create_chat_stream,
+)
+
+
+def build_client() -> OpenAICompatibleLLMClient:
+    return OpenAICompatibleLLMClient(
+        ModelInfo(
+            model_type=ModelType.LLM,
+            model_id="gpt-test",
+            provider_id="openai-test",
+            provider_name="OpenAI Test",
+            provider_config={
+                "base_url": "https://api.example.com",
+                "api_key": "test-key",
+            },
+            model_config={},
+        )
+    )
+
+
+def status_error() -> APIStatusError:
+    return APIStatusError(
+        "stream_options is not supported",
+        response=httpx.Response(
+            400, request=httpx.Request("POST", "https://api.example.com")
+        ),
+        body=None,
+    )
+
+
+def delta_event(content: str = "", finish_reason: str | None = None):
+    delta = SimpleNamespace(content=content, tool_calls=None, reasoning_content="")
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta, finish_reason=finish_reason)],
+        usage=None,
+    )
+
+
+def usage_event(prompt_tokens: int, completion_tokens: int, cached_tokens: int):
+    return SimpleNamespace(
+        choices=[],
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
+        ),
+    )
+
+
+class FakeStream:
+    def __init__(self, events):
+        self._events = events
+
+    async def __aiter__(self):
+        for event in self._events:
+            yield event
+
+
+class FakeCompletions:
+    def __init__(self, events, calls, reject_stream_options=False):
+        self._events = events
+        self._calls = calls
+        self._reject_stream_options = reject_stream_options
+
+    async def create(self, **kwargs):
+        self._calls.append(kwargs)
+        if self._reject_stream_options and kwargs.get("stream_options"):
+            raise status_error()
+        return FakeStream(self._events)
+
+
+class FakeClient:
+    def __init__(self, events, calls, reject_stream_options=False):
+        self.chat = SimpleNamespace(
+            completions=FakeCompletions(events, calls, reject_stream_options)
+        )
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.closed = True
+        return None
+
+
+@pytest.mark.anyio
+async def test_chat_stream_merges_finish_reason_and_usage_into_one_chunk(monkeypatch):
+    calls: list[dict] = []
+    fake_client = FakeClient(
+        [
+            delta_event("Hel"),
+            delta_event("lo"),
+            delta_event("", finish_reason="stop"),
+            usage_event(9, 4, 2),
+        ],
+        calls,
+    )
+    client = build_client()
+    monkeypatch.setattr(client, "_build_client", lambda: fake_client)
+
+    chunks = [
+        chunk
+        async for chunk in client.chat_stream(
+            LLMRequest(messages=[{"role": "user", "content": "ping"}])
+        )
+    ]
+
+    finals = [chunk for chunk in chunks if chunk.is_final]
+    assert len(finals) == 1
+    assert finals[0].finish_reason == "stop"
+    assert finals[0].usage == {
+        "input_tokens": 9,
+        "output_tokens": 4,
+        "cached_tokens": 2,
+    }
+    assert "".join(chunk.delta_text for chunk in chunks) == "Hello"
+    assert fake_client.closed is True
+
+
+@pytest.mark.anyio
+async def test_chat_stream_reports_usage_when_finish_reason_is_missing(monkeypatch):
+    calls: list[dict] = []
+    fake_client = FakeClient([delta_event("Hi"), usage_event(3, 1, 0)], calls)
+    client = build_client()
+    monkeypatch.setattr(client, "_build_client", lambda: fake_client)
+
+    chunks = [
+        chunk
+        async for chunk in client.chat_stream(
+            LLMRequest(messages=[{"role": "user", "content": "ping"}])
+        )
+    ]
+
+    assert chunks[-1].is_final is True
+    assert chunks[-1].usage["input_tokens"] == 3
+
+
+@pytest.mark.anyio
+async def test_chat_stream_degrades_when_gateway_rejects_stream_options(monkeypatch):
+    calls: list[dict] = []
+    fake_client = FakeClient(
+        [delta_event("Hi", finish_reason="stop")], calls, reject_stream_options=True
+    )
+    client = build_client()
+    monkeypatch.setattr(client, "_build_client", lambda: fake_client)
+
+    chunks = [
+        chunk
+        async for chunk in client.chat_stream(
+            LLMRequest(messages=[{"role": "user", "content": "ping"}])
+        )
+    ]
+
+    assert [call.get("stream_options") for call in calls] == [
+        {"include_usage": True},
+        None,
+    ]
+    assert chunks[-1].is_final is True
+
+
+def test_stream_options_default_on_and_can_be_opted_out():
+    default_kwargs: dict = {}
+    apply_stream_options(default_kwargs)
+    assert default_kwargs["stream_options"] == {"include_usage": True}
+
+    opted_out = {"stream_options": None}
+    apply_stream_options(opted_out)
+    assert "stream_options" not in opted_out
+
+
+@pytest.mark.anyio
+async def test_chat_stream_can_be_called_without_stream_options(monkeypatch):
+    calls: list[dict] = []
+    fake_client = FakeClient([delta_event("Hi", finish_reason="stop")], calls)
+    client = build_client()
+    monkeypatch.setattr(client, "_build_client", lambda: fake_client)
+
+    _ = [
+        chunk
+        async for chunk in client.chat_stream(
+            LLMRequest(messages=[{"role": "user", "content": "ping"}]),
+            stream_options=None,
+        )
+    ]
+
+    assert "stream_options" not in calls[0]
+
+
+@pytest.mark.anyio
+async def test_create_chat_stream_reraises_errors_unrelated_to_stream_options():
+    attempts: list[dict] = []
+
+    class AlwaysFailing:
+        async def create(self, **kwargs):
+            attempts.append(kwargs)
+            raise status_error()
+
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=AlwaysFailing()))
+
+    with pytest.raises(APIStatusError):
+        await create_chat_stream(fake_client, {"model": "gpt-test"})
+
+    assert len(attempts) == 1

--- a/tests/test_provider_failure_propagation.py
+++ b/tests/test_provider_failure_propagation.py
@@ -1,0 +1,206 @@
+"""Regression tests: provider failures must raise instead of returning empty.
+
+Embedding/TTS/STT/rerank clients used to swallow every exception and return
+``[]`` / ``None`` / ``""``, which made ``health_check`` report success on a
+wrong API key and let the memory pipeline consume a truncated result set.
+"""
+
+from types import SimpleNamespace
+
+import aiohttp
+import httpx
+import pytest
+from openai import APIConnectionError
+
+from core.chat.message_elements import Record
+from core.provider import (
+    EmbeddingModelClient,
+    ModelInfo,
+    ModelType,
+    ProviderAPIError,
+    ProviderManager,
+)
+from core.provider.src.aliyun_bailian import model_clients as bailian_clients
+from core.provider.src.gptsovits import model_clients as gptsovits_clients
+from core.provider.src.modelscope import model_clients as modelscope_clients
+from core.provider.src.openai import model_clients as openai_clients
+from core.provider.src.siliconflow_cn import model_clients as siliconflow_clients
+from core.provider.src.volcengine import model_clients as volcengine_clients
+
+
+def embedding_model_info(model_type_module_name: str) -> ModelInfo:
+    return ModelInfo(
+        model_type=ModelType.EMBEDDING,
+        model_id=f"{model_type_module_name}-embedding",
+        provider_id="provider-test",
+        provider_name="Provider Test",
+        provider_config={"api_key": "wrong-key", "base_url": "https://api.example.com"},
+        model_config={"timeout": 5},
+    )
+
+
+class FailingOpenAI:
+    """Stands in for AsyncOpenAI and fails the way an unreachable API does."""
+
+    def __init__(self, *args, **kwargs):
+        self.closed = False
+        self.embeddings = SimpleNamespace(create=self._create)
+
+    async def _create(self, **kwargs):
+        raise APIConnectionError(
+            request=httpx.Request("POST", "https://api.example.com/embeddings")
+        )
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.closed = True
+        return None
+
+
+EMBEDDING_CASES = [
+    (openai_clients, "OpenAIEmbeddingClient"),
+    (volcengine_clients, "VolcengineEmbeddingClient"),
+    (siliconflow_clients, "SiliconflowEmbeddingClient"),
+    (modelscope_clients, "ModelScopeEmbeddingClient"),
+    (bailian_clients, "BailianEmbeddingClient"),
+]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("module,client_name", EMBEDDING_CASES)
+async def test_embedding_failures_raise_provider_api_error(
+    monkeypatch, module, client_name
+):
+    clients: list[FailingOpenAI] = []
+
+    def build_failing_client(*args, **kwargs):
+        client = FailingOpenAI()
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(module, "AsyncOpenAI", build_failing_client)
+    client = getattr(module, client_name)(embedding_model_info(module.__name__))
+
+    with pytest.raises(ProviderAPIError):
+        await client.embed(["ping"])
+
+    assert clients and clients[0].closed is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("module,client_name", EMBEDDING_CASES)
+async def test_embedding_still_short_circuits_empty_input(
+    monkeypatch, module, client_name
+):
+    monkeypatch.setattr(module, "AsyncOpenAI", FailingOpenAI)
+    client = getattr(module, client_name)(embedding_model_info(module.__name__))
+
+    assert await client.embed([]) == []
+
+
+class FailingSession:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return None
+
+    def post(self, *args, **kwargs):
+        raise aiohttp.ClientError("connection refused")
+
+
+@pytest.mark.anyio
+async def test_gptsovits_tts_network_failure_raises(monkeypatch):
+    monkeypatch.setattr(gptsovits_clients.aiohttp, "ClientSession", FailingSession)
+    client = gptsovits_clients.GptSovitsTTSClient(
+        ModelInfo(
+            model_type=ModelType.TTS,
+            model_id="gpt-sovits",
+            provider_id="gptsovits-test",
+            provider_name="GPT-SoVITS Test",
+            provider_config={"base_url": "http://127.0.0.1:9880/tts"},
+            model_config={},
+        )
+    )
+
+    with pytest.raises(ProviderAPIError):
+        await client.text_to_speech("ping")
+
+
+@pytest.mark.anyio
+async def test_bailian_tts_without_api_key_raises():
+    client = bailian_clients.BailianCosyVoiceTTSClient(
+        ModelInfo(
+            model_type=ModelType.TTS,
+            model_id="cosyvoice-v2",
+            provider_id="bailian-test",
+            provider_name="Bailian Test",
+            provider_config={},
+            model_config={"voice": "longanyang"},
+        )
+    )
+
+    with pytest.raises(ProviderAPIError):
+        await client.text_to_speech("ping")
+
+
+@pytest.mark.anyio
+async def test_bailian_stt_without_api_key_raises():
+    client = bailian_clients.BailianSTTClient(
+        ModelInfo(
+            model_type=ModelType.STT,
+            model_id="paraformer-realtime-v2",
+            provider_id="bailian-test",
+            provider_name="Bailian Test",
+            provider_config={},
+            model_config={},
+        )
+    )
+
+    with pytest.raises(ProviderAPIError):
+        await client.speech_to_text(Record(record="aGVsbG8="))
+
+
+@pytest.mark.anyio
+async def test_bailian_rerank_without_api_key_raises():
+    client = bailian_clients.BailianRerankClient(
+        ModelInfo(
+            model_type=ModelType.RERANK,
+            model_id="gte-rerank-v2",
+            provider_id="bailian-test",
+            provider_name="Bailian Test",
+            provider_config={},
+            model_config={},
+        )
+    )
+
+    with pytest.raises(ProviderAPIError):
+        await client.rerank("ping", ["ping"])
+
+
+class RaisingEmbeddingClient(EmbeddingModelClient):
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        raise ProviderAPIError("Embedding request failed: unreachable")
+
+
+@pytest.mark.anyio
+async def test_health_check_reports_embedding_failure(monkeypatch):
+    manager = object.__new__(ProviderManager)
+    monkeypatch.setattr(
+        ProviderManager,
+        "get_model_client",
+        lambda self, *args, **kwargs: RaisingEmbeddingClient(
+            embedding_model_info("health")
+        ),
+    )
+
+    result = await manager.health_check("provider-test", "embedding", "any-model")
+
+    assert result["success"] is False
+    assert result["latency"] is None
+    assert "unreachable" in result["error"]

--- a/tests/test_provider_manager_errors.py
+++ b/tests/test_provider_manager_errors.py
@@ -1,0 +1,105 @@
+"""Regression tests for ProviderManager error reporting and model listing."""
+
+import pytest
+
+from core.provider import ModelType, ProviderManager
+
+
+class StubConfig(dict):
+    def get_config(self, key: str):
+        value = self
+        for part in key.split("."):
+            if not isinstance(value, dict) or part not in value:
+                return None
+            value = value[part]
+        return value
+
+
+def build_provider_manager(models: dict | None = None) -> ProviderManager:
+    manager = object.__new__(ProviderManager)
+    manager.kira_config = StubConfig(
+        {
+            "models": models or {},
+            "providers": {
+                "provider": {
+                    "name": "Test Provider",
+                    "provider_config": {},
+                    "model_config": {"llm": {"gpt-test": {"timeout": 120}}},
+                }
+            },
+        }
+    )
+    manager._providers = {}
+    return manager
+
+
+class StubProvider:
+    def __init__(self, models: list[dict]):
+        self._models = models
+
+    async def get_llm_list(self) -> list[dict]:
+        return self._models
+
+
+def test_get_model_client_reports_provider_that_failed_to_load():
+    manager = build_provider_manager()
+
+    with pytest.raises(ValueError, match="not loaded"):
+        manager.get_model_client("provider", "gpt-test", ModelType.LLM)
+
+
+def test_get_model_client_still_returns_none_for_unknown_model():
+    manager = build_provider_manager()
+
+    assert manager.get_model_client("provider", "missing-model") is None
+
+
+def test_default_model_without_provider_prefix_reports_malformed_config():
+    manager = build_provider_manager({"default_llm": "gpt-test"})
+
+    with pytest.raises(ValueError, match="malformed"):
+        manager.get_default_model_info("default_llm")
+
+
+def test_unset_default_model_still_reports_not_set():
+    manager = build_provider_manager()
+
+    with pytest.raises(ValueError, match="not set"):
+        manager.get_default_model_info("default_llm")
+
+
+def test_default_model_id_may_contain_colons_and_dots():
+    manager = build_provider_manager({"default_llm": "provider:vendor/model-v1.5:free"})
+
+    model_info = manager.get_default_model_info("default_llm")
+
+    assert model_info.provider_id == "provider"
+    assert model_info.model_id == "vendor/model-v1.5:free"
+    assert model_info.model_type is ModelType.LLM
+
+
+@pytest.mark.anyio
+async def test_fetch_remote_models_returns_the_llm_list():
+    manager = build_provider_manager()
+    manager._providers["provider"] = StubProvider([{"id": "gpt-test"}])
+
+    assert await manager.fetch_remote_models("provider", "llm") == [{"id": "gpt-test"}]
+
+
+@pytest.mark.anyio
+async def test_fetch_remote_models_rejects_types_without_a_list_endpoint():
+    manager = build_provider_manager()
+    manager._providers["provider"] = StubProvider([{"id": "gpt-test"}])
+
+    for model_type in ("tts", "image", "embedding"):
+        with pytest.raises(ValueError, match="does not support listing"):
+            await manager.fetch_remote_models("provider", model_type)
+
+
+@pytest.mark.anyio
+async def test_fetch_remote_models_rejects_unknown_model_types():
+    manager = build_provider_manager()
+    manager._providers["provider"] = StubProvider([{"id": "gpt-test"}])
+
+    with pytest.raises(ValueError, match="Unknown model type"):
+        await manager.fetch_remote_models("provider", "not-a-type")

--- a/tests/test_qq_message_chain.py
+++ b/tests/test_qq_message_chain.py
@@ -1,0 +1,34 @@
+from core.adapter.src.qq.napcat_client.utils import QQMessageChain, QQMessageType
+
+
+class UnknownElement:
+    """Stands in for a chat element that has no QQ counterpart"""
+
+
+def test_to_list_serialises_known_elements():
+    chain = QQMessageChain([QQMessageType.Text("hello"), QQMessageType.At(123)])
+    assert chain.to_list() == [
+        {"type": "text", "data": {"text": "hello"}},
+        {"type": "at", "data": {"qq": "123"}},
+    ]
+
+
+def test_to_list_skips_unknown_elements_without_dropping_the_rest():
+    chain = QQMessageChain([QQMessageType.Text("hello"), UnknownElement()])
+    serialised = chain.to_list()
+    assert serialised == [{"type": "text", "data": {"text": "hello"}}]
+
+
+def test_unsupported_elements_reports_unserialisable_elements():
+    unknown = UnknownElement()
+    chain = QQMessageChain([QQMessageType.Text("hello"), unknown])
+    assert chain.unsupported_elements() == [unknown]
+
+
+def test_unsupported_elements_empty_for_known_chain():
+    chain = QQMessageChain([
+        QQMessageType.Text("hello"),
+        QQMessageType.Image(url="https://example.com/a.png"),
+        QQMessageType.Reply(42),
+    ])
+    assert chain.unsupported_elements() == []

--- a/tests/test_session_manager_memory.py
+++ b/tests/test_session_manager_memory.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+from threading import Lock
+
+from core.chat.session_manager import SessionManager
+
+SESSION_ID = "qq:private:10001"
+
+
+def make_manager(tmp_path: Path) -> SessionManager:
+    """Build a SessionManager without touching the real data directory."""
+    manager = object.__new__(SessionManager)
+    manager.chat_memory = {}
+    manager.chat_memory_path = str(tmp_path / "chat_memory.json")
+    manager.memory_lock = Lock()
+    manager.max_memory_length = 10
+    return manager
+
+
+def test_write_memory_creates_missing_session(tmp_path: Path) -> None:
+    manager = make_manager(tmp_path)
+    messages = [[{"role": "user", "content": "hello"}]]
+
+    manager.write_memory(SESSION_ID, messages)
+
+    assert manager.chat_memory[SESSION_ID]["memory"] == messages
+    assert manager.chat_memory[SESSION_ID]["title"] == ""
+    persisted = json.loads(Path(manager.chat_memory_path).read_text(encoding="utf-8"))
+    assert persisted[SESSION_ID]["memory"] == messages
+
+
+def test_write_memory_preserves_existing_metadata(tmp_path: Path) -> None:
+    manager = make_manager(tmp_path)
+    manager.chat_memory[SESSION_ID] = {
+        "title": "Chat",
+        "description": "desc",
+        "timestamp": 123,
+        "memory": [[{"role": "user", "content": "old"}]],
+    }
+    messages = [[{"role": "user", "content": "new"}]]
+
+    manager.write_memory(SESSION_ID, messages)
+
+    assert manager.chat_memory[SESSION_ID]["title"] == "Chat"
+    assert manager.chat_memory[SESSION_ID]["timestamp"] == 123
+    assert manager.chat_memory[SESSION_ID]["memory"] == messages

--- a/tests/test_sessions_routes.py
+++ b/tests/test_sessions_routes.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI, HTTPException
+
+from webui.routes.sessions import SessionsRoutes
+
+SESSION_ID = "qq:private:10001"
+
+
+class FakeSessionManager:
+    """Mirrors SessionManager's create-on-access behaviour for chat_memory."""
+
+    def __init__(self, sessions=None):
+        self.chat_memory = dict(sessions or {})
+        self.writes: list[tuple[str, list]] = []
+
+    def _ensure_session_data(self, session):
+        self.chat_memory.setdefault(
+            session, {"title": "", "description": "", "timestamp": None, "memory": []},
+        )
+
+    def read_memory(self, session):
+        self._ensure_session_data(session)
+        return self.chat_memory[session]["memory"]
+
+    def write_memory(self, session, memory):
+        self._ensure_session_data(session)
+        self.chat_memory[session]["memory"] = memory
+        self.writes.append((session, memory))
+
+    def update_session_info(self, session, title=None, description=None):
+        self._ensure_session_data(session)
+
+
+def make_routes(session_manager):
+    return SessionsRoutes(FastAPI(), SimpleNamespace(session_manager=session_manager))
+
+
+@pytest.mark.anyio
+async def test_get_session_returns_404_without_creating_it():
+    session_manager = FakeSessionManager()
+    routes = make_routes(session_manager)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await routes.get_session("qq:private:injected-by-attacker")
+
+    assert exc_info.value.status_code == 404
+    assert session_manager.chat_memory == {}
+
+
+@pytest.mark.anyio
+async def test_get_session_returns_existing_session():
+    session_manager = FakeSessionManager({
+        SESSION_ID: {
+            "title": "Chat",
+            "description": "desc",
+            "timestamp": None,
+            "memory": [[{"role": "user", "content": "hi"}]],
+        },
+    })
+
+    result = await make_routes(session_manager).get_session(SESSION_ID)
+
+    assert result["id"] == SESSION_ID
+    assert result["adapter_name"] == "qq"
+    assert result["session_type"] == "private"
+    assert result["session_id"] == "10001"
+    assert result["title"] == "Chat"
+    assert result["messages"] == [[{"role": "user", "content": "hi"}]]
+
+
+@pytest.mark.anyio
+async def test_get_session_rejects_malformed_id():
+    with pytest.raises(HTTPException) as exc_info:
+        await make_routes(FakeSessionManager()).get_session("not-a-session")
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_update_session_writes_memory():
+    session_manager = FakeSessionManager()
+    messages = [[{"role": "user", "content": "hello"}]]
+
+    result = await make_routes(session_manager).update_session(SESSION_ID, {"messages": messages})
+
+    assert result["messages"] == messages
+    assert session_manager.writes == [(SESSION_ID, messages)]

--- a/tests/test_settings_restore_credentials.py
+++ b/tests/test_settings_restore_credentials.py
@@ -1,0 +1,82 @@
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+
+from webui import utils as webui_utils
+from webui.routes import settings as settings_routes
+from webui.routes.settings import SettingsRoutes
+
+
+def make_data_dir(tmp_path: Path) -> Path:
+    data_path = tmp_path / "data"
+    (data_path / "config").mkdir(parents=True)
+    (data_path / "webui.json").write_text(
+        json.dumps({"host": "0.0.0.0", "port": 5267, "access_token": "live-token"}),
+        encoding="utf-8",
+    )
+    (data_path / ".jwt_secret").write_text("live-secret", encoding="utf-8")
+    return data_path
+
+
+def make_archive(tmp_path: Path, include_credentials: bool = True) -> Path:
+    archive = tmp_path / "backup.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("config/kira.json", '{"restored": true}')
+        if include_credentials:
+            zf.writestr("webui.json", json.dumps({
+                "host": "127.0.0.1",
+                "port": 6000,
+                "access_token": "token-from-archive",
+            }))
+            zf.writestr(".jwt_secret", "secret-from-archive")
+    return archive
+
+
+def make_routes(data_path: Path, monkeypatch) -> SettingsRoutes:
+    monkeypatch.setattr(settings_routes, "get_data_path", lambda: data_path)
+    monkeypatch.setattr(webui_utils, "get_data_path", lambda: data_path)
+    return SettingsRoutes(FastAPI(), SimpleNamespace())
+
+
+def test_restore_keeps_live_credentials(tmp_path: Path, monkeypatch) -> None:
+    data_path = make_data_dir(tmp_path)
+    routes = make_routes(data_path, monkeypatch)
+
+    result = routes._do_restore(make_archive(tmp_path))
+
+    assert result.success is True
+    config = json.loads((data_path / "webui.json").read_text(encoding="utf-8"))
+    assert config["access_token"] == "live-token"
+    # Non-credential settings are still restored from the archive
+    assert config["port"] == 6000
+    assert (data_path / ".jwt_secret").read_text(encoding="utf-8") == "live-secret"
+    assert (data_path / "config" / "kira.json").read_text(encoding="utf-8") == '{"restored": true}'
+
+
+def test_restore_without_archived_credentials_leaves_them_alone(tmp_path: Path, monkeypatch) -> None:
+    data_path = make_data_dir(tmp_path)
+    routes = make_routes(data_path, monkeypatch)
+
+    result = routes._do_restore(make_archive(tmp_path, include_credentials=False))
+
+    assert result.success is True
+    config = json.loads((data_path / "webui.json").read_text(encoding="utf-8"))
+    assert config["access_token"] == "live-token"
+    assert config["port"] == 5267
+    assert (data_path / ".jwt_secret").read_text(encoding="utf-8") == "live-secret"
+
+
+def test_restore_drops_archived_token_when_none_is_active(tmp_path: Path, monkeypatch) -> None:
+    data_path = make_data_dir(tmp_path)
+    (data_path / "webui.json").write_text(
+        json.dumps({"host": "0.0.0.0", "port": 5267}), encoding="utf-8",
+    )
+    routes = make_routes(data_path, monkeypatch)
+
+    routes._do_restore(make_archive(tmp_path))
+
+    config = json.loads((data_path / "webui.json").read_text(encoding="utf-8"))
+    assert "access_token" not in config

--- a/tests/test_siliconflow_clients.py
+++ b/tests/test_siliconflow_clients.py
@@ -1,0 +1,97 @@
+"""Regression tests for Siliconflow response parsing and audio uploads."""
+
+import base64
+
+import httpx
+import pytest
+
+from core.chat.message_elements import Record
+from core.provider import ModelInfo, ModelType
+from core.provider.src.siliconflow_cn import model_clients as siliconflow_clients
+from core.provider.src.siliconflow_cn.model_clients import (
+    SiliconflowImageClient,
+    SiliconflowRerankClient,
+    resolve_audio_filename,
+)
+
+
+def build_model_info(model_type: ModelType, model_id: str) -> ModelInfo:
+    return ModelInfo(
+        model_type=model_type,
+        model_id=model_id,
+        provider_id="siliconflow-test",
+        provider_name="Siliconflow Test",
+        provider_config={"api_key": "test-key"},
+        model_config={},
+    )
+
+
+def patch_transport(monkeypatch, handler):
+    real_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        siliconflow_clients.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: real_async_client(
+            transport=httpx.MockTransport(handler)
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_image_generation_surfaces_missing_image_field(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"message": "model is overloaded"})
+
+    patch_transport(monkeypatch, handler)
+    client = SiliconflowImageClient(build_model_info(ModelType.IMAGE, "kolors"))
+
+    with pytest.raises(ValueError, match="model is overloaded"):
+        await client.text_to_image("a cat")
+
+
+@pytest.mark.anyio
+async def test_rerank_skips_out_of_range_indexes(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"index": 1, "relevance_score": 0.9},
+                    {"index": 7, "relevance_score": 0.8},
+                    {"relevance_score": 0.7},
+                    "not-a-dict",
+                ]
+            },
+        )
+
+    patch_transport(monkeypatch, handler)
+    client = SiliconflowRerankClient(build_model_info(ModelType.RERANK, "bge-reranker"))
+
+    results = await client.rerank("query", ["first", "second"])
+
+    assert [(item.index, item.text) for item in results] == [(1, "second")]
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        (b"#!AMR\n" + b"\x00" * 16, "audio.amr"),
+        (b"\x02#!SILK_V3" + b"\x00" * 16, "audio.silk"),
+        (b"OggS" + b"\x00" * 16, "audio.ogg"),
+        (b"ID3\x03\x00\x00\x00\x00\x00\x00", "audio.mp3"),
+        (b"RIFF\x00\x00\x00\x00WAVE", "audio.wav"),
+    ],
+)
+def test_audio_filename_is_derived_from_the_payload(payload, expected):
+    record = Record(record=base64.b64encode(payload).decode())
+
+    assert resolve_audio_filename(record, payload) == expected
+
+
+def test_audio_filename_falls_back_to_mime_then_wav():
+    unknown = b"\x00" * 32
+
+    assert resolve_audio_filename(Record(record="aGVsbG8=", mime="audio/amr"), unknown) == (
+        "audio.amr"
+    )
+    assert resolve_audio_filename(Record(record="aGVsbG8="), unknown) == "audio.wav"

--- a/tests/test_telemetry_stats_dedup.py
+++ b/tests/test_telemetry_stats_dedup.py
@@ -1,0 +1,139 @@
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("psutil", reason="core.telemetry imports core.utils.system_info")
+
+from core.telemetry.client import TelemetryClient  # noqa: E402
+from core.telemetry.models import TelemetryEventType  # noqa: E402
+
+
+class FakeDatabase:
+    """Minimal telemetry store: rows stay unreported until marked by id."""
+
+    def __init__(self):
+        self.message_rows = [
+            {"hour_ts": 36000, "platform": "QQ", "id": "m1"},
+            {"hour_ts": 36000, "platform": "Telegram", "id": "m2"},
+        ]
+        self.llm_rows = [
+            {
+                "hour_ts": 36000, "id": "l1", "model": "gpt-4o", "success": True,
+                "input_tokens": 100, "output_tokens": 50, "cached_tokens": 0,
+                "response_time_ms": 800,
+            },
+        ]
+        self.marked_messages: list[str] = []
+        self.marked_llm: list[str] = []
+
+    async def get_unreported_telemetry_message_rows(self, since_ts):
+        return [row for row in self.message_rows if row["id"] not in self.marked_messages]
+
+    async def get_unreported_telemetry_llm_usage_rows(self, since_ts):
+        return [row for row in self.llm_rows if row["id"] not in self.marked_llm]
+
+    async def mark_telemetry_messages_by_ids(self, ids):
+        self.marked_messages.extend(ids)
+
+    async def mark_telemetry_llm_by_ids(self, ids):
+        self.marked_llm.extend(ids)
+
+    async def delete_telemetry_records_before(self, cutoff_ts):
+        return None
+
+
+def _client(db: FakeDatabase) -> TelemetryClient:
+    config = SimpleNamespace(get_config=lambda *_args, **_kwargs: {})
+    client = TelemetryClient(db, config)
+    client.enabled = True
+    client.client_uuid = "test-uuid"
+    client.secret_key = "test-secret"
+    return client
+
+
+def _drain(client: TelemetryClient) -> list:
+    events = []
+    while not client._send_queue.empty():
+        events.append(client._send_queue.get_nowait())
+    return events
+
+
+@pytest.mark.anyio
+async def test_second_report_does_not_requeue_inflight_rows():
+    db = FakeDatabase()
+    client = _client(db)
+
+    await client._report_stats()
+    first = _drain(client)
+
+    await client._report_stats()
+    second = _drain(client)
+
+    assert {event.event_type for event in first} == {
+        TelemetryEventType.MESSAGE_STATS, TelemetryEventType.LLM_USAGE,
+    }
+    assert second == []
+
+
+@pytest.mark.anyio
+async def test_successful_send_marks_rows_and_releases_them():
+    db = FakeDatabase()
+    client = _client(db)
+
+    await client._report_stats()
+    for event in _drain(client):
+        await event._on_success()
+
+    assert sorted(db.marked_messages) == ["m1", "m2"]
+    assert db.marked_llm == ["l1"]
+    assert client._inflight_message_ids == set()
+    assert client._inflight_llm_ids == set()
+
+    await client._report_stats()
+    assert _drain(client) == []
+
+
+@pytest.mark.anyio
+async def test_failed_send_lets_rows_be_retried():
+    db = FakeDatabase()
+    client = _client(db)
+
+    await client._report_stats()
+    for event in _drain(client):
+        await event._on_failure()
+
+    assert db.marked_messages == []
+    assert client._inflight_message_ids == set()
+
+    await client._report_stats()
+    retried = _drain(client)
+
+    assert {event.event_type for event in retried} == {
+        TelemetryEventType.MESSAGE_STATS, TelemetryEventType.LLM_USAGE,
+    }
+    message_event = next(
+        e for e in retried if e.event_type == TelemetryEventType.MESSAGE_STATS
+    )
+    assert message_event.data["total_messages"] == 2
+
+
+@pytest.mark.anyio
+async def test_report_only_counts_rows_it_queues():
+    db = FakeDatabase()
+    client = _client(db)
+
+    await client._report_stats()
+    message_event = next(
+        e for e in _drain(client) if e.event_type == TelemetryEventType.MESSAGE_STATS
+    )
+    await message_event._on_success()
+
+    # A row inserted after the first aggregation must still be reported on its own.
+    db.message_rows.append({"hour_ts": 36000, "platform": "QQ", "id": "m3"})
+
+    await client._report_stats()
+    followup = next(
+        e for e in _drain(client) if e.event_type == TelemetryEventType.MESSAGE_STATS
+    )
+
+    assert followup.data["total_messages"] == 1

--- a/tests/test_tool_call_robustness.py
+++ b/tests/test_tool_call_robustness.py
@@ -1,0 +1,151 @@
+"""Tests for tool-call and config robustness against null/missing values."""
+
+import pytest
+
+from core.agent.func_tool_manager import FuncToolManager
+from core.agent.tool import ToolSet
+from core.message_manager import _config_float, _config_int
+from core.provider import LLMResponse
+from core.utils.tool_utils import BaseTool
+
+
+class RecordingTool(BaseTool):
+    """A tool whose name is only set in __init__, like plugin-provided tools."""
+
+    def __init__(self, name: str = "no_arg_tool"):
+        super().__init__()
+        self.name = name
+        self.description = "records the kwargs it was called with"
+        self.parameters = {"type": "object", "properties": {}}
+        self.calls = []
+
+    async def execute(self, event=None, **kwargs):
+        self.calls.append(kwargs)
+        return "ok"
+
+    def get_schema(self):
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": self.parameters,
+        }
+
+
+class StaticNameTool(BaseTool):
+    name = "static_tool"
+    description = "declares its name on the class"
+    parameters = {}
+
+    async def execute(self, *args, **kwargs):
+        return "ok"
+
+
+class FakeConfig:
+    def __init__(self, values: dict = None):
+        self.values = values or {}
+
+    def get_config(self, key, default=None):
+        return self.values.get(key, default)
+
+
+class FakeEvent:
+    is_stopped = False
+
+
+def _tool_call(arguments, name="no_arg_tool", call_id="call_1"):
+    function = {"name": name}
+    if arguments is not _MISSING:
+        function["arguments"] = arguments
+    return {"id": call_id, "function": function}
+
+
+_MISSING = object()
+
+
+# ====== ToolSet.add ======
+
+def test_add_class_whose_name_is_set_in_init():
+    """add() must compare the instantiated tool's name: a class that only sets
+    `name` in __init__ has no class-level attribute to read."""
+    tool_set = ToolSet()
+    tool_set.add(StaticNameTool())
+
+    tool_set.add(RecordingTool)
+
+    assert [t.name for t in tool_set.tools] == ["static_tool", "no_arg_tool"]
+
+
+def test_add_replaces_tool_with_same_name():
+    tool_set = ToolSet()
+    first = RecordingTool()
+    second = RecordingTool()
+    tool_set.add(first)
+    tool_set.add(second)
+
+    assert tool_set.tools == [second]
+    assert "no_arg_tool" in tool_set
+
+
+# ====== execute_tool argument parsing ======
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("arguments", [None, "", "   ", _MISSING])
+async def test_missing_tool_arguments_are_treated_as_empty(arguments):
+    """Providers may omit `arguments` for no-arg tool calls; that must not
+    raise AttributeError/TypeError before the tool is even called."""
+    tool = RecordingTool()
+    tool_set = ToolSet(tools=[tool])
+    manager = FuncToolManager(FakeConfig())
+
+    resp = LLMResponse("", tool_calls=[_tool_call(arguments)])
+    await manager.execute_tool(FakeEvent(), resp, tool_set=tool_set)
+
+    assert tool.calls == [{}]
+    assert resp.tool_results[0]["content"] == "ok"
+
+
+@pytest.mark.anyio
+async def test_malformed_tool_arguments_are_reported_and_ignored():
+    tool = RecordingTool()
+    tool_set = ToolSet(tools=[tool])
+    manager = FuncToolManager(FakeConfig())
+
+    resp = LLMResponse("", tool_calls=[_tool_call("{not json")])
+    await manager.execute_tool(FakeEvent(), resp, tool_set=tool_set)
+
+    assert tool.calls == [{}]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("value", [None, "", "abc", {}])
+async def test_null_tool_call_limits_fall_back_to_defaults(value):
+    """A null max_tool_calls_per_turn must not break tool execution."""
+    tool = RecordingTool()
+    tool_set = ToolSet(tools=[tool])
+    manager = FuncToolManager(FakeConfig({
+        "bot_config.agent.max_tool_calls_per_turn": value,
+        "bot_config.agent.tool_call_timeout": value,
+    }))
+
+    resp = LLMResponse("", tool_calls=[_tool_call('{"x": 1}')])
+    await manager.execute_tool(FakeEvent(), resp, tool_set=tool_set)
+
+    assert tool.calls == [{"x": 1}]
+
+
+# ====== config coercion ======
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(None, 2), ("", 2), ("abc", 2), ({}, 2), (5, 5), ("7", 7), (3.9, 3)],
+)
+def test_config_int_falls_back_on_invalid_values(value, expected):
+    assert _config_int(value, 2) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(None, 1.5), ("", 1.5), ("abc", 1.5), ([], 1.5), (2, 2.0), ("0.8", 0.8)],
+)
+def test_config_float_falls_back_on_invalid_values(value, expected):
+    assert _config_float(value, 1.5) == expected

--- a/tests/test_volcengine_video_client.py
+++ b/tests/test_volcengine_video_client.py
@@ -1,0 +1,150 @@
+"""Regression tests for the Volcengine video client.
+
+Covers the configurable polling budget replacing the hardcoded 30s cap and
+reference images / aspect ratio actually reaching the task request body.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from core.chat.message_elements import Image
+from core.provider import ModelInfo, ModelType
+from core.provider.src.volcengine import model_clients as volcengine_clients
+from core.provider.src.volcengine.model_clients import (
+    DEFAULT_VIDEO_TIMEOUT,
+    VolcengineVideoClient,
+)
+
+TASK_URL = "https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks"
+
+
+def build_client(model_config: dict | None = None) -> VolcengineVideoClient:
+    return VolcengineVideoClient(
+        ModelInfo(
+            model_type=ModelType.VIDEO,
+            model_id="doubao-seedance-1-0-pro",
+            provider_id="volcengine-test",
+            provider_name="Volcengine Test",
+            provider_config={"api_key": "test-key"},
+            model_config=model_config or {},
+        )
+    )
+
+
+def mock_client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def test_poll_budget_defaults_to_minutes_and_is_configurable():
+    assert DEFAULT_VIDEO_TIMEOUT >= 60
+    assert build_client()._poll_timeout() == float(DEFAULT_VIDEO_TIMEOUT)
+    assert build_client({"timeout": 600})._poll_timeout() == 600.0
+
+
+@pytest.mark.parametrize("invalid", ["not-a-number", 0, -5, None])
+def test_poll_budget_falls_back_on_invalid_values(invalid):
+    assert build_client({"timeout": invalid})._poll_timeout() == float(
+        DEFAULT_VIDEO_TIMEOUT
+    )
+
+
+@pytest.mark.anyio
+async def test_create_task_sends_text_only_without_reference_images():
+    bodies = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json={"id": "task-1"})
+
+    async with mock_client(handler) as client:
+        task_id = await build_client()._create_task(
+            client=client, text="a cat", duration=5
+        )
+
+    assert task_id == "task-1"
+    assert bodies[0]["content"] == [{"type": "text", "text": "a cat"}]
+    assert bodies[0]["ratio"] == "16:9"
+
+
+@pytest.mark.anyio
+async def test_create_task_serialises_single_reference_image():
+    bodies = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json={"id": "task-1"})
+
+    async with mock_client(handler) as client:
+        await build_client({"ratio": "9:16"})._create_task(
+            client=client,
+            text="a cat",
+            ref=[Image(image="https://example.com/first.png")],
+            duration=5,
+        )
+
+    assert bodies[0]["content"] == [
+        {"type": "text", "text": "a cat"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/first.png"},
+        },
+    ]
+    assert bodies[0]["ratio"] == "9:16"
+
+
+@pytest.mark.anyio
+async def test_create_task_marks_multiple_reference_images():
+    bodies = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, json={"id": "task-1"})
+
+    async with mock_client(handler) as client:
+        await build_client()._create_task(
+            client=client,
+            text="a cat",
+            ref=[
+                Image(image="https://example.com/first.png"),
+                Image(image="data:image/png;base64,aGVsbG8="),
+            ],
+            duration=5,
+        )
+
+    image_parts = bodies[0]["content"][1:]
+    assert [part["image_url"]["url"] for part in image_parts] == [
+        "https://example.com/first.png",
+        "data:image/png;base64,aGVsbG8=",
+    ]
+    assert {part["role"] for part in image_parts} == {"reference_image"}
+
+
+@pytest.mark.anyio
+async def test_generate_video_uses_configured_budget_for_http_client(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == TASK_URL:
+            return httpx.Response(200, json={"id": "task-1"})
+        return httpx.Response(
+            200,
+            json={
+                "status": "succeeded",
+                "content": {"video_url": "https://cdn.example.com/video.mp4"},
+            },
+        )
+
+    real_async_client = httpx.AsyncClient
+
+    def fake_async_client(*args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return real_async_client(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(volcengine_clients.httpx, "AsyncClient", fake_async_client)
+
+    video = await build_client({"timeout": 600}).generate_video("a cat")
+
+    assert captured["timeout"] == 600.0
+    assert video.file == "https://cdn.example.com/video.mp4"

--- a/webui/frontend/src/api/settings.ts
+++ b/webui/frontend/src/api/settings.ts
@@ -24,6 +24,11 @@ export interface BackupItem {
   created_at: string
 }
 
+export interface RestoreResponse {
+  success: boolean
+  message: string
+}
+
 export function getStorageInfo() {
   return apiClient.get<StorageInfoResponse>('/settings/storage')
 }
@@ -41,13 +46,13 @@ export function deleteBackup(filename: string) {
 }
 
 export function restoreFromBackup(filename: string) {
-  return apiClient.post(`/settings/backup/${filename}/restore`)
+  return apiClient.post<RestoreResponse>(`/settings/backup/${filename}/restore`)
 }
 
 export function restoreBackup(file: File) {
   const formData = new FormData()
   formData.append('file', file)
-  return apiClient.post('/settings/restore', formData)
+  return apiClient.post<RestoreResponse>('/settings/restore', formData)
 }
 
 export function changeAccessToken(oldToken: string, newToken: string) {

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -608,6 +608,7 @@ export default {
       logging_desc: 'Terminal and file logging configuration',
       locale: 'Locale Settings',
       locale_desc: 'Language and timezone configuration',
+      network: 'Network Settings',
       network_desc: 'Network and package source configuration',
     },
     hints: {

--- a/webui/frontend/src/views/SettingsView.vue
+++ b/webui/frontend/src/views/SettingsView.vue
@@ -526,7 +526,7 @@ async function handleRestart() {
 async function fetchBackupList() {
   try {
     const { data } = await listBackups()
-    backupList.value = data as unknown as BackupItem[]
+    backupList.value = data
   } catch {
     // silent
   }
@@ -568,8 +568,7 @@ async function handleDeleteBackup(filename: string) {
 async function handleRestoreFromBackup(filename: string) {
   restoreLoading.value = true
   try {
-    const { data } = await restoreFromBackup(filename)
-    const result = data as unknown as { success: boolean; message: string }
+    const { data: result } = await restoreFromBackup(filename)
     if (result.success) {
       notify(t('settings.restore_success'), 'success')
       await triggerRestart()
@@ -602,8 +601,7 @@ async function handleRestore() {
 
   restoreLoading.value = true
   try {
-    const { data } = await restoreBackup(file)
-    const result = data as unknown as { success: boolean; message: string }
+    const { data: result } = await restoreBackup(file)
     if (result.success) {
       notify(t('settings.restore_success'), 'success')
       restoreModalVisible.value = false

--- a/webui/routes/sessions.py
+++ b/webui/routes/sessions.py
@@ -74,6 +74,11 @@ class SessionsRoutes(Routes):
         if len(parts) < 3:
             raise HTTPException(status_code=400, detail="Invalid session id format")
 
+        # read_memory creates the session when it is missing, so an unknown id
+        # has to be rejected before it can be persisted by a plain GET.
+        if session_id not in self.lifecycle.session_manager.chat_memory:
+            raise HTTPException(status_code=404, detail="Session not found")
+
         memory = self.lifecycle.session_manager.read_memory(session_id)
 
         adapter_name, session_type, session_key = parts[0], parts[1], ":".join(parts[2:])

--- a/webui/routes/settings.py
+++ b/webui/routes/settings.py
@@ -1,4 +1,7 @@
+import asyncio
+import json
 import os
+import secrets
 import shutil
 import tempfile
 import zipfile
@@ -7,6 +10,7 @@ from pathlib import Path
 
 from fastapi import Depends, File, HTTPException, Request, UploadFile
 
+from core.logging_manager import get_logger
 from core.utils.path_utils import get_data_path
 from webui.models import (
     BackupCreateResponse,
@@ -17,10 +21,17 @@ from webui.models import (
 )
 from webui.routes.auth import require_auth
 from webui.routes.base import RouteDefinition, Routes
-from webui.utils import _update_access_token
+from webui.utils import _load_webui_config, _update_access_token
+
+logger = get_logger("webui", "blue")
 
 # Backup directory lives inside the data directory
 BACKUP_DIR_NAME = "backups"
+
+# Credentials that must survive a restore: an archived copy would silently
+# rotate the admin's access token and invalidate every issued session.
+WEBUI_CONFIG_FILE_NAME = "webui.json"
+JWT_SECRET_FILE_NAME = ".jwt_secret"
 
 
 def _get_backup_dir() -> Path:
@@ -41,6 +52,48 @@ def _calc_dir_size(path: Path) -> tuple[int, int]:
                 except OSError:
                     pass
     return total, count
+
+
+def _collect_storage_entries(data_path: Path) -> tuple[list[DirectoryEntry], int]:
+    """Return one entry per top-level subdirectory plus the total data size."""
+    directories: list[DirectoryEntry] = []
+    if data_path.exists():
+        for entry in sorted(data_path.iterdir()):
+            if not entry.is_dir():
+                continue
+            size, count = _calc_dir_size(entry)
+            directories.append(
+                DirectoryEntry(
+                    name=entry.name,
+                    path=str(entry),
+                    size_bytes=size,
+                    file_count=count,
+                )
+            )
+
+    total_size, _ = _calc_dir_size(data_path)
+    return directories, total_size
+
+
+def _write_backup_archive(data_path: Path, zip_path: Path) -> int:
+    """Pack the data directory into *zip_path* and return the archive size."""
+    # Directories to exclude from backup (backups themselves, dist builds, transient data)
+    exclude_dirs = {BACKUP_DIR_NAME, "dist", "__pycache__", "updates", "temp"}
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for root, dirs, files in os.walk(data_path):
+            # Prune excluded directories
+            dirs[:] = [d for d in dirs if d not in exclude_dirs]
+            rel_root = Path(root).relative_to(data_path)
+            for f in files:
+                full_path = Path(root) / f
+                arcname = rel_root / f
+                try:
+                    zf.write(full_path, arcname)
+                except OSError:
+                    pass
+
+    return zip_path.stat().st_size
 
 
 class SettingsRoutes(Routes):
@@ -114,22 +167,7 @@ class SettingsRoutes(Routes):
         data_path = get_data_path()
         disk = shutil.disk_usage(data_path)
 
-        directories = []
-        if data_path.exists():
-            for entry in sorted(data_path.iterdir()):
-                if not entry.is_dir():
-                    continue
-                size, count = _calc_dir_size(entry)
-                directories.append(
-                    DirectoryEntry(
-                        name=entry.name,
-                        path=str(entry),
-                        size_bytes=size,
-                        file_count=count,
-                    )
-                )
-
-        total_size, _ = _calc_dir_size(data_path)
+        directories, total_size = await asyncio.to_thread(_collect_storage_entries, data_path)
 
         return StorageInfoResponse(
             data_path=str(data_path),
@@ -151,23 +189,7 @@ class SettingsRoutes(Routes):
         filename = f"backup_{timestamp}.zip"
         zip_path = backup_dir / filename
 
-        # Directories to exclude from backup (backups themselves, dist builds, transient data)
-        exclude_dirs = {BACKUP_DIR_NAME, "dist", "__pycache__", "updates", "temp"}
-
-        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-            for root, dirs, files in os.walk(data_path):
-                # Prune excluded directories
-                dirs[:] = [d for d in dirs if d not in exclude_dirs]
-                rel_root = Path(root).relative_to(data_path)
-                for f in files:
-                    full_path = Path(root) / f
-                    arcname = rel_root / f
-                    try:
-                        zf.write(full_path, arcname)
-                    except OSError:
-                        pass
-
-        size = zip_path.stat().st_size
+        size = await asyncio.to_thread(_write_backup_archive, data_path, zip_path)
         return BackupCreateResponse(
             filename=filename,
             size_bytes=size,
@@ -220,9 +242,41 @@ class SettingsRoutes(Routes):
         if backup_path.resolve().parent != _get_backup_dir().resolve():
             raise HTTPException(status_code=400, detail="Invalid filename")
 
-        return self._do_restore(backup_path)
+        return await asyncio.to_thread(self._do_restore, backup_path)
 
     # ── Restore ──────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _keep_current_credentials(staging_path: Path) -> None:
+        """Drop the archived JWT secret and re-point the archived access token
+        at the one currently in use, so a restore cannot lock the admin out."""
+        staged_secret = staging_path / JWT_SECRET_FILE_NAME
+        if staged_secret.is_file():
+            staged_secret.unlink()
+
+        staged_config = staging_path / WEBUI_CONFIG_FILE_NAME
+        if not staged_config.is_file():
+            return
+
+        try:
+            restored_config = json.loads(staged_config.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(f"Could not read {WEBUI_CONFIG_FILE_NAME} from the archive: {e}")
+            staged_config.unlink()
+            return
+
+        if not isinstance(restored_config, dict):
+            staged_config.unlink()
+            return
+
+        current_token = _load_webui_config().get("access_token")
+        if current_token:
+            restored_config["access_token"] = current_token
+        else:
+            restored_config.pop("access_token", None)
+        staged_config.write_text(
+            json.dumps(restored_config, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
 
     def _do_restore(self, zip_source) -> RestoreResponse:
         """Extract a zip into a staging dir, validate, then copy to data directory."""
@@ -251,7 +305,10 @@ class SettingsRoutes(Routes):
                             with zf.open(member) as src, open(target, "wb") as dst:
                                 shutil.copyfileobj(src, dst)
 
-                # Step 2: Copy validated files to data_path
+                # Step 2: Keep the live credentials instead of the archived ones
+                self._keep_current_credentials(staging_path)
+
+                # Step 3: Copy validated files to data_path
                 for src_file in staging_path.rglob("*"):
                     rel = src_file.relative_to(staging_path)
                     dst_file = data_path / rel
@@ -274,7 +331,7 @@ class SettingsRoutes(Routes):
             raise HTTPException(status_code=400, detail="Only .zip files are accepted")
 
         file.file.seek(0)
-        return self._do_restore(file.file)
+        return await asyncio.to_thread(self._do_restore, file.file)
 
     # ── Access Token ────────────────────────────────────────────────────────
 
@@ -282,7 +339,10 @@ class SettingsRoutes(Routes):
         if request.app.state.disable_auth:
             raise HTTPException(status_code=400, detail="Cannot change token when auth is disabled")
         current_token = request.app.state.access_token
-        if body.old_token != current_token:
+        if not secrets.compare_digest(
+            (body.old_token or "").encode("utf-8"),
+            (current_token or "").encode("utf-8"),
+        ):
             raise HTTPException(status_code=400, detail="Old token is incorrect")
         if not body.new_token or len(body.new_token) < 6:
             raise HTTPException(status_code=400, detail="New token must be at least 6 characters")

--- a/webui/routes/skills.py
+++ b/webui/routes/skills.py
@@ -80,6 +80,10 @@ class SkillsRoutes(Routes):
     def _folder_size(path) -> int:
         return sum(item.stat().st_size for item in path.rglob("*") if item.is_file())
 
+    @classmethod
+    def _folder_sizes(cls, paths: List[Any]) -> List[int]:
+        return [cls._folder_size(path) for path in paths]
+
     @staticmethod
     def _create_skill_archive(skill_path, archive_path) -> None:
         with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
@@ -94,9 +98,12 @@ class SkillsRoutes(Routes):
             skills_manager = self.lifecycle.skills_manager
 
         try:
-            skills_info = skills_manager.skills_info
+            skills_info = list(skills_manager.skills_info)
+            sizes = await asyncio.to_thread(
+                self._folder_sizes, [skill.path for skill in skills_info]
+            )
             items: List[SkillItem] = []
-            for skill in skills_info:
+            for skill, size_bytes in zip(skills_info, sizes):
                 items.append(
                     SkillItem(
                         id=str(skill.name),
@@ -104,7 +111,7 @@ class SkillsRoutes(Routes):
                         description=str(skill.description),
                         enabled=bool(skill.enabled),
                         path=str(skill.path),
-                        size_bytes=self._folder_size(skill.path),
+                        size_bytes=size_bytes,
                     )
                 )
             return items


### PR DESCRIPTION
> Base branch is `dev`.

## Summary

A full-codebase review of `v2.30.0` turned up a set of defects that share one theme: **failures were silent**. The event bus counted handler exceptions without logging them, adapters kept looking healthy after their receive loop died, and TTS/STT/embedding clients returned empty values instead of raising, so `health_check` reported a wrong API key as a working model. For a system meant to run 24/7 this means it degrades in ways the operator cannot see.

This PR fixes the functional findings. Rebased onto `dev`, so it includes the changes from #246 and #247.

Fixes #248, Fixes #249, Fixes #250, Fixes #251, Fixes #252

Findings from the same review that touch security are being reported through the private advisory channel instead, so they are deliberately not in this PR.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

One commit per module; each commit message explains the failure it fixes.

**Core runtime (#248)**
- Log event bus handler exceptions with traceback; they were counted but never logged, so a single uncaught error in the message pipeline made the bot stop responding with an empty log.
- `schedule_tasks()` reassigned `self.tasks`, dropping the strong references to the temp-monitor and image-cache tasks and leaving `stop()` iterating an empty list. Tasks are now appended and cancelled, and `stop_monitoring()` is actually called.
- `stop()` can now wake `dispatch()` instead of leaving it blocked on an empty queue.
- MCP servers lost `env` and `timeout` on every load, so stdio servers needing an API key started with a bare environment and their tool calls silently failed.
- `init_mcp()` awaits server initialisation, so tools are registered before the first message is handled.
- Null numeric config and missing tool-call `arguments` no longer raise.
- Lifecycle cleanup runs when startup fails, not only on cancellation.

**Adapters (#249)**
- The NapCat receive loop broke out on any exception other than `ConnectionClosed`, and gave up permanently after 20 reconnects; it now reconnects with capped backoff and re-verifies the account.
- Bilibili tracked top-level comments and replies with one shared cursor, so a reply under an older thread advanced it past comments that were never processed. Both are now collected together and deduplicated by id.
- Telegram used `filters.ALL`, which also matches channel posts (crashing on a null `from_user`) and edited messages (replied to twice).
- QQ dispatched only `message_chain[0]`, so a reply combining text and a file silently lost the file.
- Permission list ids are normalised to strings; integer ids in a hand-edited config made `deny_list` checks fail open.
- weixin_oc backs off on long-poll error returns instead of spinning at request speed.
- Adapter shutdown is guarded per adapter so one failure cannot abort the sequence.

**Providers (#250)**
- TTS, STT, embedding and rerank clients raise `ProviderAPIError` instead of returning `None`/`[]`. `health_check` treats "did not raise" as success, so a wrong key or unreachable host previously showed up as a working model in the WebUI.
- Volcengine video polling was capped at a hardcoded 30s, well below the minutes such jobs take, so it always timed out; the budget is now configurable. Reference images were accepted and then dropped from the request.
- DeepSeek ignored the configured `timeout` and used the 600s SDK default.
- `AsyncOpenAI` clients are closed via `async with`, kept open for the lifetime of a stream.
- A provider that failed to instantiate now raises a clear error rather than `AttributeError` on `None`.
- `fetch_remote_models` dispatches on `model_type` instead of always listing LLMs.

**Plugins and telemetry (#251)**
- `DefaultChatPlugin.terminate()` was an empty stub while a debounce task runs per session, so disabling or reconfiguring the plugin left those tasks running against a stale context.
- Foreground `exec` now creates a process group and kills the group on timeout; previously only the shell was terminated and its children were orphaned. The background path already did this.
- Telemetry no longer re-enqueues rows that are already in flight, which double counted messages and tokens whenever the endpoint was unreachable for over 30 minutes.
- The report lock is only released by the call that acquired it.
- Restricted paths match on segments and words, so `data/files/monkey.txt` is no longer rejected for containing "key".
- Country code lookup moved to HTTPS. Note this switches provider to `api.country.is`, as `ip-api.com` only serves plaintext HTTP on its free tier — happy to change this if you would rather keep the current provider.

**WebUI (#252)**
- Backup, restore, storage size and skill listing are offloaded to a thread. With a single worker, walking and zipping the data directory inline froze every concurrent request including `/api/health` and the SSE log stream. `export_skill` already used `asyncio.to_thread`.
- `GET /api/sessions/{id}` returns 404 for an unknown session instead of persisting an empty one, which let a read create a record and `chat_memory` grow unbounded.
- Restoring a backup keeps the running access token and JWT secret, which the archive otherwise overwrote and locked the admin out.
- Added the `configuration.groups.network` key missing from `en.ts` — the only key that differed between the two locales.
- Typed the backup endpoints so the views no longer cast through `as unknown as`.

## Screenshots / Logs

No UI changes beyond the missing English label. Test run on this branch:

```
465 passed, 3 warnings in 7.55s
```

Frontend `npm run build` (`vue-tsc -b && vite build`) passes with no type errors.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [ ] This PR does not introduce breaking changes

Notes on the last two boxes:

- No new dependencies were added; nothing to add to `requirements.txt`.
- No new features, only fixes to reported issues.
- **Three behaviour changes worth calling out**, which is why the breaking-changes box is unchecked:
  1. TTS/STT/embedding/rerank now raise instead of returning empty values. Every in-repo caller already handles exceptions, but a third-party plugin relying on `embed()` returning `[]` would need to catch `ProviderAPIError`. This is what lets failover in `agent_executor` see the failure.
  2. `fetch_remote_models` returns 404 with a reason for non-LLM model types instead of silently returning the LLM list.
  3. The telemetry country-code provider changed, as noted above.

19 regression tests were added across the areas above, covering the cases that are cheap to test as pure logic: the Bilibili cursor scenario, permission list normalisation, the QQ chain fallback, MCP `env`/`timeout` loading, tool-argument robustness, telemetry deduplication, and the session 404. `BiliBiliAdapter.stop()` is left as `dev` already has it.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable video-generation timeout and aspect-ratio settings.
  * Added finance as a web search topic.
  * Improved handling of multimedia messages across QQ, Telegram, Bilibili, and WeChat.
  * Added clearer network settings labeling and safer backup restoration.

* **Bug Fixes**
  * Improved reconnection, shutdown, task management, and error reporting.
  * Prevented duplicate comment processing and malformed tool-call failures.
  * Improved provider failure reporting and streaming usage metadata.
  * Prevented unknown session lookups from creating new sessions.
  * Strengthened sensitive-file protection and timed command cleanup.

* **Tests**
  * Expanded coverage for messaging, providers, telemetry, sessions, backups, tools, and video generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->