### PR TITLE
feat(plugin): support dynamic provider and adapter registration

### DIFF
--- a/core/adapter/adapter_registry.py
+++ b/core/adapter/adapter_registry.py
@@ -64,6 +64,43 @@ class AdapterManager:
             manifest_dir, manifest.get("icon-dark" if dark else "icon"),
         )
 
+    @classmethod
+    def register_adapter_type(cls, platform: str, adapter_cls: Type[Union[IMAdapter, SocialMediaAdapter]], manifest: dict, manifest_dir: Path, schema: Optional[list[BaseConfigField]] = None) -> None:
+        """Register an Adapter type supplied by a plugin."""
+        if not isinstance(platform, str) or not platform.strip():
+            raise ValueError("Adapter platform must be a non-empty string")
+        if not inspect.isclass(adapter_cls) or not issubclass(adapter_cls, (IMAdapter, SocialMediaAdapter)):
+            raise TypeError("Adapter class must inherit from IMAdapter or SocialMediaAdapter")
+        if not isinstance(manifest, dict) or (schema is not None and not isinstance(schema, list)):
+            raise TypeError("Adapter manifest must be a dict and schema must be a list")
+        platform = platform.strip()
+        existing = cls._registry.get(platform)
+        if existing is not None and existing is not adapter_cls:
+            raise ValueError(f"Adapter platform '{platform}' is already registered")
+        cls._registry[platform] = adapter_cls
+        cls._manifests[platform] = manifest.copy()
+        cls._manifest_dirs[platform] = Path(manifest_dir)
+        cls._schemas[platform] = copy.deepcopy(schema) if schema else []
+
+    @classmethod
+    def unregister_adapter_type(cls, platform: str, adapter_cls: Type[Union[IMAdapter, SocialMediaAdapter]]) -> bool:
+        """Remove a plugin Adapter type without affecting another owner."""
+        if cls._registry.get(platform) is not adapter_cls:
+            return False
+        cls._registry.pop(platform, None)
+        cls._manifests.pop(platform, None)
+        cls._manifest_dirs.pop(platform, None)
+        cls._schemas.pop(platform, None)
+        return True
+
+    async def stop_adapter_instances_by_platform(self, platform: str) -> int:
+        """Stop runtime instances while preserving their stored configuration."""
+        stopped = 0
+        for name, adapter in list(self._adapters.items()):
+            if getattr(getattr(adapter, "info", None), "platform", None) == platform:
+                await self.stop_adapter(name)
+                stopped += 1
+        return stopped
     def get_adapter_info(self, adapter_id: str) -> Optional[AdapterInfo]:
         adapters_config = self.kira_config.get("adapters", {})
         config_entry = adapters_config.get(adapter_id)

--- a/core/adapter/adapter_registry.py
+++ b/core/adapter/adapter_registry.py
@@ -32,6 +32,7 @@ class AdapterManager:
     def __init__(self, kira_config: KiraConfig, event_queue: asyncio.Queue):
         self.kira_config = kira_config
         self._adapters: dict[str, Union[IMAdapter, SocialMediaAdapter]] = {}
+        self._adapter_tasks: dict[str, asyncio.Task] = {}
         self.adas_config: dict = kira_config.get("adapters", {}) or {}
         self.event_queue = event_queue
 
@@ -473,6 +474,51 @@ class AdapterManager:
         logger.info(f"Adapter configuration saved for {name_for_runtime}")
         return info
 
+    def _handle_adapter_start_failure(
+        self,
+        name: str,
+        adapter: Union[IMAdapter, SocialMediaAdapter],
+        error: BaseException,
+    ) -> None:
+        """Remove a failed adapter and persist it as disabled when possible."""
+        if self._adapters.get(name) is adapter:
+            self._adapters.pop(name, None)
+
+        adapter_id = getattr(getattr(adapter, "info", None), "adapter_id", None)
+        if not adapter_id:
+            return
+        adapters_config = self.kira_config.get("adapters", {}) or {}
+        config_entry = adapters_config.get(adapter_id)
+        if not isinstance(config_entry, dict):
+            return
+        config_entry["enabled"] = False
+        adapters_config[adapter_id] = config_entry
+        self.kira_config["adapters"] = adapters_config
+        self.adas_config = adapters_config
+        try:
+            self.kira_config.save_config()
+        except Exception as exc:
+            logger.error(f"Failed to persist disabled adapter {adapter_id}: {exc}")
+        logger.error(f"Adapter {name} stopped after a start failure: {error}")
+
+    def _handle_adapter_start_task_completion(
+        self,
+        name: str,
+        adapter: Union[IMAdapter, SocialMediaAdapter],
+        task: asyncio.Task,
+    ) -> None:
+        """Release a completed startup task and record asynchronous failures."""
+        if self._adapter_tasks.get(name) is task:
+            self._adapter_tasks.pop(name, None)
+        if task.cancelled():
+            logger.info(f"Adapter {name} start task was cancelled")
+            return
+        try:
+            task.result()
+            logger.info(f"Started adapter {name}")
+        except Exception as exc:
+            self._handle_adapter_start_failure(name, adapter, exc)
+
     async def register_adapter(self, info: AdapterInfo):
         platform = info.platform
         name = info.name or info.adapter_id
@@ -504,30 +550,34 @@ class AdapterManager:
             raise
 
     async def start_adapter(self, name: str):
-        """Start an adapter by specified adapter name."""
+        """Start an adapter and retain its task until startup completes."""
         adapter = self._adapters.get(name)
         if not adapter:
             raise KeyError(f"Adapter {name} is not registered")
 
         task = asyncio.create_task(adapter.start())
