### PR TITLE
fix(adapter): clean up Telegram on shutdown

### DIFF
--- a/core/adapter/src/telegram/telegram.py
+++ b/core/adapter/src/telegram/telegram.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 from typing import Any, Dict, Optional, Union, List
 import base64
+import logging
 import time
 import json
 
@@ -28,6 +29,16 @@ from core.chat.message_elements import (
 
 
 logger = get_logger("tg_adapter", "green")
+
+
+class _TelegramShutdownCancellationFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        exception = record.exc_info[1] if record.exc_info else None
+        return not (
+            record.name == "telegram.ext.Application"
+            and isinstance(exception, asyncio.CancelledError)
+            and record.getMessage().startswith("Fetching updates was aborted")
+        )
 
 
 class MessageSender:
@@ -74,7 +85,15 @@ class TelegramAdapter(IMAdapter):
         self.base_url = base_url
         self.base_file_url = base_file_url
 
-        self.app = ApplicationBuilder().token(self.bot_token).base_url(base_url).base_file_url(base_file_url).build()
+        self.app = (
+            ApplicationBuilder()
+            .token(self.bot_token)
+            .base_url(base_url)
+            .base_file_url(base_file_url)
+            .get_updates_connection_pool_size(2)
+            .get_updates_pool_timeout(5.0)
+            .build()
+        )
         self.message_sender = MessageSender()
 
     @staticmethod
@@ -115,14 +134,32 @@ class TelegramAdapter(IMAdapter):
 
     async def stop(self):
         """Stop the Telegram adapter asynchronously"""
-        if self.app:
-            try:
-                await self.app.updater.stop()
-                await self.app.stop()
-                await self.app.shutdown()
-                logger.info(f"Stopped listening messages for {self.config.get('bot_pid', 'your bot account')}")
-            except Exception as e:
-                logger.error(f"Error stopping Telegram adapter: {e}")
+        if not self.app:
+            return
+
+        shutdown_steps = []
+        if self.app.updater and self.app.updater.running:
+            shutdown_steps.append(("updater", self.app.updater.stop))
+        if self.app.running:
+            shutdown_steps.append(("application", self.app.stop))
+        shutdown_steps.append(("HTTP client", self.app.shutdown))
+        application_logger = logging.getLogger("telegram.ext.Application")
+        cancellation_filter = _TelegramShutdownCancellationFilter()
+        application_logger.addFilter(cancellation_filter)
+        try:
+            for component, shutdown in shutdown_steps:
+                try:
+                    await shutdown()
+                except asyncio.CancelledError:
+                    logger.warning(
+                        f"Telegram {component} stop was cancelled; continuing cleanup"
+                    )
+                except Exception as e:
+                    logger.error(f"Error stopping Telegram {component}: {e}")
+        finally:
+            application_logger.removeFilter(cancellation_filter)
+
+        logger.info(f"Stopped listening messages for {self.config.get('bot_pid', 'your bot account')}")
 
     def get_client(self):
         return self.app

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -1,0 +1,116 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from core.adapter.src.telegram.telegram import (
+    TelegramAdapter,
+    _TelegramShutdownCancellationFilter,
+)
+from core.adapter.adapter_info import AdapterInfo
+
+
+def test_uses_a_separate_get_updates_connection_for_shutdown_cleanup():
+    builder = Mock()
+    builder.token.return_value = builder
+    builder.base_url.return_value = builder
+    builder.base_file_url.return_value = builder
+    builder.get_updates_connection_pool_size.return_value = builder
+    builder.get_updates_pool_timeout.return_value = builder
+
+    info = AdapterInfo(
+        adapter_id="telegram-test",
+        enabled=True,
+        name="telegram-test",
+        platform="Telegram",
+        description="",
+        config={"bot_token": "token"},
+    )
+    with patch(
+        "core.adapter.src.telegram.telegram.ApplicationBuilder",
+        return_value=builder,
+    ):
+        TelegramAdapter(info, asyncio.Queue())
+
+    builder.get_updates_connection_pool_size.assert_called_once_with(2)
+    builder.get_updates_pool_timeout.assert_called_once_with(5.0)
+
+
+def test_filters_only_telegram_shutdown_cancellation_log():
+    cancellation = asyncio.CancelledError()
+    record = logging.LogRecord(
+        name="telegram.ext.Application",
+        level=logging.CRITICAL,
+        pathname="",
+        lineno=0,
+        msg="Fetching updates was aborted due to %r",
+        args=(cancellation,),
+        exc_info=(asyncio.CancelledError, cancellation, None),
+    )
+
+    assert not _TelegramShutdownCancellationFilter().filter(record)
+
+
+@pytest.mark.asyncio
+async def test_stop_closes_application_after_updater_stop_failure():
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    updater_stop = AsyncMock(side_effect=RuntimeError("connection pool timeout"))
+    application_stop = AsyncMock()
+    application_shutdown = AsyncMock()
+    adapter.app = SimpleNamespace(
+        updater=SimpleNamespace(running=True, stop=updater_stop),
+        running=True,
+        stop=application_stop,
+        shutdown=application_shutdown,
+    )
+    adapter.config = {"bot_pid": "test-bot"}
+
+    await adapter.stop()
+
+    updater_stop.assert_awaited_once()
+    application_stop.assert_awaited_once()
+    application_shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_attempts_http_client_shutdown_after_application_stop_failure():
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    updater_stop = AsyncMock()
+    application_stop = AsyncMock(side_effect=RuntimeError("application stop failed"))
+    application_shutdown = AsyncMock()
+    adapter.app = SimpleNamespace(
+        updater=SimpleNamespace(running=True, stop=updater_stop),
+        running=True,
+        stop=application_stop,
+        shutdown=application_shutdown,
+    )
+    adapter.config = {"bot_pid": "test-bot"}
+
+    await adapter.stop()
+
+    updater_stop.assert_awaited_once()
+    application_stop.assert_awaited_once()
+    application_shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_continues_after_application_stop_is_cancelled():
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    updater_stop = AsyncMock()
+    application_stop = AsyncMock(side_effect=asyncio.CancelledError())
+    application_shutdown = AsyncMock()
+    adapter.app = SimpleNamespace(
+        updater=SimpleNamespace(running=True, stop=updater_stop),
+        running=True,
+        stop=application_stop,
+        shutdown=application_shutdown,
+    )
+    adapter.config = {"bot_pid": "test-bot"}
+
+    await adapter.stop()
+
+    updater_stop.assert_awaited_once()
+    application_stop.assert_awaited_once()
+    application_shutdown.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes Telegram shutdown cleanup so a polling cancellation or pool timeout cannot skip application and HTTP-client teardown. Also suppresses the known harmless python-telegram-bot 21.3 shutdown cancellation traceback.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [x] test: Adding or updating tests

## Changes

- Reserve a second getUpdates connection and allow a longer pool wait during Telegram shutdown.
- Continue each shutdown phase independently so the HTTP client closes after an earlier failure or cancellation.
- Add regression coverage for connection-pool, application-stop, and cancellation paths.

## Screenshots / Logs

Not applicable; this change only affects application shutdown cleanup.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram adapter shutdown reliability when cancellation or component errors occur.
  * Suppressed expected polling cancellation errors from critical logs.
  * Ensured cleanup continues even when individual shutdown steps fail.

* **Performance & Reliability**
  * Configured dedicated update connection-pool capacity and timeout settings for more reliable polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->