### PR TITLE
refactor(config): move field serialization to subclasses

### DIFF
--- a/core/config/config_field.py
+++ b/core/config/config_field.py
@@ -49,20 +49,6 @@ class BaseConfigField:
         }
         if self.locales:
             data["locales"] = self.locales
-        if isinstance(self, EnumField):
-            data["options"] = list(self.options)
-        if isinstance(self, MultiSelectField):
-            if getattr(self, "options", None):
-                data["options"] = list(self.options)
-        if isinstance(self, SectionField):
-            data["collapsed"] = self.collapsed
-            data["fields"] = {f.key: f.to_dict() for f in self.fields}
-        if isinstance(self, EditorField) and getattr(self, "language", None):
-            data["language"] = self.language
-        if isinstance(self, ModelSelectField) and getattr(self, "model_type", None):
-            data["model_type"] = self.model_type
-        if isinstance(self, InfoField):
-            data["level"] = self.level
         return data
 
 
@@ -109,6 +95,11 @@ class EnumField(BaseConfigField):
         super().__init__(key, name, hint, default if default in options else options[0], locales)
         self.options = list(options)
 
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data["options"] = list(self.options)
+        return data
+
 
 class SwitchField(BaseConfigField):
     type = ConfigType.Switch
@@ -145,6 +136,12 @@ class EditorField(BaseConfigField):
         super().__init__(key, name, hint, default, locales)
         self.language = language
 
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        if self.language:
+            data["language"] = self.language
+        return data
+
 
 class TextareaField(BaseConfigField):
     type = ConfigType.Textarea
@@ -160,6 +157,12 @@ class ModelSelectField(BaseConfigField):
         super().__init__(key, name, hint, default, locales)
         self.model_type = model_type
 
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        if self.model_type:
+            data["model_type"] = self.model_type
+        return data
+
 
 class MultiSelectField(BaseConfigField):
     type = ConfigType.MultiSelect
@@ -167,6 +170,12 @@ class MultiSelectField(BaseConfigField):
     def __init__(self, key: str, name: str, hint: str, options, default=None, locales: dict = None):
         super().__init__(key, name, hint, default if isinstance(default, list) else [], locales)
         self.options = list(options)
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        if self.options:
+            data["options"] = list(self.options)
+        return data
 
 
 class PersonaSelectField(BaseConfigField):
@@ -184,6 +193,12 @@ class SectionField(BaseConfigField):
         self.fields = fields or []
         self.collapsed = collapsed
 
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data["collapsed"] = self.collapsed
+        data["fields"] = {field.key: field.to_dict() for field in self.fields}
+        return data
+
 
 class InfoField(BaseConfigField):
     """Read-only informational field, no data storage."""
@@ -192,6 +207,11 @@ class InfoField(BaseConfigField):
     def __init__(self, key: str, name: str, hint: str, level: str = "info", locales: dict = None):
         super().__init__(key, name, hint, default=None, locales=locales)
         self.level = level
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data["level"] = self.level
+        return data
 
 
 def create_field_from_schema(key: str, schema: dict) -> BaseConfigField:

--- a/tests/test_config_field.py
+++ b/tests/test_config_field.py
@@ -17,6 +17,7 @@ from core.config.config_field import (
     ModelSelectField,
     MultiSelectField,
     SectionField,
+    InfoField,
     create_field_from_schema,
     build_fields,
 )
@@ -111,6 +112,11 @@ def test_multi_select_field():
     assert f.default == ["a"]
 
 
+def test_multi_select_field_omits_empty_options():
+    f = MultiSelectField("k", "Name", "hint", options=[])
+    assert "options" not in f.to_dict()
+
+
 def test_section_field():
     child = StringField("child_k", "Child", "hint", default="v")
     f = SectionField("sec", "Section", "hint", fields=[child], collapsed=True)
@@ -118,6 +124,11 @@ def test_section_field():
     assert d["collapsed"] is True
     assert "child_k" in d["fields"]
     assert d["fields"]["child_k"]["type"] == "string"
+
+
+def test_info_field():
+    f = InfoField("info", "Info", "hint", level="warning")
+    assert f.to_dict()["level"] == "warning"
 
 
 def test_locales_included():


### PR DESCRIPTION
## Summary

Refactor configuration-field serialization so each specialized field class owns its type-specific output while preserving the WebUI schema response.

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [x] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [x] test: Adding or updating tests

## Changes

- Keep shared configuration-field serialization in `BaseConfigField`.
- Override `to_dict()` in specialized field classes to append their own schema keys.
- Add coverage for empty multi-select options and informational field serialization.

## Screenshots / Logs

Not applicable; this is a backend serialization refactor. Local test result: `42 passed`.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration field serialization to preserve field-specific settings and output rules.
  * Empty multi-select options are now omitted from serialized configuration data.
  * Info field warning levels are preserved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->