+        self._adapter_tasks[name] = task
+        task.add_done_callback(
+            lambda completed_task: self._handle_adapter_start_task_completion(
+                name, adapter, completed_task
+            )
+        )
         await asyncio.sleep(0)
         if task.done():
             task.result()
 
-        def log_completion(completed_task: asyncio.Task):
-            if completed_task.cancelled():
-                logger.info(f"Adapter {name} start task was cancelled")
-                return
-            try:
-                completed_task.result()
-                logger.info(f"Started adapter {name}")
-            except Exception as exc:
-                logger.error(f"Adapter {name} stopped after a start failure: {exc}")
-
-        task.add_done_callback(log_completion)
-
     async def stop_adapter(self, name: str):
-        """stop an adapter by specified adapter name"""
+        """Stop an adapter and cancel any still-running startup task."""
+        task = self._adapter_tasks.pop(name, None)
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                logger.error(f"Adapter {name} failed while stopping its start task: {exc}")
+
         adapter = self._adapters.get(name)
         if adapter:
             await adapter.stop()

--- a/core/adapter/adapter_registry.py
+++ b/core/adapter/adapter_registry.py
@@ -336,6 +336,8 @@ class AdapterManager:
             logger.error(f"Adapter config not found after generation for {adapter_id}")
             return None
 
+        old_entry = copy.deepcopy(config_entry)
+
         if config:
             entry_config = config_entry.get("config") or {}
             entry_config.update(config)
@@ -348,6 +350,18 @@ class AdapterManager:
         enabled = status == "active"
         config_entry["enabled"] = enabled
 
+        if enabled:
+            try:
+                info = self.get_adapter_info(adapter_id)
+                if not info:
+                    raise RuntimeError(f"Failed to read adapter info for {adapter_id}")
+                await self.register_adapter(info)
+            except Exception:
+                adapters_config[adapter_id] = old_entry
+                self.kira_config["adapters"] = adapters_config
+                self.adas_config = adapters_config
+                raise
+
         adapters_config[adapter_id] = config_entry
         self.kira_config["adapters"] = adapters_config
         try:
@@ -358,13 +372,6 @@ class AdapterManager:
 
         self.adas_config = adapters_config
 
-        if enabled:
-            try:
-                info = self.get_adapter_info(adapter_id)
-                if info:
-                    await self.register_adapter(info)
-            except Exception as e:
-                logger.error(f"Failed to start adapter {adapter_id} after creation: {e}")
 
         info = self.get_adapter_info(adapter_id)
         if not info:
@@ -387,6 +394,7 @@ class AdapterManager:
             return None
 
         old_enabled = bool(config_entry.get("enabled", False))
+        old_entry = copy.deepcopy(config_entry)
         old_config = copy.deepcopy(config_entry.get("config") or {})
         old_name = config_entry.get("name") or adapter_id
         old_desc = config_entry.get("desc") or ""
@@ -411,6 +419,21 @@ class AdapterManager:
         if status:
             config_entry["enabled"] = status == "active"
 
+        new_enabled = bool(config_entry.get("enabled", False))
+        name_for_runtime = config_entry.get("name") or adapter_id
+
+        if new_enabled and not old_enabled:
+            try:
+                info = self.get_adapter_info(adapter_id)
+                if not info:
+                    raise RuntimeError(f"Failed to read adapter info for {adapter_id}")
+                await self.register_adapter(info)
+            except Exception:
+                adapters_config[adapter_id] = old_entry
+                self.kira_config["adapters"] = adapters_config
+                self.adas_config = adapters_config
+                raise
+
         adapters_config[adapter_id] = config_entry
         self.kira_config["adapters"] = adapters_config
         try:
@@ -420,17 +443,6 @@ class AdapterManager:
             return None
 
         self.adas_config = adapters_config
-
-        new_enabled = bool(config_entry.get("enabled", False))
-        name_for_runtime = config_entry.get("name") or adapter_id
-
-        if new_enabled and not old_enabled:
-            try:
-                info = self.get_adapter_info(adapter_id)
-                if info:
-                    await self.register_adapter(info)
-            except Exception as e:
-                logger.error(f"Failed to start adapter {adapter_id} after update: {e}")
 
         if old_enabled and new_enabled:
             new_config = config_entry.get("config") or {}
@@ -465,13 +477,11 @@ class AdapterManager:
         platform = info.platform
         name = info.name or info.adapter_id
         if not platform:
-            logger.error(f"Adapter {name} has no platform configured")
-            return
+            raise ValueError(f"Adapter {name} has no platform configured")
 
         adapter_cls = self.get_adapter_class(platform)
         if not adapter_cls:
-            logger.error(f"No adapter registered for platform {platform}")
-            return
+            raise ValueError(f"No adapter registered for platform {platform}")
 
         if not info.enabled:
             return
@@ -482,22 +492,39 @@ class AdapterManager:
             elif issubclass(adapter_cls, SocialMediaAdapter):
                 instance = adapter_cls(info, self.event_queue)
             else:
-                logger.error(f"Adapter class for platform {platform} is not a valid adapter type")
-                return
+                raise TypeError(f"Adapter class for platform {platform} is not a valid adapter type")
         except Exception as e:
-            logger.error(f"Failed to instantiate adapter {name}: {e}")
-            return
+            raise RuntimeError(f"Failed to instantiate adapter {name}") from e
 
         self._adapters[name] = instance
-        await self.start_adapter(name)
-
-    async def start_adapter(self, name):
-        """start an adapter by specified adapter name"""
         try:
