### PR TITLE
fix(update): preserve runtime data during source updates

### DIFF
--- a/core/utils/path_utils.py
+++ b/core/utils/path_utils.py
@@ -3,6 +3,7 @@ from pathlib import Path, PureWindowsPath
 from typing import Optional
 
 # ─── Path overrides (set once via init_paths at startup) ─────────────────────
+_configured_data_dir: Optional[Path] = None
 _data_dir: Optional[Path] = None
 _webui_dir: Optional[Path] = None
 
@@ -15,9 +16,10 @@ def init_paths(
     Set path overrides from CLI arguments.  Must be called once at startup,
     before any other module reads paths.
     """
-    global _data_dir, _webui_dir
+    global _configured_data_dir, _data_dir, _webui_dir
     if data_dir is not None:
-        _data_dir = Path(data_dir).resolve()
+        _configured_data_dir = Path(data_dir).absolute()
+        _data_dir = _configured_data_dir.resolve()
     if webui_dir is not None:
         _webui_dir = Path(webui_dir).resolve()
 
@@ -29,6 +31,11 @@ def get_root_path() -> Path:
 def get_data_path() -> Path:
     """Return the data directory.  Defaults to ``<cwd>/data``."""
     return _data_dir if _data_dir is not None else get_root_path() / "data"
+
+
+def get_configured_data_path() -> Path:
+    """Return the configured data path without resolving symlinks or junctions."""
+    return _configured_data_dir if _configured_data_dir is not None else get_root_path() / "data"
 
 
 def get_webui_dist_path() -> Path:

--- a/tests/test_releases.py
+++ b/tests/test_releases.py
@@ -1,5 +1,6 @@
 import io
 import asyncio
+import shutil
 import subprocess
 import tempfile
 import zipfile
@@ -52,6 +53,7 @@ def test_apply_update_never_replaces_runtime_data(tmp_path: Path, monkeypatch) -
 
     monkeypatch.setattr(releases, "get_root_path", lambda: root)
     monkeypatch.setattr(releases, "get_data_path", lambda: root / "data")
+    monkeypatch.setattr(releases, "get_configured_data_path", lambda: root / "data")
 
     releases.ReleasesRoutes._apply_update(archive)
 
@@ -77,6 +79,7 @@ def test_apply_update_never_replaces_custom_runtime_data(tmp_path: Path, monkeyp
 
     monkeypatch.setattr(releases, "get_root_path", lambda: root)
     monkeypatch.setattr(releases, "get_data_path", lambda: runtime_data)
+    monkeypatch.setattr(releases, "get_configured_data_path", lambda: runtime_data)
 
     releases.ReleasesRoutes._apply_update(archive)
 
@@ -85,10 +88,37 @@ def test_apply_update_never_replaces_custom_runtime_data(tmp_path: Path, monkeyp
     assert (runtime_data / "config" / "settings.json").read_text(encoding="utf-8") == "user settings"
 
 
+def test_apply_update_never_replaces_data_dir_alias(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "app"
+    root.mkdir()
+    runtime_data = root / "data"
+    (runtime_data / "config").mkdir(parents=True)
+    (runtime_data / "config" / "settings.json").write_text("user settings", encoding="utf-8")
+    data_alias = root / "data-alias"
+
+    archive = tmp_path / "update.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("KiraAI-release/main.py", "new application")
+        zf.writestr("KiraAI-release/data-alias/config/settings.json", "release data")
+
+    monkeypatch.setattr(releases, "get_root_path", lambda: root)
+    monkeypatch.setattr(releases, "get_data_path", lambda: runtime_data)
+    monkeypatch.setattr(releases, "get_configured_data_path", lambda: data_alias)
+
+    releases.ReleasesRoutes._apply_update(archive)
+
+    assert (root / "main.py").read_text(encoding="utf-8") == "new application"
+    assert (runtime_data / "config" / "settings.json").read_text(encoding="utf-8") == "user settings"
+    assert not data_alias.exists()
+
+
 def test_repository_does_not_track_runtime_data() -> None:
     project_root = Path(__file__).resolve().parents[1]
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        raise RuntimeError("git executable is required for this test")
     tracked_paths = subprocess.run(
-        ["git", "ls-files", "--", "data"],
+        [git_executable, "ls-files", "--", "data"],
         cwd=project_root,
         check=True,
         capture_output=True,

--- a/tests/test_releases.py
+++ b/tests/test_releases.py
@@ -118,14 +118,15 @@ def test_repository_does_not_track_runtime_data() -> None:
     if git_executable is None:
         raise RuntimeError("git executable is required for this test")
     tracked_paths = subprocess.run(
-        [git_executable, "ls-files", "--", "data"],
+        [git_executable, "ls-files"],
         cwd=project_root,
         check=True,
         capture_output=True,
         text=True,
-    ).stdout.strip()
+    ).stdout.splitlines()
 
-    assert not tracked_paths
+    runtime_data_paths = [path for path in tracked_paths if path.partition("/")[0].casefold() == "data"]
+    assert not runtime_data_paths
 
 
 def test_apply_update_stages_on_application_filesystem(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_releases.py
+++ b/tests/test_releases.py
@@ -1,5 +1,6 @@
 import io
 import asyncio
+import subprocess
 import tempfile
 import zipfile
 from pathlib import Path
@@ -47,15 +48,54 @@ def test_apply_update_never_replaces_runtime_data(tmp_path: Path, monkeypatch) -
     archive = tmp_path / "update.zip"
     with zipfile.ZipFile(archive, "w") as zf:
         zf.writestr("KiraAI-release/main.py", "new application")
-        zf.writestr("KiraAI-release/data/plugins/example/manifest.json", "release data")
+        zf.writestr("KiraAI-release/Data/plugins/example/manifest.json", "release data")
 
     monkeypatch.setattr(releases, "get_root_path", lambda: root)
+    monkeypatch.setattr(releases, "get_data_path", lambda: root / "data")
 
     releases.ReleasesRoutes._apply_update(archive)
 
     assert (root / "main.py").read_text(encoding="utf-8") == "new application"
     assert (root / "data" / "config" / "settings.json").read_text(encoding="utf-8") == "user settings"
     assert not (root / "data" / "plugins" / "example").exists()
+
+
+def test_apply_update_never_replaces_custom_runtime_data(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "app"
+    root.mkdir()
+    (root / "data" / "config").mkdir(parents=True)
+    (root / "data" / "config" / "settings.json").write_text("default user settings", encoding="utf-8")
+    runtime_data = root / "runtime-state"
+    (runtime_data / "config").mkdir(parents=True)
+    (runtime_data / "config" / "settings.json").write_text("user settings", encoding="utf-8")
+
+    archive = tmp_path / "update.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("KiraAI-release/main.py", "new application")
+        zf.writestr("KiraAI-release/Data/config/settings.json", "release default data")
+        zf.writestr("KiraAI-release/runtime-state/config/settings.json", "release data")
+
+    monkeypatch.setattr(releases, "get_root_path", lambda: root)
+    monkeypatch.setattr(releases, "get_data_path", lambda: runtime_data)
+
+    releases.ReleasesRoutes._apply_update(archive)
+
+    assert (root / "main.py").read_text(encoding="utf-8") == "new application"
+    assert (root / "data" / "config" / "settings.json").read_text(encoding="utf-8") == "default user settings"
+    assert (runtime_data / "config" / "settings.json").read_text(encoding="utf-8") == "user settings"
+
+
+def test_repository_does_not_track_runtime_data() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    tracked_paths = subprocess.run(
+        ["git", "ls-files", "--", "data"],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    assert not tracked_paths
 
 
 def test_apply_update_stages_on_application_filesystem(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_releases.py
+++ b/tests/test_releases.py
@@ -37,6 +37,27 @@ def test_apply_update_replaces_files_and_leaves_legacy_backups_untouched(tmp_pat
     assert stale_file_artifact.exists()
 
 
+def test_apply_update_never_replaces_runtime_data(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "app"
+    root.mkdir()
+    (root / "main.py").write_text("old application", encoding="utf-8")
+    (root / "data" / "config").mkdir(parents=True)
+    (root / "data" / "config" / "settings.json").write_text("user settings", encoding="utf-8")
+
+    archive = tmp_path / "update.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("KiraAI-release/main.py", "new application")
+        zf.writestr("KiraAI-release/data/plugins/example/manifest.json", "release data")
+
+    monkeypatch.setattr(releases, "get_root_path", lambda: root)
+
+    releases.ReleasesRoutes._apply_update(archive)
+
+    assert (root / "main.py").read_text(encoding="utf-8") == "new application"
+    assert (root / "data" / "config" / "settings.json").read_text(encoding="utf-8") == "user settings"
+    assert not (root / "data" / "plugins" / "example").exists()
+
+
 def test_apply_update_stages_on_application_filesystem(tmp_path: Path, monkeypatch) -> None:
     root = tmp_path / "app"
     root.mkdir()

--- a/webui/routes/releases.py
+++ b/webui/routes/releases.py
@@ -15,7 +15,7 @@ from core.logging_manager import get_logger
 from core.plugin.plugin_installer import install_requirements
 from core.utils.dist_checker import apply_dist_archive, download_dist_archive
 from core.utils.github_api import download_asset, get_all_releases, pick_fastest_source
-from core.utils.path_utils import get_data_path, get_root_path
+from core.utils.path_utils import get_configured_data_path, get_data_path, get_root_path
 from core.utils.update_transaction import STAGE_PREFIX, UpdateTransaction
 from webui.models import DownloadReleaseRequest, ReleaseUpdateProgress, ReleasesResponse
 from webui.routes.auth import require_auth
@@ -31,14 +31,15 @@ RESTART_PROGRESS_GRACE_SECONDS = 2.0  # Let the browser observe the restarting s
 def _get_protected_source_update_items(root: Path) -> frozenset[str]:
     """Return source paths that must never replace user-owned runtime data."""
     protected_items = {"data"}
-    data_path = get_data_path().resolve()
-    try:
-        relative_data_path = data_path.relative_to(root.resolve())
-    except ValueError:
-        return frozenset(protected_items)
-    if not relative_data_path.parts:
-        raise ValueError("Source updates are unsafe when the runtime data directory is the application root")
-    protected_items.add(relative_data_path.parts[0].casefold())
+    root = root.resolve()
+    for data_path in (get_data_path(), get_configured_data_path()):
+        try:
+            relative_data_path = data_path.absolute().relative_to(root)
+        except ValueError:
+            continue
+        if not relative_data_path.parts:
+            raise ValueError("Source updates are unsafe when the runtime data directory is the application root")
+        protected_items.add(relative_data_path.parts[0].casefold())
     return frozenset(protected_items)
 
 

--- a/webui/routes/releases.py
+++ b/webui/routes/releases.py
@@ -26,8 +26,22 @@ logger = get_logger("releases", "green")
 RESTART_EXIT_CODE = 42
 RESTART_DELAY_SECONDS = 0.5  # Allow HTTP response to flush before hard exit
 RESTART_PROGRESS_GRACE_SECONDS = 2.0  # Let the browser observe the restarting state first
-# Runtime data is user-owned and must never be replaced by a source update.
-PROTECTED_SOURCE_UPDATE_ITEMS = frozenset({"data"})
+
+
+def _get_protected_source_update_items(root: Path) -> frozenset[str]:
+    """Return source paths that must never replace user-owned runtime data."""
+    protected_items = {"data"}
+    data_path = get_data_path().resolve()
+    try:
+        relative_data_path = data_path.relative_to(root.resolve())
+    except ValueError:
+        return frozenset(protected_items)
+    if not relative_data_path.parts:
+        raise ValueError("Source updates are unsafe when the runtime data directory is the application root")
+    protected_items.add(relative_data_path.parts[0].casefold())
+    return frozenset(protected_items)
+
+
 _install_lock = asyncio.Lock()
 
 _RELEASES_CACHE_TTL = 300  # 5 minutes
@@ -253,9 +267,11 @@ class ReleasesRoutes(Routes):
             else:
                 source_root = tmp
 
-            # Collect what the zip contains (top-level names only)
+            # Collect what the zip contains (top-level names only). Runtime data
+            # is excluded even if it was accidentally committed to a release.
+            protected_items = _get_protected_source_update_items(root)
             zip_items: list[str] = [
-                item.name for item in source_root.iterdir() if item.name not in PROTECTED_SOURCE_UPDATE_ITEMS
+                item.name for item in source_root.iterdir() if item.name.casefold() not in protected_items
             ]
             if not zip_items:
                 raise ValueError("Update archive does not contain any application files")

--- a/webui/routes/releases.py
+++ b/webui/routes/releases.py
@@ -26,6 +26,8 @@ logger = get_logger("releases", "green")
 RESTART_EXIT_CODE = 42
 RESTART_DELAY_SECONDS = 0.5  # Allow HTTP response to flush before hard exit
 RESTART_PROGRESS_GRACE_SECONDS = 2.0  # Let the browser observe the restarting state first
+# Runtime data is user-owned and must never be replaced by a source update.
+PROTECTED_SOURCE_UPDATE_ITEMS = frozenset({"data"})
 _install_lock = asyncio.Lock()
 
 _RELEASES_CACHE_TTL = 300  # 5 minutes
@@ -252,7 +254,11 @@ class ReleasesRoutes(Routes):
                 source_root = tmp
 
             # Collect what the zip contains (top-level names only)
-            zip_items: list[str] = [item.name for item in source_root.iterdir()]
+            zip_items: list[str] = [
+                item.name for item in source_root.iterdir() if item.name not in PROTECTED_SOURCE_UPDATE_ITEMS
+            ]
+            if not zip_items:
+                raise ValueError("Update archive does not contain any application files")
 
             # Place staging inside root: root.parent can be a different Docker
             # mount, which makes rename() fail with EXDEV (cross-device link).


### PR DESCRIPTION
## Summary

Prevents the in-app source updater from replacing the user-owned `data/` directory when a release archive accidentally includes it.

## Type of change

- [x] fix: Bug fix
- [ ] feat: New feature
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Exclude top-level `data/` from source update transactions.
- Add a regression test proving local runtime data is retained and archived data is ignored.

## Screenshots / Logs

Not applicable. `python -m pytest tests/test_releases.py -v` passed: 7 tests.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Source updates now protect runtime data from being overwritten.
  * Updates preserve both default and custom runtime settings.
  * Archives containing only protected runtime data are rejected instead of applied.
  * Runtime data is excluded from version-controlled application files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->