### PR TITLE
feat(openai): support extra TTS request body

### DIFF
--- a/core/provider/src/openai/schema.json
+++ b/core/provider/src/openai/schema.json
@@ -113,6 +113,28 @@
         }
       }
     },
+    "tts": {
+      "section_advanced": {
+        "type": "section",
+        "name": "Advanced Settings",
+        "hint": "Advanced model configuration options",
+        "collapsed": true,
+        "locales": {
+          "zh": { "name": "高级设置", "hint": "高级模型配置选项" }
+        },
+        "fields": {
+          "extra_body": {
+            "name": "Extra Body",
+            "type": "json",
+            "default": {},
+            "hint": "Additional fields merged into the request body (JSON object)",
+            "locales": {
+              "zh": { "name": "自定义请求体", "hint": "合并到请求体中的额外字段（JSON 对象）" }
+            }
+          }
+        }
+      }
+    },
     "image": {
       "timeout": {
         "name": "Timeout",

--- a/core/utils/model_clients.py
+++ b/core/utils/model_clients.py
@@ -202,6 +202,22 @@ class OpenAICompatibleTTSClient(TTSModelClient):
     def __init__(self, model: ModelInfo):
         super().__init__(model)
 
+    def _build_request_kwargs(self, text: str, **overrides) -> dict:
+        model_config = self.model.model_config or {}
+        section_advanced = model_config.get("section_advanced") or {}
+        extra_body = section_advanced.get("extra_body")
+
+        request_kwargs = {
+            "model": self.model.model_id,
+            "voice": model_config.get("voice_name", ""),
+            "input": text,
+            "response_format": "mp3",
+        }
+        if isinstance(extra_body, dict) and extra_body:
+            request_kwargs["extra_body"] = extra_body
+        request_kwargs.update(overrides)
+        return request_kwargs
+
     async def text_to_speech(self, text: str, **kwargs) -> Record:
         section_advanced = self.model.provider_config.get("section_advanced")
         default_headers = section_advanced.get("headers", {}) if isinstance(section_advanced, dict) else {}
@@ -214,10 +230,7 @@ class OpenAICompatibleTTSClient(TTSModelClient):
         )
 
         async with client.audio.speech.with_streaming_response.create(
-                model=self.model.model_id,
-                voice=self.model.model_config.get("voice_name", ""),
-                input=text,
-                response_format="mp3"
+                **self._build_request_kwargs(text, **kwargs)
         ) as response:
             audio_bytes = b""
             async for chunk in response.iter_bytes():

--- a/tests/test_openai_tts_client.py
+++ b/tests/test_openai_tts_client.py
@@ -1,0 +1,39 @@
+from core.provider import ModelInfo, ModelType
+from core.utils.model_clients import OpenAICompatibleTTSClient
+
+
+def test_openai_compatible_tts_sends_extra_body_from_advanced_settings():
+    client = OpenAICompatibleTTSClient(
+        ModelInfo(
+            model_type=ModelType.TTS,
+            model_id="tts-model",
+            provider_id="test-provider",
+            provider_name="Test Provider",
+            model_config={
+                "voice_name": "alloy",
+                "section_advanced": {"extra_body": {"speed": 1.2}},
+            },
+        )
+    )
+
+    assert client._build_request_kwargs("Hello") == {
+        "model": "tts-model",
+        "voice": "alloy",
+        "input": "Hello",
+        "response_format": "mp3",
+        "extra_body": {"speed": 1.2},
+    }
+
+
+def test_openai_compatible_tts_omits_empty_extra_body():
+    client = OpenAICompatibleTTSClient(
+        ModelInfo(
+            model_type=ModelType.TTS,
+            model_id="tts-model",
+            provider_id="test-provider",
+            provider_name="Test Provider",
+            model_config={"section_advanced": {"extra_body": {}}},
+        )
+    )
+
+    assert "extra_body" not in client._build_request_kwargs("Hello")


### PR DESCRIPTION
## Summary

Add an Advanced Settings JSON field for OpenAI-compatible TTS models. Non-empty values are forwarded as `extra_body` to the speech synthesis request, allowing compatible providers to receive custom TTS parameters.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [x] test: Adding or updating tests

## Changes

- Add the OpenAI TTS Advanced Settings > Extra Body JSON configuration field.
- Forward non-empty TTS `extra_body` values to `audio.speech.create`.
- Add unit tests for forwarding and omitting empty request bodies.

## Screenshots / Logs

Not applicable (provider schema and backend request construction only).

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes
