### PR TITLE
fix: close Discord gateway before cancelling bot task

### DIFF
--- a/core/adapter/src/discord/discord.py
+++ b/core/adapter/src/discord/discord.py
@@ -228,11 +228,19 @@ class DiscordAdapter(IMAdapter):
         finally:
             if self._bot_task and not self._bot_task.done():
                 self._bot_task.cancel()
+
+                async def wait_for_bot_task():
+                    try:
+                        await self._bot_task
+                    except asyncio.CancelledError:
+                        pass
+
+                waiter = asyncio.create_task(wait_for_bot_task())
                 try:
-                    await asyncio.shield(self._bot_task)
+                    await asyncio.shield(waiter)
                 except asyncio.CancelledError:
-                    if not self._bot_task.cancelled():
-                        raise
+                    waiter.cancel()
+                    raise
 
         if self.bot:
             self.logger.info(f"Stopped Discord adapter for {self.config.get('bot_pid', 'bot')}")

--- a/core/adapter/src/discord/discord.py
+++ b/core/adapter/src/discord/discord.py
@@ -222,14 +222,19 @@ class DiscordAdapter(IMAdapter):
 
     async def stop(self):
         """Stop the Discord adapter."""
-        if self._bot_task and not self._bot_task.done():
-            self._bot_task.cancel()
-            try:
-                await self._bot_task
-            except asyncio.CancelledError:
-                pass
-        if self.bot and not self.bot.is_closed():
-            await self.bot.close()
+        try:
+            if self.bot and not self.bot.is_closed():
+                await self.bot.close()
+        finally:
+            if self._bot_task and not self._bot_task.done():
+                self._bot_task.cancel()
+                try:
+                    await asyncio.shield(self._bot_task)
+                except asyncio.CancelledError:
+                    if not self._bot_task.cancelled():
+                        raise
+
+        if self.bot:
             self.logger.info(f"Stopped Discord adapter for {self.config.get('bot_pid', 'bot')}")
 
     def get_client(self) -> discord.Bot:

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -9,6 +9,7 @@ from core.adapter.src.telegram.telegram import (
     TelegramAdapter,
     _TelegramShutdownCancellationFilter,
 )
+from core.adapter.src.discord.discord import DiscordAdapter
 from core.adapter.adapter_registry import AdapterManager
 from core.adapter.adapter_info import AdapterInfo
 
@@ -165,3 +166,71 @@ async def test_stop_continues_after_application_stop_is_cancelled():
     updater_stop.assert_awaited_once()
     application_stop.assert_awaited_once()
     application_shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_stop_closes_gateway_before_cancelling_bot_task():
+    events = []
+
+    async def wait_for_cancellation():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            events.append("bot-task-cancelled")
+            raise
+
+    async def close_bot():
+        events.append("bot-closed")
+
+    adapter = DiscordAdapter.__new__(DiscordAdapter)
+    adapter._bot_task = asyncio.create_task(wait_for_cancellation())
+    adapter.bot = SimpleNamespace(
+        is_closed=Mock(return_value=False),
+        close=AsyncMock(side_effect=close_bot),
+    )
+    adapter.config = {"bot_pid": "test-bot"}
+    adapter.logger = Mock()
+
+    await asyncio.sleep(0)
+    await adapter.stop()
+
+    adapter.bot.close.assert_awaited_once()
+    assert events == ["bot-closed", "bot-task-cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_discord_stop_propagates_outer_cancellation_after_closing_gateway():
+    task_release = asyncio.Event()
+    gateway_closed = asyncio.Event()
+    task_cancelled = asyncio.Event()
+
+    async def wait_after_cancellation():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            task_cancelled.set()
+            await task_release.wait()
+
+    async def close_bot():
+        gateway_closed.set()
+
+    adapter = DiscordAdapter.__new__(DiscordAdapter)
+    adapter._bot_task = asyncio.create_task(wait_after_cancellation())
+    adapter.bot = SimpleNamespace(
+        is_closed=Mock(return_value=False),
+        close=AsyncMock(side_effect=close_bot),
+    )
+    adapter.config = {"bot_pid": "test-bot"}
+    adapter.logger = Mock()
+
+    await asyncio.sleep(0)
+    stop_task = asyncio.create_task(adapter.stop())
+    await gateway_closed.wait()
+    await task_cancelled.wait()
+    stop_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await stop_task
+
+    task_release.set()
+    await adapter._bot_task

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -199,23 +199,19 @@ async def test_discord_stop_closes_gateway_before_cancelling_bot_task():
 
 
 @pytest.mark.asyncio
-async def test_discord_stop_propagates_outer_cancellation_after_closing_gateway():
-    task_release = asyncio.Event()
+async def test_discord_stop_propagates_caller_cancellation_racing_with_bot_task():
+    close_release = asyncio.Event()
     gateway_closed = asyncio.Event()
-    task_cancelled = asyncio.Event()
 
-    async def wait_after_cancellation():
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            task_cancelled.set()
-            await task_release.wait()
+    async def wait_for_cancellation():
+        await asyncio.Event().wait()
 
     async def close_bot():
         gateway_closed.set()
+        await close_release.wait()
 
     adapter = DiscordAdapter.__new__(DiscordAdapter)
-    adapter._bot_task = asyncio.create_task(wait_after_cancellation())
+    adapter._bot_task = asyncio.create_task(wait_for_cancellation())
     adapter.bot = SimpleNamespace(
         is_closed=Mock(return_value=False),
         close=AsyncMock(side_effect=close_bot),
@@ -226,11 +222,11 @@ async def test_discord_stop_propagates_outer_cancellation_after_closing_gateway(
     await asyncio.sleep(0)
     stop_task = asyncio.create_task(adapter.stop())
     await gateway_closed.wait()
-    await task_cancelled.wait()
-    stop_task.cancel()
+    adapter._bot_task.add_done_callback(lambda _: stop_task.cancel())
+    close_release.set()
 
     with pytest.raises(asyncio.CancelledError):
         await stop_task
 
-    task_release.set()
-    await adapter._bot_task
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._bot_task


### PR DESCRIPTION
## Summary

Fixes Discord shutdown ordering so py-cord closes the gateway and stops its keep-alive thread before the bot task is cancelled. This prevents the heartbeat thread from submitting work to a closed event loop during Ctrl+C shutdown.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Close the Discord gateway before cancelling the background bot task.
- Preserve outer shutdown cancellation while the bot task is being collected.
- Add regressions for close ordering and Ctrl+C propagation.

## Screenshots / Logs

`python -m pytest tests/test_telegram_adapter.py tests/test_adapter_manager.py -v` — 15 passed.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling for Discord integrations.
  * Ensured the connection closes cleanly before background activity stops.
  * Preserved cancellation behavior when shutdown is interrupted.
* **Tests**
  * Added coverage for orderly connection closure and cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->