### PR TITLE
fix: prevent plugin async lifecycle leaks

### DIFF
--- a/core/plugin/builtin_plugins/chat/main.py
+++ b/core/plugin/builtin_plugins/chat/main.py
@@ -100,16 +100,15 @@ class DefaultChatPlugin(BasePlugin):
             raise
         finally:
             current_task = asyncio.current_task()
-            if self.session_tasks.get(sid) is not current_task:
-                return
-            self.session_tasks.pop(sid, None)
-            if event.is_set() and not self._terminating:
-                self.session_tasks[sid] = asyncio.create_task(
-                    self._debounce_loop(sid, event),
-                    name=f"chat_debounce_{sid}",
-                )
-            else:
-                self.session_events.pop(sid, None)
+            if self.session_tasks.get(sid) is current_task:
+                self.session_tasks.pop(sid, None)
+                if event.is_set() and not self._terminating:
+                    self.session_tasks[sid] = asyncio.create_task(
+                        self._debounce_loop(sid, event),
+                        name=f"chat_debounce_{sid}",
+                    )
+                else:
+                    self.session_events.pop(sid, None)
 
     @on.llm_request(priority=Priority.MEDIUM)
     async def inject_group_prompt(self, event: KiraMessageBatchEvent, req: LLMRequest, *_):

--- a/core/plugin/builtin_plugins/chat/main.py
+++ b/core/plugin/builtin_plugins/chat/main.py
@@ -41,6 +41,8 @@ class DefaultChatPlugin(BasePlugin):
 
     @on.im_message(priority=Priority.HIGH)
     async def handle_msg(self, event: KiraMessageEvent):
+        if self._terminating:
+            return
 
         # === Check waking words ===
         for m in event.message.chain:
@@ -83,9 +85,13 @@ class DefaultChatPlugin(BasePlugin):
     async def _debounce_loop(self, sid: str, event: asyncio.Event):
         try:
             while True:
+                if self._terminating:
+                    return
                 await event.wait()
                 event.clear()
                 await asyncio.sleep(self.debounce_interval)
+                if self._terminating:
+                    return
                 if event.is_set() and not self.receive_unmentioned:
                     continue
                 buffer_len = self.ctx.message_processor.get_session_buffer_length(sid)

--- a/core/plugin/builtin_plugins/chat/main.py
+++ b/core/plugin/builtin_plugins/chat/main.py
@@ -12,6 +12,7 @@ class DefaultChatPlugin(BasePlugin):
         super().__init__(ctx, cfg)
         self.session_events: dict[str, asyncio.Event] = {}
         self.session_tasks: dict[str, asyncio.Task] = {}
+        self._terminating = False
         bot_cfg = ctx.config["bot_config"].get("bot", {})
         self.debounce_interval = float(bot_cfg.get("max_message_interval", 1.5))
         self.max_buffer_messages = int(bot_cfg.get("max_buffer_messages", 3))
@@ -24,13 +25,19 @@ class DefaultChatPlugin(BasePlugin):
         self.waking_words = cfg.get("waking_words", [])
     
     async def initialize(self):
+        self._terminating = False
         logger.info(f"[Default Chat] initialize")
     
     async def terminate(self):
-        """
-        Cleanup when plugin is terminated
-        """
-        pass
+        """Cancel all pending debounce tasks before the plugin is unloaded."""
+        self._terminating = True
+        tasks = list(self.session_tasks.values())
+        self.session_tasks.clear()
+        self.session_events.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     @on.im_message(priority=Priority.HIGH)
     async def handle_msg(self, event: KiraMessageEvent):
@@ -67,27 +74,42 @@ class DefaultChatPlugin(BasePlugin):
         if sid not in self.session_events:
             self.session_events[sid] = asyncio.Event()
         if sid not in self.session_tasks:
-            self.session_tasks[sid] = asyncio.create_task(self._debounce_loop(sid))
+            self.session_tasks[sid] = asyncio.create_task(
+                self._debounce_loop(sid, self.session_events[sid]),
+                name=f"chat_debounce_{sid}",
+            )
         self.session_events[sid].set()
 
-    async def _debounce_loop(self, sid: str):
-        event = self.session_events[sid]
-        while True:
-            await event.wait()
-            event.clear()
-            try:
+    async def _debounce_loop(self, sid: str, event: asyncio.Event):
+        try:
+            while True:
+                await event.wait()
+                event.clear()
                 await asyncio.sleep(self.debounce_interval)
