### PR TITLE
fix(webui): align modal layouts

### DIFF
--- a/webui/frontend/src/components/common/ConfirmModal.vue
+++ b/webui/frontend/src/components/common/ConfirmModal.vue
@@ -5,8 +5,8 @@
     @close="onCancel"
   >
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl">
-      <div class="px-6 py-4">
-        <div class="flex items-center mb-4">
+      <div class="px-6 pt-6 pb-4">
+        <div class="flex items-center mb-2">
           <div :class="variant === 'info' ? 'bg-blue-100 dark:bg-blue-900/30' : 'bg-red-100 dark:bg-red-900/30'" class="rounded-full p-3 mr-4">
             <IconInfo v-if="variant === 'info'" class="w-6 h-6 text-blue-600 dark:text-blue-400" />
             <IconWarning v-else class="w-6 h-6 text-red-600 dark:text-red-400" />
@@ -22,7 +22,7 @@
         </div>
         <slot></slot>
       </div>
-      <div class="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex justify-end space-x-3">
+      <div class="px-6 pb-6 flex justify-end space-x-3">
         <button
           class="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           @click="onCancel"

--- a/webui/frontend/src/views/AdapterView.vue
+++ b/webui/frontend/src/views/AdapterView.vue
@@ -79,7 +79,7 @@
 
     <!-- Create/Edit Modal -->
     <Modal v-model="dialogVisible" content-class="max-w-md">
-      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full mx-4 flex flex-col modal-card" style="max-height: 90vh;">
+      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full flex flex-col modal-card" style="max-height: 90vh;">
         <div class="flex justify-between items-center px-6 py-4 border-b border-gray-200 dark:border-gray-700">
           <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">
             {{ editMode ? $t('adapter.edit_title') : $t('adapter.add') }}

--- a/webui/frontend/src/views/PersonaView.vue
+++ b/webui/frontend/src/views/PersonaView.vue
@@ -77,7 +77,7 @@
 
     <!-- Create/Edit Modal -->
     <Modal v-model="dialogVisible" content-class="max-w-4xl" content-style="width: 90%;">
-      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full mx-4 flex flex-col modal-card" style="max-height: 90vh;">
+      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full flex flex-col modal-card" style="max-height: 90vh;">
         <div class="flex justify-between items-center px-6 py-4 border-b border-gray-200 dark:border-gray-700">
           <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">
             {{ editMode ? $t('persona.edit_title') : $t('persona.modal_title') }}

--- a/webui/frontend/src/views/ProviderView.vue
+++ b/webui/frontend/src/views/ProviderView.vue
@@ -166,7 +166,7 @@
 
     <!-- Create Provider Dialog -->
     <Modal v-model="createDialogVisible" content-class="max-w-md">
-      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full mx-4 flex flex-col modal-card" style="max-height: 90vh;">
+      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full flex flex-col modal-card" style="max-height: 90vh;">
         <div class="flex justify-between items-center px-6 py-4 border-b border-gray-200 dark:border-gray-700">
           <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">{{ $t('provider.add') }}</h3>
           <button class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" @click="createDialogVisible = false">
@@ -205,7 +205,7 @@
 
     <!-- Add/Edit Model Dialog -->
     <Modal v-model="modelDialogVisible" content-class="max-w-md">
-      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full mx-4 modal-card flex flex-col" style="max-height: 90vh;">
+      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full modal-card flex flex-col" style="max-height: 90vh;">
         <div class="flex justify-between items-center px-6 py-4 border-b border-gray-200 dark:border-gray-700">
           <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">{{ modelEditMode ? $t('provider.edit_model') : $t('provider.add_model') }}</h3>
           <button class="text-gray-400 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300" @click="modelDialogVisible = false">
@@ -264,7 +264,7 @@
 
     <!-- Remote Model Selection Modal -->
     <Modal v-model="remoteModelDialogVisible" content-class="max-w-2xl">
-      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full mx-4 flex flex-col modal-card" style="max-height: 80vh;">
+      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full flex flex-col modal-card" style="max-height: 80vh;">
         <div class="flex justify-between items-center px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0">
           <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">{{ $t('provider.fetch_remote_models') }}</h3>
           <button class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" @click="remoteModelDialogVisible = false">

--- a/webui/frontend/src/views/StickerView.vue
+++ b/webui/frontend/src/views/StickerView.vue
@@ -75,7 +75,7 @@
 
     <!-- Create/Edit Modal -->
     <Modal v-model="dialogVisible" content-class="max-w-md">
-      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full mx-4 flex flex-col modal-card" style="max-height: 90vh;">
+      <div class="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full flex flex-col modal-card" style="max-height: 90vh;">
         <div class="flex justify-between items-center px-6 py-4 border-b border-gray-200 dark:border-gray-700">
           <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">
             {{ editMode ? $t('sticker.modal_title_edit') : $t('sticker.modal_title_add') }}


### PR DESCRIPTION
## Summary

Fixes inconsistent horizontal alignment in WebUI modal content and refines the confirmation dialog layout by removing its visual divider and balancing its spacing.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Remove duplicate horizontal margins from adapter, provider, sticker, and persona modal content panels.
- Remove the confirmation dialog divider and refine its vertical spacing.

## Screenshots / Logs

- `npx vue-tsc -b` passed.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed (not needed for this UI-only fix)
- [x] New dependencies have been added to `requirements.txt` (not applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer (not applicable)
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved confirmation modal spacing for clearer content and action areas.
  * Removed unnecessary borders and adjusted padding in the confirmation dialog.
  * Expanded adapter, persona, provider, and sticker create/edit modals to use available horizontal space more effectively.
  * Updated provider model-related dialogs with the same wider layout for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->