### PR TITLE
fix: prevent adapter shutdown hangs

### DIFF
--- a/core/adapter/adapter_registry.py
+++ b/core/adapter/adapter_registry.py
@@ -574,7 +574,14 @@ class AdapterManager:
         if task and not task.done():
             task.cancel()
             try:
-                await task
+                await asyncio.wait_for(
+                    asyncio.shield(task), timeout=ADAPTER_STOP_TIMEOUT
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    f"Adapter {name} start task did not finish after cancellation within "
+                    f"{ADAPTER_STOP_TIMEOUT:.0f}s; continuing application shutdown"
+                )
             except asyncio.CancelledError:
                 pass
             except Exception as exc:
@@ -606,10 +613,9 @@ class AdapterManager:
 
         if name_value in self._adapters:
             try:
-                await self._adapters[name_value].stop()
+                await self.stop_adapter(name_value)
             except Exception as e:
                 logger.error(f"Failed to stop adapter {adapter_id} before deletion: {e}")
-            self._adapters.pop(name_value, None)
 
         del adapters_config[adapter_id]
         self.kira_config["adapters"] = adapters_config

--- a/core/adapter/adapter_registry.py
+++ b/core/adapter/adapter_registry.py
@@ -22,6 +22,8 @@ from .adapter_utils import IMAdapter, SocialMediaAdapter
 
 logger = get_logger("adapter", "blue")
 
+ADAPTER_STOP_TIMEOUT = 15.0
+
 
 class AdapterManager:
     _registry: Dict[str, Type[Union[IMAdapter, SocialMediaAdapter]]] = {}
@@ -580,8 +582,17 @@ class AdapterManager:
 
         adapter = self._adapters.get(name)
         if adapter:
-            await adapter.stop()
-            self._adapters.pop(name, None)
+            try:
+                await asyncio.wait_for(adapter.stop(), timeout=ADAPTER_STOP_TIMEOUT)
+            except asyncio.TimeoutError:
+                logger.error(
+                    f"Adapter {name} stop timed out after {ADAPTER_STOP_TIMEOUT:.0f}s; "
+                    "continuing application shutdown"
+                )
+            except Exception as exc:
+                logger.error(f"Adapter {name} failed while stopping: {exc}")
+            finally:
+                self._adapters.pop(name, None)
             logger.info(f"Stopped adapter {name}")
 
     async def delete_adapter(self, adapter_id: str) -> bool:
@@ -614,8 +625,8 @@ class AdapterManager:
 
     async def stop_adapters(self):
         """stop all running adapters"""
-        for ada in self._adapters:
-            await self._adapters[ada].stop()
+        for name in list(self._adapters):
+            await self.stop_adapter(name)
 
     def get_adapters(self) -> dict[str, Union[IMAdapter, SocialMediaAdapter]]:
         """return the entire dict where adapters are registered"""

--- a/core/adapter/src/telegram/telegram.py
+++ b/core/adapter/src/telegram/telegram.py
@@ -160,6 +160,9 @@ class TelegramAdapter(IMAdapter):
                         f"{TELEGRAM_SHUTDOWN_TIMEOUT:.0f}s; continuing cleanup"
                     )
                 except asyncio.CancelledError:
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise
                     logger.warning(
                         f"Telegram {component} stop was cancelled; continuing cleanup"
                     )

