### PR TITLE
feat: support uv in launch scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,24 @@ If your idea hasn't been proposed yet, feel free to open an issue. When proposin
 
 ### Backend
 
+The launch scripts automatically prefer `uv` when it is installed. They create a `venv` environment with Python 3.11 and retain pip so plugins can install runtime dependencies. For manual setup with uv:
+
+```bash
+uv venv venv --python 3.11 --seed
+```
+
+```powershell
+# Windows
+uv pip install --python .\venv\Scripts\python.exe -r requirements.txt
+```
+
+```bash
+# macOS / Linux
+uv pip install --python venv/bin/python -r requirements.txt
+```
+
+Without uv, use the existing Python and pip workflow:
+
 ```bash
 # Create and activate a virtual environment (recommended)
 python -m venv venv

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ KiraAI, a modular, multi-platform AI digital life that connects various AI model
 > [!NOTE]
 > For other deployment options, see the [Deployment Guide](https://docs.kira-ai.top/deployment/windows.html).
 
-First of all, you need to have Python 3.10+ installed and in the `PATH` environment variable
+First of all, install Python 3.10+ and add it to the `PATH` environment variable. Alternatively, install [uv](https://docs.astral.sh/uv/); it can provide the preferred Python 3.11 runtime automatically.
 
 Go to [Releases](https://github.com/KiraAI-Dev/KiraAI/releases) and download `Source code
 (zip)` from the release tagged latest
@@ -98,6 +98,28 @@ Re-run `npm run build` after pulling frontend changes.
 You can start KiraAI via (venv):
 - Batch script: `scripts\run.bat`
 - Linux script: `scripts/run.sh` (make executable first)
+
+When `uv` is installed, the scripts automatically use it. To create the same environment manually:
+
+```bash
+uv venv venv --python 3.11 --seed
+```
+
+Then install dependencies and start KiraAI:
+
+```powershell
+# Windows
+uv pip install --python .\venv\Scripts\python.exe -r requirements.txt
+.\venv\Scripts\python.exe main.py
+```
+
+```bash
+# macOS / Linux
+uv pip install --python venv/bin/python -r requirements.txt
+venv/bin/python main.py
+```
+
+`--seed` keeps `pip` in `venv`, which lets plugins install their own dependencies at runtime.
 
 Make Linux script executable and run:
 ```bash

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -52,7 +52,7 @@ KiraAI，一个模块化、跨平台的 AI 数字生命项目，以数字生命�
 > [!NOTE]
 > 如需使用其他部署方案，请参考 [部署文档](https://docs.kira-ai.top/zh/deployment/windows.html)
 
-首先，确保你的电脑中安装了 Python 3.10+ 并且添加到了 `PATH` 环境变量
+首先，确保你的电脑中安装了 Python 3.10+ 并且添加到了 `PATH` 环境变量。也可以安装 [uv](https://docs.astral.sh/uv/)；它可在需要时自动提供推荐的 Python 3.11 运行时。
 
 前往 [Releases](https://github.com/KiraAI-Dev/KiraAI/releases) 下载标记为 `latest` 的 Release 中的 `Source code
 (zip)`
@@ -97,6 +97,28 @@ python main.py --webui-dir webui/static/dist --ignore-webui-version-check
 可通过以下方式启动 KiraAI（venv）：
 - Windows 批处理：`scripts\run.bat`
 - Linux 脚本：`scripts/run.sh`（先赋予可执行权限）
+
+安装了 `uv` 时，启动脚本会自动使用它。若需要手动创建相同环境：
+
+```bash
+uv venv venv --python 3.11 --seed
+```
+
+随后安装依赖并启动 KiraAI：
+
+```powershell
+# Windows
+uv pip install --python .\venv\Scripts\python.exe -r requirements.txt
+.\venv\Scripts\python.exe main.py
+```
+
+```bash
+# macOS / Linux
+uv pip install --python venv/bin/python -r requirements.txt
+venv/bin/python main.py
+```
+
+`--seed` 会在 `venv` 中保留 `pip`，以便插件在运行时安装其自身依赖。
 
 Linux 赋权并运行：
 ```bash

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -19,33 +19,9 @@ if not errorlevel 1 (
     echo uv not found. Falling back to the system Python.
 )
 
-if not exist "venv" (
-    echo [1/3] Creating virtual environment...
-    if "!USE_UV!"=="1" (
-        uv venv venv --python 3.11 --seed
-    ) else (
-        python -m venv venv
-    )
-    if errorlevel 1 (
-        echo Failed to create virtual environment.
-        pause
-        exit /b 1
-    )
-) else (
-    echo Virtual environment already exists.
-)
+echo [1/4] Testing pip mirrors...
 
-echo [2/3] Activating virtual environment...
-call .\venv\Scripts\activate.bat
-if errorlevel 1 (
-    echo Failed to activate virtual environment.
-    pause
-    exit /b 1
-)
-
-echo [3/3] Testing pip mirrors...
-
-set "MIRROR="
+set "MIRROR_URL="
 set "BEST_SPEED=0"
 
 for %%M in (
@@ -62,8 +38,50 @@ for %%M in (
 )
 
 echo.
-if defined MIRROR (
-    echo   Selected: !MIRROR!
+if defined MIRROR_URL (
+    echo   Selected: !MIRROR_URL!
+) else (
+    echo   No package index is reachable.
+)
+
+if not exist "venv" (
+    echo [2/4] Creating virtual environment...
+    if "!USE_UV!"=="1" (
+        if defined MIRROR_URL (
+            uv venv venv --python 3.11 --seed --index-url "!MIRROR_URL!"
+            if errorlevel 1 (
+                echo uv failed to create the virtual environment. Falling back to the system Python.
+                set "USE_UV=0"
+                python -m venv --clear venv
+            )
+        ) else (
+            echo Skipping uv environment creation because no package index was selected.
+            set "USE_UV=0"
+            python -m venv venv
+        )
+    ) else (
+        python -m venv venv
+    )
+    if errorlevel 1 (
+        echo Failed to create virtual environment.
+        pause
+        exit /b 1
+    )
+) else (
+    echo Virtual environment already exists.
+)
+
+echo [3/4] Activating virtual environment...
+call .\venv\Scripts\activate.bat
+if errorlevel 1 (
+    echo Failed to activate virtual environment.
+    pause
+    exit /b 1
+)
+
+echo [4/4] Installing dependencies...
+if defined MIRROR_URL (
+    set "MIRROR=-i !MIRROR_URL!"
 ) else (
     echo   All mirrors unreachable, using default PyPI.
     set "MIRROR=-i https://pypi.org/simple/"
@@ -103,7 +121,7 @@ if defined OK (
     call :parse_ms "!T!" MS
     call :format_speed !SPEED_INT! FMT
     echo     !NAME! ... !MS!ms, !FMT!
-    if !SPEED_INT! gtr !BEST_SPEED! (set "BEST_SPEED=!SPEED_INT!" & set "MIRROR=-i !URL!")
+    if !SPEED_INT! gtr !BEST_SPEED! (set "BEST_SPEED=!SPEED_INT!" & set "MIRROR_URL=!URL!")
 ) else (
     echo     !NAME! ... unreachable
 )

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -14,7 +14,7 @@ set "USE_UV=0"
 where uv >nul 2>nul
 if not errorlevel 1 (
     set "USE_UV=1"
-    echo uv detected. Using uv with Python 3.11.
+    echo uv detected. Using uv.
 ) else (
     echo uv not found. Falling back to the system Python.
 )

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -10,9 +10,22 @@ if exist ".venv" if not exist "venv" (
     rename .venv venv
 )
 
+set "USE_UV=0"
+where uv >nul 2>nul
+if not errorlevel 1 (
+    set "USE_UV=1"
+    echo uv detected. Using uv with Python 3.11.
+) else (
+    echo uv not found. Falling back to the system Python.
+)
+
 if not exist "venv" (
     echo [1/3] Creating virtual environment...
-    python -m venv venv
+    if "!USE_UV!"=="1" (
+        uv venv venv --python 3.11 --seed
+    ) else (
+        python -m venv venv
+    )
     if errorlevel 1 (
         echo Failed to create virtual environment.
         pause
@@ -56,13 +69,22 @@ if defined MIRROR (
     set "MIRROR=-i https://pypi.org/simple/"
 )
 
-python -m pip install --upgrade pip !MIRROR!
+if "!USE_UV!"=="1" (
+    uv pip install --python ".\venv\Scripts\python.exe" --upgrade pip !MIRROR!
+) else (
+    python -m pip install --upgrade pip !MIRROR!
+)
 if errorlevel 1 (
     echo Failed to upgrade pip.
     pause
     exit /b 1
 )
-pip install -r requirements.txt !MIRROR!
+
+if "!USE_UV!"=="1" (
+    uv pip install --python ".\venv\Scripts\python.exe" -r requirements.txt !MIRROR!
+) else (
+    python -m pip install -r requirements.txt !MIRROR!
+)
 if errorlevel 1 (
     echo Failed to install dependencies.
     pause

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -15,7 +15,7 @@ fi
 USE_UV=0
 if command -v uv >/dev/null 2>&1; then
   USE_UV=1
-  echo "uv detected. Using uv with Python 3.11."
+  echo "uv detected. Using uv."
 else
   echo "uv not found. Falling back to the system Python."
 fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,6 +12,14 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN="python"
 fi
 
+USE_UV=0
+if command -v uv >/dev/null 2>&1; then
+  USE_UV=1
+  echo "uv detected. Using uv with Python 3.11."
+else
+  echo "uv not found. Falling back to the system Python."
+fi
+
 # Step 1: Migrate .venv -> venv (backward compatibility)
 if [ -d .venv ] && [ ! -d venv ]; then
   echo "[compat] Renaming .venv to venv..."
@@ -21,7 +29,11 @@ fi
 # Step 1: Create venv if missing
 if [ ! -d venv ]; then
   echo "[1/3] Creating virtual environment..."
-  "$PYTHON_BIN" -m venv venv
+  if [ "$USE_UV" -eq 1 ]; then
+    uv venv venv --python 3.11 --seed
+  else
+    "$PYTHON_BIN" -m venv venv
+  fi
 else
   echo "Virtual environment already exists."
 fi
@@ -80,9 +92,18 @@ else
   MIRROR="-i https://pypi.org/simple/"
 fi
 
-python -m pip install --upgrade pip $MIRROR
+if [ "$USE_UV" -eq 1 ]; then
+  uv pip install --python "venv/bin/python" --upgrade pip $MIRROR
+else
+  python -m pip install --upgrade pip $MIRROR
+fi
+
 if [ -f requirements.txt ]; then
-  pip install -r requirements.txt $MIRROR
+  if [ "$USE_UV" -eq 1 ]; then
+    uv pip install --python "venv/bin/python" -r requirements.txt $MIRROR
+  else
+    python -m pip install -r requirements.txt $MIRROR
+  fi
 else
   echo "requirements.txt not found, skipping dependency installation."
 fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -26,27 +26,7 @@ if [ -d .venv ] && [ ! -d venv ]; then
   mv .venv venv
 fi
 
-# Step 1: Create venv if missing
-if [ ! -d venv ]; then
-  echo "[1/3] Creating virtual environment..."
-  if [ "$USE_UV" -eq 1 ]; then
-    uv venv venv --python 3.11 --seed
-  else
-    "$PYTHON_BIN" -m venv venv
-  fi
-else
-  echo "Virtual environment already exists."
-fi
-
-# Step 2: Activate venv
-echo "[2/3] Activating virtual environment..."
-# shellcheck disable=SC1091
-source venv/bin/activate
-
-# Step 3: Test pip mirrors and select fastest
-echo "[3/3] Testing pip mirrors..."
-
-MIRROR=""
+MIRROR_URL=""
 BEST_SPEED=0
 
 test_mirror() {
@@ -72,21 +52,57 @@ test_mirror() {
     echo "    $name ... ${ms}ms, $fmt_speed"
     if (( speed_int > BEST_SPEED )); then
       BEST_SPEED=$speed_int
-      MIRROR="-i $url"
+      MIRROR_URL="$url"
     fi
   else
     echo "    $name ... unreachable"
   fi
 }
 
+echo "[1/4] Testing pip mirrors..."
 test_mirror "pypi.org" "https://pypi.org/simple/"
 test_mirror "pypi.tuna.tsinghua.edu.cn" "https://pypi.tuna.tsinghua.edu.cn/simple/"
 test_mirror "mirrors.aliyun.com" "https://mirrors.aliyun.com/pypi/simple/"
 test_mirror "mirrors.cloud.tencent.com" "https://mirrors.cloud.tencent.com/pypi/simple/"
 
 echo
-if [ -n "$MIRROR" ]; then
-  echo "  Selected: $MIRROR"
+if [ -n "$MIRROR_URL" ]; then
+  echo "  Selected: $MIRROR_URL"
+else
+  echo "  No package index is reachable."
+fi
+
+# Step 1: Create venv if missing
+if [ ! -d venv ]; then
+  echo "[2/4] Creating virtual environment..."
+  if [ "$USE_UV" -eq 1 ]; then
+    if [ -n "$MIRROR_URL" ]; then
+      if ! uv venv venv --python 3.11 --seed --index-url "$MIRROR_URL"; then
+        echo "uv failed to create the virtual environment. Falling back to the system Python."
+        USE_UV=0
+        "$PYTHON_BIN" -m venv --clear venv
+      fi
+    else
+      echo "Skipping uv environment creation because no package index was selected."
+      USE_UV=0
+      "$PYTHON_BIN" -m venv venv
+    fi
+  else
+    "$PYTHON_BIN" -m venv venv
+  fi
+else
+  echo "Virtual environment already exists."
+fi
+
+# Step 2: Activate venv
+echo "[3/4] Activating virtual environment..."
+# shellcheck disable=SC1091
+source venv/bin/activate
+
+# Step 3: Install dependencies
+echo "[4/4] Installing dependencies..."
+if [ -n "$MIRROR_URL" ]; then
+  MIRROR="-i $MIRROR_URL"
 else
   echo "  All mirrors unreachable, using default PyPI."
   MIRROR="-i https://pypi.org/simple/"


### PR DESCRIPTION
## Summary

Add uv-first support to the launcher scripts while preserving the existing Python and pip fallback. This lets users who already have uv create a seeded `venv` and install base dependencies with uv, without changing runtime plugin dependency installation.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [x] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Prefer uv in the Windows and macOS/Linux launcher scripts when it is available.
- Create a new `venv` with Python 3.11 and seeded pip; reuse any existing `venv` unchanged.
- Retain the existing system Python and pip path when uv is unavailable.
- Document automatic and manual uv startup in the English, Chinese, and contributor guides.

## Screenshots / Logs

Not applicable for launcher and documentation changes.

Validated with `bash -n scripts/run.sh` and `git diff --check`.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup guides in English and Chinese with `uv` installation and manual environment setup instructions.
  - Clarified supported Python versions, platform-specific commands, and the purpose of the `--seed` option.

- **New Features**
  - Startup scripts now automatically use `uv` with Python 3.11 when available.
  - Retained the existing Python and pip workflow as a fallback when `uv` is not installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->