### PR TITLE
feat: add OpenAI speech-to-text support

### DIFF
--- a/core/provider/src/openai/provider.py
+++ b/core/provider/src/openai/provider.py
@@ -3,13 +3,18 @@ import httpx
 from core.provider import ModelType, BaseProvider
 
 from .model_clients import OpenAIImageClient, OpenAIEmbeddingClient
-from core.utils.model_clients import OpenAICompatibleLLMClient, OpenAICompatibleTTSClient
+from core.utils.model_clients import (
+    OpenAICompatibleLLMClient,
+    OpenAICompatibleSTTClient,
+    OpenAICompatibleTTSClient,
+)
 
 
 class OpenAIProvider(BaseProvider):
     models = {
         ModelType.LLM: OpenAICompatibleLLMClient,
         ModelType.TTS: OpenAICompatibleTTSClient,
+        ModelType.STT: OpenAICompatibleSTTClient,
         ModelType.IMAGE: OpenAIImageClient,
         ModelType.EMBEDDING: OpenAIEmbeddingClient
     }

--- a/core/provider/src/openai/schema.json
+++ b/core/provider/src/openai/schema.json
@@ -83,6 +83,36 @@
         }
       }
     },
+    "stt": {
+      "timeout": {
+        "name": "Timeout",
+        "type": "integer",
+        "default": 120,
+        "min": 1,
+        "hint": "Request timeout in seconds",
+        "locales": {
+          "zh": { "name": "超时", "hint": "请求超时时间（秒）" }
+        }
+      },
+      "language": {
+        "name": "Language",
+        "type": "string",
+        "default": null,
+        "hint": "Optional ISO-639-1 language code to improve transcription accuracy",
+        "locales": {
+          "zh": { "name": "语言", "hint": "可选的 ISO-639-1 语言代码，用于提高转写准确度" }
+        }
+      },
+      "prompt": {
+        "name": "Prompt",
+        "type": "string",
+        "default": null,
+        "hint": "Optional guidance for transcription style or vocabulary",
+        "locales": {
+          "zh": { "name": "提示词", "hint": "可选的转写风格或词汇提示" }
+        }
+      }
+    },
     "image": {
       "timeout": {
         "name": "Timeout",

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -1,10 +1,11 @@
 from openai import AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionError, NOT_GIVEN
 import base64
 import time
+from pathlib import Path
 from typing import AsyncGenerator, Optional
 
 from core.provider import ModelInfo
-from core.provider import LLMModelClient, TTSModelClient, ImageModelClient, EmbeddingModelClient
+from core.provider import LLMModelClient, TTSModelClient, STTModelClient, ImageModelClient, EmbeddingModelClient
 from core.provider.llm_model import LLMRequest, LLMResponse, LLMStreamChunk
 from core.chat.message_elements import Record
 from core.config.default import VERSION
@@ -224,3 +225,52 @@ class OpenAICompatibleTTSClient(TTSModelClient):
 
         b64_str = base64.b64encode(audio_bytes).decode("utf-8")
         return Record(record=b64_str)
+
+
+class OpenAICompatibleSTTClient(STTModelClient):
+    """Speech-to-text client for OpenAI-compatible transcription APIs."""
+
+    def __init__(self, model: ModelInfo):
+        super().__init__(model)
+
+    def _build_client(self) -> AsyncOpenAI:
+        provider_config = self.model.provider_config or {}
+        model_config = self.model.model_config or {}
+        section_advanced = provider_config.get("section_advanced")
+        default_headers = section_advanced.get("headers", {}) if isinstance(section_advanced, dict) else {}
+        if not isinstance(default_headers, dict) or not default_headers:
+            default_headers = None
+        timeout = model_config.get("timeout", 120)
+        return AsyncOpenAI(
+            api_key=provider_config.get("api_key", ""),
+            base_url=provider_config.get("base_url", ""),
+            default_headers=default_headers,
+            timeout=timeout,
+        )
+
+    def _build_request_kwargs(self, record_path: str, **overrides) -> dict:
+        model_config = self.model.model_config or {}
+        request_kwargs = {
+            "model": self.model.model_id,
+            "file": Path(record_path),
+        }
+        for field in ("language", "prompt"):
+            value = model_config.get(field)
+            if value:
+                request_kwargs[field] = value
+        request_kwargs.update(overrides)
+        return request_kwargs
+
+    async def speech_to_text(self, record: Record, **kwargs) -> str:
+        if record is None:
+            return ""
+
+        record_path = await record.to_path()
+        if not record_path:
+            raise ValueError("Speech recognition received an empty audio record")
+
+        client = self._build_client()
+        response = await client.audio.transcriptions.create(
+            **self._build_request_kwargs(record_path, **kwargs)
+        )
+        return response.text or ""

--- a/tests/test_openai_stt_client.py
+++ b/tests/test_openai_stt_client.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core.provider import ModelInfo, ModelType
+from core.utils.model_clients import OpenAICompatibleSTTClient
+
+
+class _FakeTranscriptions:
+    def __init__(self):
+        self.kwargs = None
+
+    async def create(self, **kwargs):
+        self.kwargs = kwargs
+        return SimpleNamespace(text="transcribed text")
+
+
+class _FakeRecord:
+    def __init__(self, path: str):
+        self.path = path
+
+    async def to_path(self) -> str:
+        return self.path
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_stt_sends_audio_path_and_optional_settings(tmp_path):
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"audio")
+    transcriptions = _FakeTranscriptions()
+    client = OpenAICompatibleSTTClient(
+        ModelInfo(
+            model_type=ModelType.STT,
+            model_id="transcription-model",
+            provider_id="test-provider",
+            provider_name="Test Provider",
+            model_config={"language": "zh", "prompt": "Names: KiraAI"},
+        )
+    )
+    client._build_client = lambda: SimpleNamespace(
+        audio=SimpleNamespace(transcriptions=transcriptions)
+    )
+
+    text = await client.speech_to_text(_FakeRecord(str(audio_path)))
+
+    assert text == "transcribed text"
+    assert transcriptions.kwargs == {
+        "model": "transcription-model",
+        "file": Path(audio_path),
+        "language": "zh",
+        "prompt": "Names: KiraAI",
+    }
+
+
+def test_openai_compatible_stt_omits_empty_optional_settings():
+    client = OpenAICompatibleSTTClient(
+        ModelInfo(
+            model_type=ModelType.STT,
+            model_id="transcription-model",
+            provider_id="test-provider",
+            provider_name="Test Provider",
+            model_config=None,
+        )
+    )
+
+    assert client._build_request_kwargs("C:/audio.wav") == {
+        "model": "transcription-model",
+        "file": Path("C:/audio.wav"),
+    }


### PR DESCRIPTION
## Summary

Adds OpenAI-compatible speech-to-text support so an OpenAI provider instance can transcribe incoming voice messages through the audio transcriptions API.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [x] test: Adding or updating tests

## Changes

- Add a reusable OpenAI-compatible STT model client in `core/utils/model_clients.py`.
- Register STT support in the OpenAI provider and expose timeout, language, and prompt settings.
- Add unit coverage for transcription request construction and optional settings.

## Screenshots / Logs

Not applicable: this is a backend provider capability. Relevant OpenAI tests: 8 passed.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAI-compatible speech-to-text models.
  * Added speech-to-text configuration options for timeout, language, and transcription prompts.
  * Audio transcription now supports optional language and prompt settings.

* **Bug Fixes**
  * Improved handling of empty audio input by returning an empty transcription or reporting invalid paths clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->