-            task = asyncio.create_task(self._adapters[name].start())
-            task.add_done_callback(lambda t: logger.info(f"Started adapter {name}"))
-        except Exception as e:
-            logger.error(f"Failed to start adapter {name}: {e}")
+            await self.start_adapter(name)
+        except Exception:
+            self._adapters.pop(name, None)
+            raise
+
+    async def start_adapter(self, name: str):
+        """Start an adapter by specified adapter name."""
+        adapter = self._adapters.get(name)
+        if not adapter:
+            raise KeyError(f"Adapter {name} is not registered")
+
+        task = asyncio.create_task(adapter.start())
+        await asyncio.sleep(0)
+        if task.done():
+            task.result()
+
+        def log_completion(completed_task: asyncio.Task):
+            if completed_task.cancelled():
+                logger.info(f"Adapter {name} start task was cancelled")
+                return
+            try:
+                completed_task.result()
+                logger.info(f"Started adapter {name}")
+            except Exception as exc:
+                logger.error(f"Adapter {name} stopped after a start failure: {exc}")
+
+        task.add_done_callback(log_completion)
 
     async def stop_adapter(self, name: str):
         """stop an adapter by specified adapter name"""

--- a/core/plugin/plugin_context.py
+++ b/core/plugin/plugin_context.py
@@ -116,6 +116,49 @@ class PluginContext:
             return client
         return
 
+    async def register_provider(self, relative_path: str) -> str:
+        """Register a Provider directory for the calling plugin."""
+        frame = inspect.currentframe().f_back
+        plugin_id = None
+        if frame and self.plugin_mgr:
+            module_name = frame.f_globals.get("__name__", "")
+            plugin_id = self.plugin_mgr.get_plugin_id_for_module(module_name)
+        if not plugin_id:
+            raise RuntimeError("Plugin context is not associated with a loaded plugin")
+        return await self.plugin_mgr.register_plugin_provider(plugin_id, relative_path)
+
+    async def unregister_provider(self, provider_format: str) -> bool:
+        """Unregister a Provider type owned by the calling plugin."""
+        frame = inspect.currentframe().f_back
+        plugin_id = None
+        if frame and self.plugin_mgr:
+            module_name = frame.f_globals.get("__name__", "")
+            plugin_id = self.plugin_mgr.get_plugin_id_for_module(module_name)
+        if not plugin_id:
+            raise RuntimeError("Plugin context is not associated with a loaded plugin")
+        return await self.plugin_mgr.unregister_plugin_provider(plugin_id, provider_format)
+
+    async def register_adapter(self, relative_path: str) -> str:
+        """Register an Adapter directory for the calling plugin."""
+        frame = inspect.currentframe().f_back
+        plugin_id = None
+        if frame and self.plugin_mgr:
+            module_name = frame.f_globals.get("__name__", "")
+            plugin_id = self.plugin_mgr.get_plugin_id_for_module(module_name)
+        if not plugin_id:
+            raise RuntimeError("Plugin context is not associated with a loaded plugin")
+        return await self.plugin_mgr.register_plugin_adapter(plugin_id, relative_path)
+
+    async def unregister_adapter(self, platform: str) -> bool:
+        """Unregister an Adapter type owned by the calling plugin."""
+        frame = inspect.currentframe().f_back
+        plugin_id = None
+        if frame and self.plugin_mgr:
+            module_name = frame.f_globals.get("__name__", "")
+            plugin_id = self.plugin_mgr.get_plugin_id_for_module(module_name)
+        if not plugin_id:
+            raise RuntimeError("Plugin context is not associated with a loaded plugin")
+        return await self.plugin_mgr.unregister_plugin_adapter(plugin_id, platform)
     def get_default_embedding_client(self) -> Optional[EmbeddingModelClient]:
         client = self.provider_mgr.get_default_embedding()
         if isinstance(client, EmbeddingModelClient):

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -835,7 +835,11 @@ class PluginManager:
     @staticmethod
     def _find_component_class(module, base_types: tuple[type, ...], kind: str) -> type:
         for _, candidate in inspect.getmembers(module, inspect.isclass):
-            if issubclass(candidate, base_types) and candidate not in base_types:
+            if (
+                candidate.__module__ == module.__name__
+                and issubclass(candidate, base_types)
+                and candidate not in base_types
+            ):
                 return candidate
         names = ", ".join(base_type.__name__ for base_type in base_types)
         raise ValueError(f"No {kind} class inheriting from {names} found in {module.__name__}")
@@ -922,20 +926,39 @@ class PluginManager:
         for adapter_id in (self.ctx.config.get("adapters", {}) or {}):
             info = self.ctx.adapter_mgr.get_adapter_info(adapter_id)
             if info and info.platform == platform:
-                await self.ctx.adapter_mgr.register_adapter(info)
+                try:
+                    await self.ctx.adapter_mgr.register_adapter(info)
+                except Exception as e:
+                    logger.error(
+                        f"Failed to restore adapter {adapter_id} for plugin {plugin_id}: {e}"
+                    )
         logger.info(f"Registered Adapter platform {platform} from plugin {plugin_id}")
         return platform
 
     async def unregister_plugin_adapter(self, plugin_id: str, platform: str) -> bool:
+        """Remove a plugin-owned Adapter after its runtime instances stop."""
         if not self.ctx or not self.ctx.adapter_mgr:
             raise RuntimeError("Adapter manager is not available")
-        metadata = _ensure_components(plugin_id).unregister_adapter(platform)
+        comp = _ensure_components(plugin_id)
+        metadata = comp.adapters.get(platform)
         if metadata is None:
             return False
