### PR TITLE
fix: follow GitHub repository transfer redirects

### DIFF
--- a/core/utils/github_api.py
+++ b/core/utils/github_api.py
@@ -17,6 +17,15 @@ GH_PROXY_LIST = [
 ]
 
 
+def _github_client_kwargs(timeout: float, proxy: Optional[str]) -> dict:
+    # GitHub returns 301 after a repository transfer. Treat it as the
+    # documented redirect rather than surfacing it as a release-fetch error.
+    client_kwargs: dict = {"timeout": timeout, "follow_redirects": True}
+    if proxy:
+        client_kwargs["proxy"] = proxy
+    return client_kwargs
+
+
 def parse_github_url(url: str) -> Tuple[str, str]:
     """
     Parse a GitHub URL or 'owner/repo' shorthand into (owner, repo).
@@ -47,9 +56,7 @@ async def get_latest_release(owner: str, repo: str, proxy: Optional[str] = None)
     'tarball_url', 'zipball_url', 'body'])
     """
     url = f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
-    client_kwargs: dict = {"timeout": 10.0}
-    if proxy:
-        client_kwargs["proxy"] = proxy
+    client_kwargs = _github_client_kwargs(10.0, proxy)
 
     async with httpx.AsyncClient(**client_kwargs) as client:
         try:
@@ -89,9 +96,7 @@ async def get_all_releases(
     max_pages — safety cap to avoid excessive pagination
     """
     releases: List[dict] = []
-    client_kwargs: dict = {"timeout": 10.0}
-    if proxy:
-        client_kwargs["proxy"] = proxy
+    client_kwargs = _github_client_kwargs(10.0, proxy)
 
     async with httpx.AsyncClient(**client_kwargs) as client:
         for page in range(1, max_pages + 1):
@@ -142,9 +147,7 @@ async def get_release_assets(
     Raises httpx.HTTPError on network or API failures.
     """
     url = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag}"
-    client_kwargs: dict = {"timeout": 10.0}
-    if proxy:
-        client_kwargs["proxy"] = proxy
+    client_kwargs = _github_client_kwargs(10.0, proxy)
 
     async with httpx.AsyncClient(**client_kwargs) as client:
         resp = await client.get(url)

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,6 +1,10 @@
+import asyncio
 import hashlib
+
+import httpx
 import pytest
 
+from core.utils import github_api
 from core.utils.github_api import parse_github_url, verify_sha256
 
 
@@ -65,3 +69,29 @@ def test_verify_sha256_strips_whitespace():
     data = b"test"
     digest = hashlib.sha256(data).hexdigest()
     assert verify_sha256(data, f"  {digest}  ") is True
+
+
+def test_get_all_releases_follows_repository_transfer_redirect(monkeypatch):
+    old_url = "https://api.github.com/repos/xxynet/KiraAI/releases?per_page=30&page=1"
+    new_url = "https://api.github.com/repositories/1087096210/releases?per_page=30&page=1"
+    requested_urls: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        if str(request.url) == old_url:
+            return httpx.Response(301, headers={"Location": new_url}, request=request)
+        if str(request.url) == new_url:
+            return httpx.Response(200, json=[], request=request)
+        raise AssertionError(f"Unexpected request: {request.url}")
+
+    real_async_client = httpx.AsyncClient
+
+    def mock_async_client(**kwargs):
+        return real_async_client(transport=httpx.MockTransport(handler), **kwargs)
+
+    monkeypatch.setattr(github_api.httpx, "AsyncClient", mock_async_client)
+
+    releases = asyncio.run(github_api.get_all_releases("xxynet", "KiraAI"))
+
+    assert releases == []
+    assert requested_urls == [old_url, new_url]


### PR DESCRIPTION
## Summary

Fix Release API requests after a GitHub repository transfer. GitHub returns a 301 redirect for the previous repository path, which the updater previously treated as a failure.

## Type of change

- [x] fix: Bug fix
- [ ] feat: New feature
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Enable redirect following for GitHub Release metadata requests.
- Share the Release API client configuration across latest-release, release-list, and release-assets requests.
- Add a regression test covering the 301 response produced by a transferred repository.

## Screenshots / Logs

`python -m pytest tests/test_github_api.py -v` — 14 passed.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub release retrieval when repositories have been transferred.
  * Release requests now follow redirects automatically, helping users access releases at updated repository locations.
  * Standardized request timeout and optional proxy handling across release-related operations.

* **Tests**
  * Added coverage confirming redirected repository requests complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->