--- a/core/adapter/src/telegram/telegram.py
+++ b/core/adapter/src/telegram/telegram.py
@@ -30,6 +30,8 @@ from core.chat.message_elements import (
 
 logger = get_logger("tg_adapter", "green")
 
+TELEGRAM_SHUTDOWN_TIMEOUT = 5.0
+
 
 class _TelegramShutdownCancellationFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
@@ -149,7 +151,14 @@ class TelegramAdapter(IMAdapter):
         try:
             for component, shutdown in shutdown_steps:
                 try:
-                    await shutdown()
+                    await asyncio.wait_for(
+                        shutdown(), timeout=TELEGRAM_SHUTDOWN_TIMEOUT
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        f"Telegram {component} stop timed out after "
+                        f"{TELEGRAM_SHUTDOWN_TIMEOUT:.0f}s; continuing cleanup"
+                    )
                 except asyncio.CancelledError:
                     logger.warning(
                         f"Telegram {component} stop was cancelled; continuing cleanup"

--- a/tests/test_adapter_manager.py
+++ b/tests/test_adapter_manager.py
@@ -89,3 +89,60 @@ def test_delayed_adapter_start_failure_disables_the_adapter():
     assert info.name not in manager._adapter_tasks
     assert manager.kira_config["adapters"][adapter_id]["enabled"] is False
     assert manager.kira_config.save_count == 1
+
+
+class _CancellationResistantStartAdapter:
+    def __init__(self, release_event):
+        self.release_event = release_event
+        self.stop_calls = 0
+
+    async def start(self):
+        try:
+            await self.release_event.wait()
+        except asyncio.CancelledError:
+            await self.release_event.wait()
+
+    async def stop(self):
+        self.stop_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_stop_adapter_bounds_wait_for_cancellation_resistant_start_task(monkeypatch):
+    monkeypatch.setattr("core.adapter.adapter_registry.ADAPTER_STOP_TIMEOUT", 0.01)
+    release_event = asyncio.Event()
+    adapter = _CancellationResistantStartAdapter(release_event)
+    manager = object.__new__(AdapterManager)
+    manager._adapters = {"test": adapter}
+    start_task = asyncio.create_task(adapter.start())
+    manager._adapter_tasks = {"test": start_task}
+    await asyncio.sleep(0)
+
+    await manager.stop_adapter("test")
+
+    assert adapter.stop_calls == 1
+    assert "test" not in manager._adapters
+    release_event.set()
+    await start_task
+
+
+class _BlockingStopAdapter:
+    async def stop(self):
+        await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_delete_adapter_uses_bounded_stop(monkeypatch):
+    monkeypatch.setattr("core.adapter.adapter_registry.ADAPTER_STOP_TIMEOUT", 0.01)
+    adapter_id = "blocked-adapter"
+    manager = object.__new__(AdapterManager)
+    manager._adapters = {"blocked": _BlockingStopAdapter()}
+    manager._adapter_tasks = {}
+    manager.kira_config = _SavingConfig(
+        {"adapters": {adapter_id: {"name": "blocked"}}}
+    )
+    manager.adas_config = manager.kira_config["adapters"]
+
+    assert await manager.delete_adapter(adapter_id) is True
+    assert "blocked" not in manager._adapters
+    assert adapter_id not in manager.kira_config["adapters"]
+    assert manager.kira_config.save_count == 1

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -9,6 +9,7 @@ from core.adapter.src.telegram.telegram import (
     TelegramAdapter,
     _TelegramShutdownCancellationFilter,
 )
+from core.adapter.adapter_registry import AdapterManager
 from core.adapter.adapter_info import AdapterInfo
 
 
@@ -116,6 +117,33 @@ async def test_stop_continues_after_updater_stop_times_out(monkeypatch):
     updater_stop.assert_awaited_once()
     application_stop.assert_awaited_once()
     application_shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_adapter_stop_timeout_propagates_to_telegram_stop(monkeypatch):
+    monkeypatch.setattr("core.adapter.adapter_registry.ADAPTER_STOP_TIMEOUT", 0.01)
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    updater_stop = AsyncMock(side_effect=asyncio.Event().wait)
+    application_stop = AsyncMock()
+    application_shutdown = AsyncMock()
+    adapter.app = SimpleNamespace(
+        updater=SimpleNamespace(running=True, stop=updater_stop),
+        running=True,
+        stop=application_stop,
+        shutdown=application_shutdown,
+    )
+    adapter.config = {"bot_pid": "test-bot"}
+
+    manager = AdapterManager.__new__(AdapterManager)
+    manager._adapter_tasks = {}
+    manager._adapters = {"telegram-test": adapter}
+
+    await manager.stop_adapter("telegram-test")
+
+    updater_stop.assert_awaited_once()
+    application_stop.assert_not_awaited()
+    application_shutdown.assert_not_awaited()
+    assert "telegram-test" not in manager._adapters
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -94,6 +94,29 @@ async def test_stop_attempts_http_client_shutdown_after_application_stop_failure
     application_stop.assert_awaited_once()
     application_shutdown.assert_awaited_once()
 
+@pytest.mark.asyncio
+async def test_stop_continues_after_updater_stop_times_out(monkeypatch):
+    monkeypatch.setattr(
+        "core.adapter.src.telegram.telegram.TELEGRAM_SHUTDOWN_TIMEOUT", 0.01
+    )
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    updater_stop = AsyncMock(side_effect=asyncio.Event().wait)
+    application_stop = AsyncMock()
+    application_shutdown = AsyncMock()
+    adapter.app = SimpleNamespace(
+        updater=SimpleNamespace(running=True, stop=updater_stop),
+        running=True,
+        stop=application_stop,
+        shutdown=application_shutdown,
+    )
+    adapter.config = {"bot_pid": "test-bot"}
+
+    await adapter.stop()
+
+    updater_stop.assert_awaited_once()
+    application_stop.assert_awaited_once()
+    application_shutdown.assert_awaited_once()
+
 
 @pytest.mark.asyncio
 async def test_stop_continues_after_application_stop_is_cancelled():


### PR DESCRIPTION
## Summary

Prevent application shutdown from hanging indefinitely when an adapter's network cleanup stalls. Telegram shutdown steps now time out independently, and the adapter manager continues stopping the remaining application components after an adapter timeout.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [x] test: Adding or updating tests

## Changes

- Bound each Telegram updater, application, and HTTP-client shutdown step to 5 seconds.
- Added a 15-second adapter-level shutdown fallback for normal, startup, and bulk teardown paths.
- Route adapter deletion through the same bounded cleanup path.
- Added regression coverage for Telegram timeout propagation, cancellation-resistant startup tasks, and adapter deletion.

## Screenshots / Logs

N/A — backend shutdown behavior. A timeout now emits an adapter-specific warning and teardown proceeds.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown reliability by preventing stalled adapters or components from blocking application shutdown indefinitely.
  * Shutdown now continues with remaining cleanup tasks when an individual component exceeds its timeout.
  * Ensured stopped adapters are removed even when shutdown times out.

* **Tests**
  * Added coverage verifying cleanup continues after a component shutdown timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->