-        await self.ctx.adapter_mgr.stop_adapter_instances_by_platform(platform)
+        try:
+            await self.ctx.adapter_mgr.stop_adapter_instances_by_platform(platform)
+        except Exception as e:
+            logger.error(
+                f"Failed to stop Adapter platform {platform} for plugin {plugin_id}: {e}"
+            )
+            return False
         removed = self.ctx.adapter_mgr.unregister_adapter_type(platform, metadata["class"])
+        if not removed:
+            logger.error(
+                f"Failed to unregister Adapter platform {platform} for plugin {plugin_id}"
+            )
+            return False
+        comp.unregister_adapter(platform)
         logger.info(f"Unregistered Adapter platform {platform} from plugin {plugin_id}")
-        return removed
+        return True
 
     def get_plugin_tools(self, plugin_name: Optional[str] = None) -> Dict[str, Dict[str, Any]]:
         if plugin_name is None:
@@ -1622,9 +1645,25 @@ class PluginManager:
         if not comp:
             return
         for platform in list(comp.adapters):
-            await self.unregister_plugin_adapter(plugin_id, platform)
+            try:
+                if not await self.unregister_plugin_adapter(plugin_id, platform):
+                    logger.error(
+                        f"Adapter platform {platform} was not cleaned up for plugin {plugin_id}"
+                    )
+            except Exception as e:
+                logger.error(
+                    f"Failed to clean up Adapter platform {platform} for plugin {plugin_id}: {e}"
+                )
         for provider_format in list(comp.providers):
-            await self.unregister_plugin_provider(plugin_id, provider_format)
+            try:
+                if not await self.unregister_plugin_provider(plugin_id, provider_format):
+                    logger.error(
+                        f"Provider format {provider_format} was not cleaned up for plugin {plugin_id}"
+                    )
+            except Exception as e:
+                logger.error(
+                    f"Failed to clean up Provider format {provider_format} for plugin {plugin_id}: {e}"
+                )
 
     def _cleanup_plugin_registration(self, plugin_id: str) -> None:
         comp = _plugin_components.get(plugin_id)

--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -15,6 +15,9 @@ from packaging.version import Version, InvalidVersion
 from core.utils.path_utils import get_data_path, get_config_path, resolve_manifest_icon_path
 from core.logging_manager import get_logger
 from core.config.config_field import BaseConfigField, SectionField, build_fields
+from core.provider import BaseProvider, ProviderManager
+from core.adapter import AdapterManager
+from core.adapter.adapter_utils import IMAdapter, SocialMediaAdapter
 from core.config import VERSION
 from .plugin import BasePlugin
 from .plugin_context import PluginContext
@@ -170,9 +173,11 @@ class PluginComponents:
     widgets: List[dict] = field(default_factory=list)
     widget_funcs: Dict[str, Callable] = field(default_factory=dict)
 
+    providers: Dict[str, dict] = field(default_factory=dict)
+    adapters: Dict[str, dict] = field(default_factory=dict)
     def has_any(self) -> bool:
         return bool(self.tools or self.tags or self.hooks or self.pages
-                    or self.api_routes or self.ws_routes or self.static_dirs or self.widgets)
+                    or self.api_routes or self.ws_routes or self.static_dirs or self.widgets or self.providers or self.adapters)
 
     def register_tool(self, name: str, description: str, params: dict, func: Callable):
         self.tools[name] = {
@@ -255,6 +260,17 @@ class PluginComponents:
             "size": size,
         })
         self.widget_funcs[widget_id] = func
+    def register_provider(self, provider_format: str, metadata: dict) -> None:
+        self.providers[provider_format] = metadata
+
+    def unregister_provider(self, provider_format: str) -> Optional[dict]:
+        return self.providers.pop(provider_format, None)
+
+    def register_adapter(self, platform: str, metadata: dict) -> None:
+        self.adapters[platform] = metadata
+
+    def unregister_adapter(self, platform: str) -> Optional[dict]:
+        return self.adapters.pop(platform, None)
 
 
 _plugin_components: Dict[str, PluginComponents] = {}
@@ -766,6 +782,160 @@ class PluginManager:
 
     def get_plugin_components(self) -> Dict[str, PluginComponents]:
         return dict(_plugin_components)