-            except asyncio.CancelledError:
-                break
-            if event.is_set() and not self.receive_unmentioned:
-                continue
-            buffer_len = self.ctx.message_processor.get_session_buffer_length(sid)
-            if buffer_len == 0:
-                continue
-            try:
-                await self.ctx.message_processor.flush_session_messages(sid)
-            except Exception:
-                logger.exception(f"[Debounce] Error flushing session {sid}")
+                if event.is_set() and not self.receive_unmentioned:
+                    continue
+                buffer_len = self.ctx.message_processor.get_session_buffer_length(sid)
+                if buffer_len == 0:
+                    return
+                try:
+                    await self.ctx.message_processor.flush_session_messages(sid)
+                except Exception:
+                    logger.exception(f"[Debounce] Error flushing session {sid}")
+                return
+        except asyncio.CancelledError:
+            raise
+        finally:
+            current_task = asyncio.current_task()
+            if self.session_tasks.get(sid) is not current_task:
+                return
+            self.session_tasks.pop(sid, None)
+            if event.is_set() and not self._terminating:
+                self.session_tasks[sid] = asyncio.create_task(
+                    self._debounce_loop(sid, event),
+                    name=f"chat_debounce_{sid}",
+                )
+            else:
+                self.session_events.pop(sid, None)
 
     @on.llm_request(priority=Priority.MEDIUM)
     async def inject_group_prompt(self, event: KiraMessageBatchEvent, req: LLMRequest, *_):

--- a/core/plugin/builtin_plugins/file/main.py
+++ b/core/plugin/builtin_plugins/file/main.py
@@ -351,6 +351,32 @@ class FilePlugin(BasePlugin):
             return None
         return normalized
 
