### PR TITLE
feat: report launch source telemetry

### DIFF
--- a/core/telemetry/client.py
+++ b/core/telemetry/client.py
@@ -47,6 +47,7 @@ class TelemetryClient:
         self.client_uuid: Optional[str] = self.telemetry_config.get("client_uuid")
         self.secret_key: Optional[str] = self.telemetry_config.get("secret_key")
         self.machine_id: Optional[str] = None
+        self.launch_source = "launcher" if os.environ.get("KIRA_LAUNCH_SOURCE") == "launcher" else "core"
 
         self.server_url: str = os.environ.get("KIRA_TELEMETRY_SERVER", "https://telemetry.kira-ai.top/api/v1")
         self.heartbeat_interval: int = 300  # 5 minutes
@@ -140,7 +141,7 @@ class TelemetryClient:
             started_ts = self.stats.get_stats("started_ts") if self.stats else None
             if started_ts:
                 uptime_ms = int((datetime.now(timezone.utc).timestamp() - started_ts) * 1000)
-                self.send_event(TelemetryEventType.SYSTEM_SHUTDOWN, {"uptime_duration_ms": uptime_ms})
+                self.send_system_shutdown(uptime_ms)
 
             # Restart worker if it already exited but events remain in queue
             if self._worker_task is None or (self._worker_task.done() and not self._send_queue.empty()):
@@ -416,6 +417,7 @@ class TelemetryClient:
             "kira_ai_version": VERSION,
             "python_version": python_version or sys_platform.python_version(),
             "platform": sys_platform.platform(),
+            "launch_source": self.launch_source,
         }
         data.update(collect_system_profile())
         if self.machine_id:
@@ -427,6 +429,7 @@ class TelemetryClient:
     def send_system_shutdown(self, uptime_duration_ms: int) -> None:
         self.send_event(TelemetryEventType.SYSTEM_SHUTDOWN, {
             "uptime_duration_ms": uptime_duration_ms,
+            "launch_source": self.launch_source,
         })
 
     def send_heartbeat(self, uptime_ms: int, active_connections: int = 0) -> None:

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -51,29 +51,6 @@ def test_get_anonymous_machine_id_returns_none_when_unavailable():
         assert get_anonymous_machine_id() is None
 
 
-def test_system_startup_includes_system_profile():
-    telemetry = object.__new__(TelemetryClient)
-    telemetry.country_code = "CN"
-    telemetry.machine_id = "anonymous-machine-id"
-    telemetry.send_event = MagicMock()
-    profile = {
-        "memory_total_mb": 8192,
-        "cpu_physical_cores": 4,
-        "cpu_logical_cores": 8,
-        "architecture": "arm64",
-    }
-
-    with patch("core.telemetry.client.collect_system_profile", return_value=profile):
-        telemetry.send_system_startup(python_version="3.12.0")
-
-    event_type, data = telemetry.send_event.call_args.args
-    assert event_type == "system_startup"
-    assert data["python_version"] == "3.12.0"
-    assert data["country_code"] == "CN"
-    assert data["machine_id"] == "anonymous-machine-id"
-    assert {key: data[key] for key in profile} == profile
-
-
 def test_telemetry_payload_omits_machine_id_for_non_startup_event():
     telemetry = object.__new__(TelemetryClient)
     telemetry.client_uuid = "installation-id"

--- a/tests/test_system_routes.py
+++ b/tests/test_system_routes.py
@@ -1,0 +1,35 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+
+from webui.routes.system import SystemRoutes
+
+
+@pytest.mark.anyio
+async def test_shutdown_stops_the_lifecycle_and_schedules_normal_exit(monkeypatch):
+    scheduled = []
+
+    class Loop:
+        def call_later(self, delay, callback, *args):
+            scheduled.append((delay, callback, args))
+
+    class Lifecycle:
+        def __init__(self):
+            self.stopped = False
+            self.uvicorn_server = SimpleNamespace(should_exit=False)
+
+        async def stop(self):
+            self.stopped = True
+
+    lifecycle = Lifecycle()
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: Loop())
+    routes = SystemRoutes(FastAPI(), lifecycle)
+
+    response = await routes.shutdown()
+
+    assert response == {"status": "shutting_down"}
+    assert lifecycle.stopped is True
+    assert lifecycle.uvicorn_server.should_exit is True
+    assert scheduled == [(0.5, __import__("os")._exit, (0,))]

--- a/webui/routes/system.py
+++ b/webui/routes/system.py
@@ -18,6 +18,13 @@ class SystemRoutes(Routes):
                 tags=["system"],
                 dependencies=[Depends(require_auth)],
             ),
+            RouteDefinition(
+                path="/api/system/shutdown",
+                methods=["POST"],
+                endpoint=self.shutdown,
+                tags=["system"],
+                dependencies=[Depends(require_auth)],
+            ),
         ]
 
     async def restart(self):
@@ -28,3 +35,12 @@ class SystemRoutes(Routes):
         import asyncio
         asyncio.get_running_loop().call_later(0.5, os._exit, RESTART_EXIT_CODE)
         return {"status": "restarting"}
+
+    async def shutdown(self):
+        """Stop normally so the supervisor can exit with its child."""
+        await self.lifecycle.stop()
+        if self.lifecycle.uvicorn_server:
+            self.lifecycle.uvicorn_server.should_exit = True
+        import asyncio
+        asyncio.get_running_loop().call_later(0.5, os._exit, 0)
+        return {"status": "shutting_down"}


### PR DESCRIPTION
## Summary

Adds launch-channel attribution to lifecycle telemetry and a graceful shutdown endpoint for the launcher.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Read `KIRA_LAUNCH_SOURCE` and include `launch_source` in startup and shutdown telemetry events.
- Add an authenticated endpoint that performs lifecycle cleanup before the supervisor exits normally.
- Add coverage for the graceful shutdown route.

## Screenshots / Logs

Not applicable; focused route test passed.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint to safely shut down the application and report its shutdown status.
  - Startup and shutdown telemetry now identifies whether the application was launched directly or through the launcher.

- **Bug Fixes**
  - Improved shutdown handling to stop services, signal the server to exit, and complete the process termination sequence reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->