### PR TITLE
fix(webui): standardize model default selects

### DIFF
--- a/webui/frontend/src/components/common/CustomSelect.vue
+++ b/webui/frontend/src/components/common/CustomSelect.vue
@@ -4,6 +4,7 @@
     <div
       class="custom-select-trigger"
       :class="{ active: isOpen, 'has-value': !!modelValue, placeholder: !modelValue, disabled: props.disabled }"
+      :style="props.height ? { height: props.height, minHeight: props.height } : undefined"
       @click.stop="toggleDropdown"
       @keydown.enter.prevent="onEnter"
       @keydown.space.prevent="onEnter"
@@ -81,6 +82,7 @@ const props = defineProps<{
   options: Option[]
   placeholder?: string
   disabled?: boolean
+  height?: string
 }>()
 
 const emit = defineEmits<{

--- a/webui/frontend/src/views/ConfigView.vue
+++ b/webui/frontend/src/views/ConfigView.vue
@@ -180,34 +180,24 @@
               <div class="text-xs text-gray-500 dark:text-gray-400" v-html="highlightSearch($t(field.hintKey, field.hintFallback))" />
             </div>
             <div class="flex flex-col sm:flex-row gap-2 md:gap-3">
-              <select
-                :value="getModelProvider(field.key)"
-                class="w-full sm:w-40 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                @change="(e) => setModelProvider(field.key, (e.target as HTMLSelectElement).value, field.modelType)"
-              >
-                <option value="">{{ $t('configuration.none') }}</option>
-                <option
-                  v-for="p in providers"
-                  :key="p.id"
-                  :value="p.id"
-                >
-                  {{ p.name || p.id }}
-                </option>
-              </select>
-              <select
-                :value="getModelId(field.key)"
-                class="w-full sm:w-48 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                @change="(e) => setModelId(field.key, (e.target as HTMLSelectElement).value)"
-              >
-                <option value="">{{ $t('configuration.none') }}</option>
-                <option
-                  v-for="modelId in getAvailableModels(field.key, field.modelType)"
-                  :key="modelId"
-                  :value="modelId"
-                >
-                  {{ modelId }}
-                </option>
-              </select>
+              <div class="w-full sm:w-40">
+                <CustomSelect
+                  :modelValue="getModelProvider(field.key)"
+                  :options="modelProviderOptions"
+                  :placeholder="$t('configuration.none')"
+                  height="38px"
+                  @update:modelValue="(value: string) => setModelProvider(field.key, value, field.modelType)"
+                />
+              </div>
+              <div class="w-full sm:w-48">
+                <CustomSelect
+                  :modelValue="getModelId(field.key)"
+                  :options="getModelOptions(field.key, field.modelType)"
+                  :placeholder="$t('configuration.none')"
+                  height="38px"
+                  @update:modelValue="(value: string) => setModelId(field.key, value)"
+                />
+              </div>
             </div>
             <p
               v-if="validationErrors[field.key]"
@@ -708,6 +698,24 @@ function getModelId(key: string): string {
   return parseModelReference(getFieldValue(key) || '').modelId
 }
 
+const modelProviderOptions = computed(() => [
+  { value: '', label: t('configuration.none') },
+  ...providers.value.map(provider => ({
+    value: provider.id,
+    label: provider.name || provider.id,
+  })),
+])
+
+function getModelOptions(key: string, modelType?: string) {
+  return [
+    { value: '', label: t('configuration.none') },
+    ...getAvailableModels(key, modelType).map(modelId => ({
+      value: modelId,
+      label: modelId,
+    })),
+  ]
+}
+
 function setModelProvider(key: string, providerId: string, _modelType?: string) {
   if (!providerId) {
     delete pendingProviders.value[key]
@@ -1077,6 +1085,7 @@ onUnmounted(() => {
   background: rgba(148, 163, 184, 0.15);
   border-color: rgba(148, 163, 184, 0.25);
 }
+
 .modified-badge-enter-active,
 .modified-badge-leave-active {
   transition: opacity 0.2s ease, transform 0.2s ease;

--- a/webui/frontend/src/views/ConfigView.vue
+++ b/webui/frontend/src/views/ConfigView.vue
@@ -725,6 +725,7 @@ function setModelProvider(key: string, providerId: string, _modelType?: string) 
     validateField(key)
     return
   }
+  if (providerId === getModelProvider(key)) return
   // Switching provider invalidates any previously chosen model, so we clear
   // the persisted value and park the provider in pending state until the user
   // picks a model. `validateField` will flag this as required-but-missing.


### PR DESCRIPTION
## Summary

Replaces the default-model provider and model dropdowns in the configuration page with the shared `CustomSelect` component, while preserving their original control height and selection behavior.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Add an optional `height` prop to `CustomSelect`.
- Use `CustomSelect` for model provider and model selections in the configuration page.
- Preserve the prior 38px control height and dynamic provider/model option behavior.

## Screenshots / Logs

- `npx vue-tsc -b` passed.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed (not needed for this UI-only fix)
- [x] New dependencies have been added to `requirements.txt` (not applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer (not applicable)
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved configuration selectors with a consistent, customizable appearance.
  * Added support for setting selector height to improve layout flexibility.
  * Model and provider options now update dynamically while preserving localized empty-state messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->