+
+    def _resolve_plugin_component_dir(self, plugin_id: str, relative_path: str) -> Path:
+        plugin_root = _plugin_module_paths.get(plugin_id)
+        if plugin_root is None:
+            raise ValueError(f"Plugin '{plugin_id}' has no registered root directory")
+        candidate = Path(relative_path)
+        if candidate.is_absolute():
+            raise ValueError("Plugin component path must be relative to the plugin root")
+        component_dir = (plugin_root / candidate).resolve()
+        if not component_dir.is_relative_to(plugin_root.resolve()):
+            raise ValueError("Plugin component path must stay inside the plugin root")
+        if not component_dir.is_dir():
+            raise ValueError(f"Plugin component directory does not exist: {relative_path}")
+        return component_dir
+
+    def _load_plugin_component_module(self, plugin_id: str, component_dir: Path, kind: str):
+        plugin_root = _plugin_module_paths[plugin_id].resolve()
+        package_name = f"plugins.{plugin_root.name}"
+        package_dir = plugin_root
+        for part in component_dir.relative_to(plugin_root).parts:
+            package_name = f"{package_name}.{part}"
+            package_dir = package_dir / part
+            if package_name not in sys.modules:
+                package = types.ModuleType(package_name)
+                package.__path__ = [str(package_dir)]
+                sys.modules[package_name] = package
+
+        script_path = component_dir / f"{kind}.py"
+        if not script_path.exists():
+            script_path = component_dir / "__init__.py"
+        if not script_path.exists():
+            raise ValueError(f"No {kind}.py or __init__.py found in {component_dir}")
+
+        module_name = f"{package_name}.__kira_{kind}__"
+        module = sys.modules.get(module_name)
+        if module is not None:
+            return module
+        spec = importlib.util.spec_from_file_location(module_name, script_path)
+        if not spec or not spec.loader:
+            raise ValueError(f"Failed to create module spec for {script_path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            sys.modules.pop(module_name, None)
+            raise
+        _module_to_plugin[module_name] = plugin_id
+        return module
+
+    @staticmethod
+    def _find_component_class(module, base_types: tuple[type, ...], kind: str) -> type:
+        for _, candidate in inspect.getmembers(module, inspect.isclass):
+            if issubclass(candidate, base_types) and candidate not in base_types:
+                return candidate
+        names = ", ".join(base_type.__name__ for base_type in base_types)
+        raise ValueError(f"No {kind} class inheriting from {names} found in {module.__name__}")
+
+    async def register_plugin_provider(self, plugin_id: str, relative_path: str) -> str:
+        if not self.ctx or not self.ctx.provider_mgr:
+            raise RuntimeError("Provider manager is not available")
+        component_dir = self._resolve_plugin_component_dir(plugin_id, relative_path)
+        manifest_path = component_dir / "manifest.json"
+        if not manifest_path.exists():
+            raise ValueError(f"Provider manifest not found: {relative_path}")
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        provider_format = str(manifest.get("name") or "").strip()
+        if not provider_format:
+            raise ValueError("Provider manifest must define a name")
+        comp = _ensure_components(plugin_id)
+        existing = comp.providers.get(provider_format)
+        if existing:
+            if existing["path"] == component_dir:
+                return provider_format
+            raise ValueError(f"Plugin already registered Provider format '{provider_format}'")
+        module = self._load_plugin_component_module(plugin_id, component_dir, "provider")
+        provider_cls = self._find_component_class(module, (BaseProvider,), "Provider")
+        raw_schema = {}
+        schema_path = component_dir / "schema.json"
+        if schema_path.exists():
+            raw_schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        schema = {
+            "provider_config": build_fields(raw_schema.get("provider_config") or {}),
+            "model_config": {
+                model_type: build_fields(fields)
+                for model_type, fields in (raw_schema.get("model_config") or {}).items()
+                if isinstance(fields, dict)
+            },
+        }
+        self.ctx.provider_mgr.register_provider_type(
+            provider_format, provider_cls, manifest, component_dir, schema
+        )
+        comp.register_provider(provider_format, {"path": component_dir, "class": provider_cls})
+        for provider_id, config in (self.ctx.config.get("providers", {}) or {}).items():
+            if isinstance(config, dict) and config.get("format") == provider_format:
+                self.ctx.provider_mgr.set_provider(provider_id, config)
+        logger.info(f"Registered Provider format {provider_format} from plugin {plugin_id}")
+        return provider_format
+
+    async def unregister_plugin_provider(self, plugin_id: str, provider_format: str) -> bool:
+        if not self.ctx or not self.ctx.provider_mgr:
+            raise RuntimeError("Provider manager is not available")
+        metadata = _ensure_components(plugin_id).unregister_provider(provider_format)
+        if metadata is None:
+            return False
+        self.ctx.provider_mgr.remove_provider_instances_by_format(provider_format)
+        removed = self.ctx.provider_mgr.unregister_provider_type(provider_format, metadata["class"])
+        logger.info(f"Unregistered Provider format {provider_format} from plugin {plugin_id}")
+        return removed
+
+    async def register_plugin_adapter(self, plugin_id: str, relative_path: str) -> str:
+        if not self.ctx or not self.ctx.adapter_mgr:
+            raise RuntimeError("Adapter manager is not available")
+        component_dir = self._resolve_plugin_component_dir(plugin_id, relative_path)
+        manifest_path = component_dir / "manifest.json"
+        if not manifest_path.exists():
+            raise ValueError(f"Adapter manifest not found: {relative_path}")
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        platform = str(manifest.get("name") or "").strip()
+        if not platform:
+            raise ValueError("Adapter manifest must define a name")
+        comp = _ensure_components(plugin_id)
+        existing = comp.adapters.get(platform)
+        if existing:
+            if existing["path"] == component_dir:
+                return platform
+            raise ValueError(f"Plugin already registered Adapter platform '{platform}'")
+        module = self._load_plugin_component_module(plugin_id, component_dir, "adapter")
+        adapter_cls = self._find_component_class(module, (IMAdapter, SocialMediaAdapter), "Adapter")
+        raw_schema = {}
+        schema_path = component_dir / "schema.json"
+        if schema_path.exists():
+            raw_schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        self.ctx.adapter_mgr.register_adapter_type(
+            platform, adapter_cls, manifest, component_dir, build_fields(raw_schema)
+        )
+        comp.register_adapter(platform, {"path": component_dir, "class": adapter_cls})
+        for adapter_id in (self.ctx.config.get("adapters", {}) or {}):
+            info = self.ctx.adapter_mgr.get_adapter_info(adapter_id)
+            if info and info.platform == platform:
+                await self.ctx.adapter_mgr.register_adapter(info)
+        logger.info(f"Registered Adapter platform {platform} from plugin {plugin_id}")
+        return platform
+
+    async def unregister_plugin_adapter(self, plugin_id: str, platform: str) -> bool:
+        if not self.ctx or not self.ctx.adapter_mgr:
+            raise RuntimeError("Adapter manager is not available")
+        metadata = _ensure_components(plugin_id).unregister_adapter(platform)
+        if metadata is None:
+            return False
+        await self.ctx.adapter_mgr.stop_adapter_instances_by_platform(platform)
+        removed = self.ctx.adapter_mgr.unregister_adapter_type(platform, metadata["class"])
+        logger.info(f"Unregistered Adapter platform {platform} from plugin {plugin_id}")
+        return removed
 
     def get_plugin_tools(self, plugin_name: Optional[str] = None) -> Dict[str, Dict[str, Any]]:
         if plugin_name is None:
@@ -1447,11 +1617,19 @@ class PluginManager:
             self._web_app.openapi_schema = None
             logger.debug(f"Removed {removed} route(s) for plugin {plugin_id}")
 
+    async def _cleanup_plugin_runtime_components(self, plugin_id: str) -> None:
+        comp = _plugin_components.get(plugin_id)
+        if not comp:
+            return
+        for platform in list(comp.adapters):
+            await self.unregister_plugin_adapter(plugin_id, platform)
+        for provider_format in list(comp.providers):
+            await self.unregister_plugin_provider(plugin_id, provider_format)
+
     def _cleanup_plugin_registration(self, plugin_id: str) -> None:
         comp = _plugin_components.get(plugin_id)
         if not comp:
             return
-
         # clean up tool registration
         if self.ctx and getattr(self.ctx, "tool_mgr", None):
             for tool_name in list(comp.tools.keys()):
@@ -1651,6 +1829,7 @@ class PluginManager:
                 logger.info(f"Terminated plugin {plugin_id}")
             except Exception as e:
                 logger.error(f"Error terminating plugin {plugin_id}: {e}")
+            await self._cleanup_plugin_runtime_components(plugin_id)
             self._cleanup_plugin_registration(plugin_id)
             return
 
@@ -1664,6 +1843,7 @@ class PluginManager:
         self.plugin_instances.clear()
         self.plugin_configs.clear()
         for name in list(_plugin_components.keys()):
+            await self._cleanup_plugin_runtime_components(name)
             self._cleanup_plugin_registration(name)
 
     async def uninstall_plugin(self, plugin_id: str) -> None:

--- a/core/provider/provider_manager.py
+++ b/core/provider/provider_manager.py
@@ -85,6 +85,45 @@ class ProviderManager:
             manifest_dir, manifest.get("icon-dark" if dark else "icon"),
         )
 