+    @staticmethod
+    def _read_file_lines(path: Path) -> list[str]:
+        return path.read_text(encoding="utf-8").splitlines(keepends=True)
+
+    @staticmethod
+    def _read_file_text(path: Path) -> str:
+        return path.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _write_file_text(path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    @staticmethod
+    def _list_directory(path: Path) -> list[str]:
+        return sorted(os.listdir(path))
+
+    @staticmethod
+    def _find_files(path: Path, pattern: str) -> list[Path]:
+        matches = path.glob(pattern)
+        return sorted(
+            (match for match in matches if match.is_file()),
+            key=lambda match: match.stat().st_mtime,
+            reverse=True,
+        )
+
     @register.tool(
         "read_file",
         "Read a plain text file (txt, html, py, etc..) in allowed read paths",
@@ -385,8 +411,7 @@ class FilePlugin(BasePlugin):
 
         try:
             abs_path = self._resolve_path(path)
-            with open(abs_path, 'r', encoding="utf-8") as f:
-                file_lines = f.readlines()
+            file_lines = await asyncio.to_thread(self._read_file_lines, abs_path)
             if offset > len(file_lines) or offset < 1:
                 return "Offset out of range"
 
@@ -437,8 +462,7 @@ class FilePlugin(BasePlugin):
 
         try:
             abs_path = self._resolve_path(path)
-            with open(abs_path, 'w', encoding="utf-8") as f:
-                f.write(content)
+            await asyncio.to_thread(self._write_file_text, abs_path, content)
             return "File written successfully"
         except Exception as e:
             return f"Failed to write file: {e}"
@@ -478,9 +502,7 @@ class FilePlugin(BasePlugin):
 
         try:
             abs_path = self._resolve_path(path)
-
-            with open(abs_path, 'r', encoding="utf-8") as f:
-                content = f.read()
+            content = await asyncio.to_thread(self._read_file_text, abs_path)
 
             if old_text == "":
                 return "Error: old_text must not be empty."
@@ -492,11 +514,8 @@ class FilePlugin(BasePlugin):
 
             new_content = content.replace(old_text, new_text)
 
-            abs_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(abs_path, 'w', encoding="utf-8") as f:
-                f.write(new_content)
-
-                return f"Successfully edited file: {path}, {replacements} replacement(s) made."
+            await asyncio.to_thread(self._write_file_text, abs_path, new_content)
+            return f"Successfully edited file: {path}, {replacements} replacement(s) made."
         except Exception as e:
             return f"Failed to edit file: {str(e)}"
 
@@ -530,8 +549,7 @@ class FilePlugin(BasePlugin):
 
         try:
             abs_path = self._resolve_path(path)
-
-            files = sorted(os.listdir(abs_path))
+            files = await asyncio.to_thread(self._list_directory, abs_path)
 
             if offset < 1 or offset > len(files):
                 return "offset out of range"
@@ -829,7 +847,8 @@ class FilePlugin(BasePlugin):
             return f"Path not found: {path}"
 
         if self._has_ripgrep():
-            return self._grep_with_rg(
+            return await asyncio.to_thread(
+                self._grep_with_rg,
                 pattern, abs_path, output_mode, context,
                 case_insensitive, glob, multiline, limit,
             )
@@ -902,14 +921,7 @@ class FilePlugin(BasePlugin):
             if not abs_path.is_dir():
                 return f"Not a directory: {path}"
 
-            matches = sorted(
-                abs_path.glob(pattern),
-                key=lambda p: p.stat().st_mtime if p.is_file() else 0,
-                reverse=True,
-            )
-
-            # Filter to files only
-            files = [m for m in matches if m.is_file()]
+            files = await asyncio.to_thread(self._find_files, abs_path, pattern)
 
             if not files:
                 return "No files found."

--- a/core/plugin/builtin_plugins/sticker/main.py
+++ b/core/plugin/builtin_plugins/sticker/main.py
@@ -120,10 +120,12 @@ class DefaultStickerPlugin(BasePlugin):
 
     async def _scan_once(self):
         logger.info("Scanning unregistered stickers")
-        sticker_files = [
-            f for f in os.listdir(self.sticker_mgr.sticker_folder)
-            if f.lower().endswith(STICKER_EXTENSIONS)
-        ]
+        sticker_files = await asyncio.to_thread(
+            lambda: [
+                f for f in os.listdir(self.sticker_mgr.sticker_folder)
+                if f.lower().endswith(STICKER_EXTENSIONS)
+            ]
+        )
         pending = [
             f for f in sticker_files
             if f not in self.sticker_mgr.sticker_paths

--- a/core/plugin/plugin_installer.py
+++ b/core/plugin/plugin_installer.py
@@ -138,7 +138,7 @@ async def install_from_zip(
     """
     temp_zip = _temp_dir() / f"upload_{uuid.uuid4().hex[:8]}.zip"
     try:
-        temp_zip.write_bytes(zip_bytes)
+        await asyncio.to_thread(temp_zip.write_bytes, zip_bytes)
     except Exception as e:
         temp_zip.unlink(missing_ok=True)
         raise IOError(f"Failed to write uploaded zip to temp: {e}") from e
@@ -205,6 +205,26 @@ async def install_requirements(plugin_dir: Path, pypi_mirror: Optional[str] = No
 # ---------------------------------------------------------------------------
 
 async def _extract_and_install(
+    temp_zip: Path,
+    plugins_dir: Path,
+    preferred_name: str = "",
+    is_plugin_installed: Optional[Callable[[str], bool]] = None,
+    target_dir: Optional[Path] = None,
+    expected_plugin_id: Optional[str] = None,
+) -> Path:
+    """Extract and install a plugin archive without blocking the event loop."""
+    return await asyncio.to_thread(
+        _extract_and_install_sync,
+        temp_zip,
+        plugins_dir,
+        preferred_name,
+        is_plugin_installed,
+        target_dir,
+        expected_plugin_id,
+    )
+
+
+def _extract_and_install_sync(
     temp_zip: Path,
     plugins_dir: Path,
     preferred_name: str = "",

--- a/core/plugin/plugin_installer.py
+++ b/core/plugin/plugin_installer.py
@@ -49,10 +49,14 @@ async def _run_thread_worker(func: Callable, *args):
     try:
         return await asyncio.shield(worker)
     except asyncio.CancelledError:
-        try:
-            await asyncio.shield(worker)
-        except Exception as exc:
-            logger.warning(f"Background plugin installer worker failed during cancellation: {exc}")
+        while not worker.done():
+            try:
+                await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                continue
+            except Exception as exc:
+                logger.warning(f"Background plugin installer worker failed during cancellation: {exc}")
+                break
         raise
 
 

--- a/core/plugin/plugin_installer.py
+++ b/core/plugin/plugin_installer.py
@@ -43,6 +43,18 @@ def _temp_dir() -> Path:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+async def _run_thread_worker(func: Callable, *args):
+    """Run blocking work in a thread and settle it before propagating cancellation."""
+    worker = asyncio.create_task(asyncio.to_thread(func, *args))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        try:
+            await asyncio.shield(worker)
+        except Exception as exc:
+            logger.warning(f"Background plugin installer worker failed during cancellation: {exc}")
+        raise
+
 
 async def install_from_github(
     repo_url: str,
@@ -138,19 +150,26 @@ async def install_from_zip(
     """
     temp_zip = _temp_dir() / f"upload_{uuid.uuid4().hex[:8]}.zip"
     try:
-        await asyncio.to_thread(temp_zip.write_bytes, zip_bytes)
+        await _run_thread_worker(temp_zip.write_bytes, zip_bytes)
+    except asyncio.CancelledError:
+        temp_zip.unlink(missing_ok=True)
+        raise
     except Exception as e:
         temp_zip.unlink(missing_ok=True)
         raise IOError(f"Failed to write uploaded zip to temp: {e}") from e
 
-    return await _extract_and_install(
-        temp_zip,
-        plugins_dir,
-        preferred_name=preferred_name,
-        is_plugin_installed=is_plugin_installed,
-        target_dir=target_dir,
-        expected_plugin_id=expected_plugin_id,
-    )
+    try:
+        return await _extract_and_install(
+            temp_zip,
+            plugins_dir,
+            preferred_name=preferred_name,
+            is_plugin_installed=is_plugin_installed,
+            target_dir=target_dir,
+            expected_plugin_id=expected_plugin_id,
+        )
+    except asyncio.CancelledError:
+        temp_zip.unlink(missing_ok=True)
+        raise
 
 
 async def install_requirements(plugin_dir: Path, pypi_mirror: Optional[str] = None) -> List[str]:
@@ -213,7 +232,7 @@ async def _extract_and_install(
     expected_plugin_id: Optional[str] = None,
 ) -> Path:
     """Extract and install a plugin archive without blocking the event loop."""
-    return await asyncio.to_thread(
+    return await _run_thread_worker(
         _extract_and_install_sync,
         temp_zip,
         plugins_dir,

--- a/tests/test_chat_plugin.py
+++ b/tests/test_chat_plugin.py
@@ -1,0 +1,55 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.plugin.builtin_plugins.chat.main import DefaultChatPlugin
+
+
+def _plugin():
+    processor = SimpleNamespace(
+        get_session_buffer_length=lambda _sid: 1,
+        flush_session_messages=AsyncMock(),
+    )
+    ctx = SimpleNamespace(
+        config={"bot_config": {"bot": {}}},
+        message_processor=processor,
+    )
+    plugin = DefaultChatPlugin(ctx, {})
+    plugin.debounce_interval = 0
+    return plugin
+
+
+@pytest.mark.anyio
+async def test_terminate_cancels_pending_debounce_tasks():
+    plugin = _plugin()
+    sid = "test:dm:1"
+    event = asyncio.Event()
+    task = asyncio.create_task(plugin._debounce_loop(sid, event))
+    plugin.session_events[sid] = event
+    plugin.session_tasks[sid] = task
+    await asyncio.sleep(0)
+
+    await plugin.terminate()
+
+    assert task.done()
+    assert plugin.session_tasks == {}
+    assert plugin.session_events == {}
+
+
+@pytest.mark.anyio
+async def test_completed_debounce_task_releases_session_state():
+    plugin = _plugin()
+    sid = "test:dm:1"
+    event = asyncio.Event()
+    event.set()
+    task = asyncio.create_task(plugin._debounce_loop(sid, event))
+    plugin.session_events[sid] = event
+    plugin.session_tasks[sid] = task
+
+    await task
+
+    plugin.ctx.message_processor.flush_session_messages.assert_awaited_once_with(sid)
+    assert sid not in plugin.session_tasks
+    assert sid not in plugin.session_events

--- a/tests/test_chat_plugin.py
+++ b/tests/test_chat_plugin.py
@@ -1,6 +1,6 @@
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -54,3 +54,37 @@ async def test_completed_debounce_task_releases_session_state():
     plugin.ctx.message_processor.flush_session_messages.assert_awaited_once_with(sid)
     assert sid not in plugin.session_tasks
     assert sid not in plugin.session_events
+
+
+@pytest.mark.anyio
+async def test_terminate_rejects_messages_arriving_during_cleanup():
+    plugin = _plugin()
+    sid = "test:dm:1"
+    cancellation_received = asyncio.Event()
+    release = asyncio.Event()
+
+    async def wait_for_termination():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_received.set()
+            await release.wait()
+            raise
+
+    task = asyncio.create_task(wait_for_termination())
+    plugin.session_events[sid] = asyncio.Event()
+    plugin.session_tasks[sid] = task
+    terminate_task = asyncio.create_task(plugin.terminate())
+    await cancellation_received.wait()
+
+    event = SimpleNamespace(buffer=Mock(), flush=Mock())
+    try:
+        await plugin.handle_msg(event)
+        event.buffer.assert_not_called()
+        event.flush.assert_not_called()
+        assert plugin.session_tasks == {}
+        assert plugin.session_events == {}
+    finally:
+        release.set()
+
+    await terminate_task

--- a/tests/test_chat_plugin.py
+++ b/tests/test_chat_plugin.py
@@ -34,6 +34,7 @@ async def test_terminate_cancels_pending_debounce_tasks():
     await plugin.terminate()
 
     assert task.done()
+    assert task.cancelled()
     assert plugin.session_tasks == {}
     assert plugin.session_events == {}
 

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -119,12 +119,57 @@ async def test_cancelled_upload_waits_for_writer_and_cleans_temp_file(tmp_path, 
     )
     await asyncio.to_thread(started.wait)
 
-    install_task.cancel()
-    await asyncio.sleep(0)
-    assert not install_task.done()
-
-    release.set()
+    try:
+        install_task.cancel()
+        await asyncio.sleep(0)
+        assert not install_task.done()
+        install_task.cancel()
+        await asyncio.sleep(0)
+        assert not install_task.done()
+    finally:
+        release.set()
     with pytest.raises(asyncio.CancelledError):
         await install_task
 
     assert not list((tmp_path / "temp").glob("upload_*.zip"))
+
+
+@pytest.mark.anyio
+async def test_cancelled_extraction_waits_for_worker_after_repeated_cancellation(
+    tmp_path, monkeypatch
+):
+    temp_zip = tmp_path / "temp" / "upload_test.zip"
+    temp_zip.parent.mkdir(parents=True)
+    temp_zip.write_bytes(b"archive")
+    started = threading.Event()
+    release = threading.Event()
+    worker_finished = threading.Event()
+
+    def blocking_extract(path: Path, *_args):
+        started.set()
+        try:
+            release.wait()
+        finally:
+            path.unlink(missing_ok=True)
+            worker_finished.set()
+
+    monkeypatch.setattr(plugin_installer, "_extract_and_install_sync", blocking_extract)
+    install_task = asyncio.create_task(
+        plugin_installer._extract_and_install(temp_zip, tmp_path / "plugins")
+    )
+    await asyncio.to_thread(started.wait)
+
+    try:
+        install_task.cancel()
+        await asyncio.sleep(0)
+        assert not install_task.done()
+        install_task.cancel()
+        await asyncio.sleep(0)
+        assert not install_task.done()
+    finally:
+        release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await install_task
+
+    assert worker_finished.is_set()
+    assert not temp_zip.exists()

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import json
+import threading
 import zipfile
 from pathlib import Path
 
@@ -97,3 +98,33 @@ def test_install_from_github_downloads_the_requested_commit(tmp_path, monkeypatc
     assert downloaded_urls == [
         f"https://github.com/example/plugin/archive/{commit_sha}.zip"
     ]
+
+
+@pytest.mark.anyio
+async def test_cancelled_upload_waits_for_writer_and_cleans_temp_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(plugin_installer, "get_data_path", lambda: tmp_path)
+    started = threading.Event()
+    release = threading.Event()
+    original_write_bytes = Path.write_bytes
+
+    def blocking_write_bytes(path: Path, data: bytes):
+        if path.parent == tmp_path / "temp" and path.name.startswith("upload_"):
+            started.set()
+            release.wait()
+        return original_write_bytes(path, data)
+
+    monkeypatch.setattr(Path, "write_bytes", blocking_write_bytes)
+    install_task = asyncio.create_task(
+        plugin_installer.install_from_zip(_plugin_archive("plugin-id"), tmp_path / "plugins")
+    )
+    await asyncio.to_thread(started.wait)
+
+    install_task.cancel()
+    await asyncio.sleep(0)
+    assert not install_task.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await install_task
+
+    assert not list((tmp_path / "temp").glob("upload_*.zip"))


### PR DESCRIPTION
## Summary

Fix plugin lifecycle and event-loop responsiveness issues: debounce tasks are cleaned up when the chat plugin stops, and blocking plugin I/O is moved to worker threads.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [x] test: Adding or updating tests

## Changes

- Cancel and release chat debounce tasks during plugin termination and after idle flushes.
- Move file tool read/write/list/search and ripgrep work off the event loop.
- Move sticker directory scanning and plugin archive write/extraction off the event loop.
- Add chat plugin lifecycle regression coverage.

## Screenshots / Logs

Backend-only change. Validation: `uv run pytest tests/ -q` — 385 passed (one third-party deprecation warning).

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat shutdown reliability by cancelling pending message-processing tasks and clearing session state.
  - Prevented file, sticker, and plugin installation operations from blocking the application, improving responsiveness.
  - Improved plugin installation handling during archive uploads and extraction.
  - Ensured pending chat messages are flushed correctly when processing completes.

- **Tests**
  - Added coverage for chat task cancellation, message flushing, and session cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->