+    @classmethod
+    def register_provider_type(cls, provider_format: str, provider_cls: Type[BaseProvider], manifest: dict, manifest_dir: Path, schema: Optional[dict] = None) -> None:
+        """Register a Provider type supplied by a plugin."""
+        if not isinstance(provider_format, str) or not provider_format.strip():
+            raise ValueError("Provider format must be a non-empty string")
+        if not inspect.isclass(provider_cls) or not issubclass(provider_cls, BaseProvider):
+            raise TypeError("Provider class must inherit from BaseProvider")
+        if not isinstance(manifest, dict) or (schema is not None and not isinstance(schema, dict)):
+            raise TypeError("Provider manifest and schema must be dictionaries")
+        provider_format = provider_format.strip()
+        existing = cls._registry.get(provider_format)
+        if existing is not None and existing is not provider_cls:
+            raise ValueError(f"Provider format '{provider_format}' is already registered")
+        cls._registry[provider_format] = provider_cls
+        cls._manifests[provider_format] = manifest.copy()
+        cls._manifest_dirs[provider_format] = Path(manifest_dir)
+        cls._schemas[provider_format] = copy.deepcopy(schema) if schema else {}
+
+    @classmethod
+    def unregister_provider_type(cls, provider_format: str, provider_cls: Type[BaseProvider]) -> bool:
+        """Remove a plugin Provider type without affecting another owner."""
+        if cls._registry.get(provider_format) is not provider_cls:
+            return False
+        cls._registry.pop(provider_format, None)
+        cls._manifests.pop(provider_format, None)
+        cls._manifest_dirs.pop(provider_format, None)
+        cls._schemas.pop(provider_format, None)
+        return True
+
+    def remove_provider_instances_by_format(self, provider_format: str) -> int:
+        """Remove runtime instances while preserving their stored configuration."""
+        removed = 0
+        configs = self.kira_config.get("providers", {}) or {}
+        for provider_id in list(self._providers):
+            if isinstance(configs.get(provider_id), dict) and configs[provider_id].get("format") == provider_format:
+                self._providers.pop(provider_id, None)
+                removed += 1
+        return removed
+
     def get_model_client(
         self,
         provider_id: str,

--- a/data/plugins/plugin_registration_smoke_test/adapter/adapter.py
+++ b/data/plugins/plugin_registration_smoke_test/adapter/adapter.py
@@ -1,0 +1,18 @@
+from core.adapter.adapter_utils import IMAdapter
+
+
+class PluginRegistrationSmokeAdapter(IMAdapter):
+    async def start(self):
+        pass
+
+    async def stop(self):
+        pass
+
+    def get_client(self):
+        return None
+
+    async def send_group_message(self, group_id, send_message_obj):
+        return None
+
+    async def send_direct_message(self, user_id, send_message_obj):
+        return None

--- a/data/plugins/plugin_registration_smoke_test/adapter/manifest.json
+++ b/data/plugins/plugin_registration_smoke_test/adapter/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "plugin-registration-smoke-adapter",
+  "display_name": "Plugin Registration Smoke Adapter",
+  "description": "Minimal Adapter registered by the plugin lifecycle."
+}

--- a/data/plugins/plugin_registration_smoke_test/adapter/schema.json
+++ b/data/plugins/plugin_registration_smoke_test/adapter/schema.json
@@ -1,0 +1,8 @@
+{
+  "label": {
+    "name": "Label",
+    "type": "string",
+    "default": "smoke-test",
+    "hint": "No-op configuration field for registration testing."
+  }
+}

--- a/data/plugins/plugin_registration_smoke_test/main.py
+++ b/data/plugins/plugin_registration_smoke_test/main.py
@@ -1,0 +1,10 @@
+from core.plugin import BasePlugin
+
+
+class PluginRegistrationSmokeTest(BasePlugin):
+    async def initialize(self):
+        await self.ctx.register_provider("provider")
+        await self.ctx.register_adapter("adapter")
+
+    async def terminate(self):
+        pass

--- a/data/plugins/plugin_registration_smoke_test/manifest.json
+++ b/data/plugins/plugin_registration_smoke_test/manifest.json
@@ -1,0 +1,13 @@
+{
+  "plugin_id": "plugin_registration_smoke_test",
+  "display_name": "Plugin Registration Smoke Test",
+  "version": "0.1.0",
+  "author": "KiraAI",
+  "description": "Minimal plugin that verifies dynamic Provider and Adapter registration.",
+  "locales": {
+    "zh": {
+      "display_name": "插件注册冒烟测试",
+      "description": "验证动态 Provider 和 Adapter 注册的最小插件。"
+    }
+  }
+}

--- a/data/plugins/plugin_registration_smoke_test/provider/manifest.json
+++ b/data/plugins/plugin_registration_smoke_test/provider/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "plugin-registration-smoke-provider",
+  "display_name": "Plugin Registration Smoke Provider",
+  "description": "Minimal Provider registered by the plugin lifecycle."
+}

--- a/data/plugins/plugin_registration_smoke_test/provider/provider.py
+++ b/data/plugins/plugin_registration_smoke_test/provider/provider.py
@@ -1,0 +1,5 @@
+from core.provider import BaseProvider
+
+
+class PluginRegistrationSmokeProvider(BaseProvider):
+    models = {}

--- a/data/plugins/plugin_registration_smoke_test/provider/provider.py
+++ b/data/plugins/plugin_registration_smoke_test/provider/provider.py
@@ -1,5 +1,7 @@
+from typing import ClassVar
+
 from core.provider import BaseProvider
 
 
 class PluginRegistrationSmokeProvider(BaseProvider):
-    models = {}
+    models: ClassVar[dict] = {}

--- a/data/plugins/plugin_registration_smoke_test/provider/schema.json
+++ b/data/plugins/plugin_registration_smoke_test/provider/schema.json
@@ -1,0 +1,11 @@
+{
+  "provider_config": {
+    "label": {
+      "name": "Label",
+      "type": "string",
+      "default": "smoke-test",
+      "hint": "No-op configuration field for registration testing."
+    }
+  },
+  "model_config": {}
+}

--- a/tests/test_adapter_manager.py
+++ b/tests/test_adapter_manager.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from core.adapter.adapter_info import AdapterInfo
 from core.adapter.adapter_registry import AdapterManager
 
 
@@ -38,3 +39,53 @@ def test_update_rejects_enabling_an_unregistered_adapter_platform():
         asyncio.run(manager.update_adapter("plugin-adapter", status="active"))
 
     assert manager.kira_config["adapters"]["plugin-adapter"]["enabled"] is False
+
+class _SavingConfig(dict):
+    def __init__(self, value):
+        super().__init__(value)
+        self.save_count = 0
+
+    def save_config(self):
+        self.save_count += 1
+
+
+class _DelayedFailingAdapter:
+    def __init__(self, info):
+        self.info = info
+
+    async def start(self):
+        await asyncio.sleep(0)
+        raise RuntimeError("startup failed")
+
+    async def stop(self):
+        return None
+
+
+def test_delayed_adapter_start_failure_disables_the_adapter():
+    adapter_id = "delayed-failure"
+    info = AdapterInfo(
+        enabled=True,
+        adapter_id=adapter_id,
+        name="delayed-failure",
+        platform="test-platform",
+    )
+    adapter = _DelayedFailingAdapter(info)
+    manager = object.__new__(AdapterManager)
+    manager._adapters = {info.name: adapter}
+    manager._adapter_tasks = {}
+    manager.kira_config = _SavingConfig(
+        {"adapters": {adapter_id: {"enabled": True}}}
+    )
+    manager.adas_config = manager.kira_config["adapters"]
+
+    async def run_startup():
+        await manager.start_adapter(info.name)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    asyncio.run(run_startup())
+
+    assert info.name not in manager._adapters
+    assert info.name not in manager._adapter_tasks
+    assert manager.kira_config["adapters"][adapter_id]["enabled"] is False
+    assert manager.kira_config.save_count == 1

--- a/tests/test_adapter_manager.py
+++ b/tests/test_adapter_manager.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from core.adapter.adapter_registry import AdapterManager
@@ -10,3 +12,29 @@ def test_adapter_name_rejects_colon():
 
 def test_adapter_name_allows_regular_name():
     AdapterManager._validate_adapter_name("my-adapter")
+
+class _NoSaveConfig(dict):
+    def save_config(self):
+        raise AssertionError("An unavailable adapter platform must not be persisted")
+
+
+def test_update_rejects_enabling_an_unregistered_adapter_platform():
+    manager = object.__new__(AdapterManager)
+    manager.kira_config = _NoSaveConfig(
+        {
+            "adapters": {
+                "plugin-adapter": {
+                    "enabled": False,
+                    "name": "plugin-adapter",
+                    "platform": "plugin-platform-that-is-not-registered",
+                    "config": {},
+                }
+            }
+        }
+    )
+    manager.adas_config = manager.kira_config["adapters"]
+
+    with pytest.raises(ValueError, match="No adapter registered"):
+        asyncio.run(manager.update_adapter("plugin-adapter", status="active"))
+
+    assert manager.kira_config["adapters"]["plugin-adapter"]["enabled"] is False

--- a/tests/test_plugin_widget_lifecycle.py
+++ b/tests/test_plugin_widget_lifecycle.py
@@ -1,5 +1,8 @@
-from core.plugin import plugin_registry
+import asyncio
+from types import ModuleType, SimpleNamespace
 
+from core.plugin import plugin_registry
+from core.provider import BaseProvider
 
 def test_cleanup_preserves_widget_declarations(monkeypatch):
     """Widgets must remain declared so a disabled plugin can be re-enabled."""
@@ -25,3 +28,73 @@ def test_cleanup_preserves_widget_declarations(monkeypatch):
 
     assert components.widgets[0]["widget_id"] == f"{plugin_id}:status_widget"
     assert components.widget_funcs[f"{plugin_id}:status_widget"] is status_widget
+
+class _FailingStopAdapterManager:
+    async def stop_adapter_instances_by_platform(self, platform):
+        raise RuntimeError("stop failed")
+
+    def unregister_adapter_type(self, platform, adapter_cls):
+        raise AssertionError("The type must remain registered after a stop failure")
+
+
+class _ProviderManager:
+    pass
+
+
+def test_unregister_plugin_adapter_keeps_metadata_when_stop_fails(monkeypatch):
+    plugin_id = "adapter_cleanup_failure"
+    platform = "adapter-cleanup-platform"
+    components = plugin_registry.PluginComponents()
+    adapter_cls = type("PluginAdapter", (), {})
+    components.register_adapter(platform, {"class": adapter_cls})
+    monkeypatch.setitem(plugin_registry._plugin_components, plugin_id, components)
+
+    manager = plugin_registry.PluginManager(
+        ctx=SimpleNamespace(adapter_mgr=_FailingStopAdapterManager())
+    )
+
+    assert asyncio.run(manager.unregister_plugin_adapter(plugin_id, platform)) is False
+    assert components.adapters[platform]["class"] is adapter_cls
+
+
+def test_runtime_cleanup_continues_after_adapter_cleanup_failure(monkeypatch):
+    plugin_id = "runtime_cleanup_failure"
+    components = plugin_registry.PluginComponents()
+    components.register_adapter("failing-platform", {"class": object})
+    components.register_provider("remaining-provider", {"class": object})
+    monkeypatch.setitem(plugin_registry._plugin_components, plugin_id, components)
+
+    manager = plugin_registry.PluginManager(ctx=SimpleNamespace())
+    provider_cleanup_calls = []
+
+    async def fail_adapter_cleanup(plugin_id_arg, platform):
+        assert plugin_id_arg == plugin_id
+        assert platform == "failing-platform"
+        raise RuntimeError("adapter cleanup failed")
+
+    async def clean_provider(plugin_id_arg, provider_format):
+        provider_cleanup_calls.append((plugin_id_arg, provider_format))
+        return True
+
+    monkeypatch.setattr(manager, "unregister_plugin_adapter", fail_adapter_cleanup)
+    monkeypatch.setattr(manager, "unregister_plugin_provider", clean_provider)
+
+    asyncio.run(manager._cleanup_plugin_runtime_components(plugin_id))
+
+    assert provider_cleanup_calls == [(plugin_id, "remaining-provider")]
+
+
+def test_component_class_lookup_ignores_imported_provider_classes():
+    module = ModuleType("plugin_component_module")
+    imported_provider = type(
+        "ImportedProvider", (BaseProvider,), {"__module__": "shared_provider_module"}
+    )
+    local_provider = type(
+        "LocalProvider", (BaseProvider,), {"__module__": module.__name__}
+    )
+    module.ImportedProvider = imported_provider
+    module.LocalProvider = local_provider
+
+    assert plugin_registry.PluginManager._find_component_class(
+        module, (BaseProvider,), "Provider"
+    ) is local_provider


### PR DESCRIPTION
## Summary

Adds plugin-owned Provider and Adapter registration through `self.ctx`, with lifecycle cleanup when the plugin stops. Also makes adapter startup failures propagate to the API and preserves the prior configuration when activation fails, including when a plugin-provided adapter has been unregistered.

## Type of change

- [x] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [x] test: Adding or updating tests

## Changes

- Add plugin-context Provider and Adapter registration/unregistration APIs backed by each plugin's `PluginComponents`.
- Load plugin-owned component manifests, schemas, and relative icon assets; unregister runtime instances and types during plugin shutdown.
- Reject and surface adapter startup failures before persisting an enabled state, with regression coverage for an unavailable plugin adapter platform.

## Screenshots / Logs

`python -m pytest tests/test_adapter_manager.py tests/test_plugin_widget_lifecycle.py -v` — 4 passed.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plugins can now dynamically register and unregister provider and adapter integrations.
  - Added support for plugin-defined manifests and configuration schemas.
  - Plugin integrations are automatically cleaned up when a plugin is disabled or removed.

- **Bug Fixes**
  - Failed integration startup now reports clear errors and safely rolls back configuration changes.
  - Invalid or unavailable integrations can no longer be enabled silently.

- **Tests**
  - Added coverage validating plugin registration and failed adapter activation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->