### PR TITLE
fix: parse MCP media results and suppress payload logs

### DIFF
--- a/core/agent/mcp_mgr.py
+++ b/core/agent/mcp_mgr.py
@@ -1,16 +1,19 @@
 import json
 import asyncio
 import uuid
-from typing import Optional, Literal
+from typing import Any, Optional, Literal
 from dataclasses import dataclass, field
+from urllib.parse import urlparse
 from fastmcp import Client
 
 from .func_tool_manager import FuncToolManager
+from .tool import ToolResult
+from core.chat.message_elements import File, Image, Record
 from core.utils.path_utils import get_config_path
 
 from core.logging_manager import get_logger
 
-logger = get_logger("mcp", "orange")
+logger = get_logger("mcp_mgr", "orange")
 
 MCP_CONFIG_PATH = get_config_path() / "mcp.json"
 
@@ -602,9 +605,113 @@ class MCPManager:
                 )
                 await self.close_connection(server.id)
                 raise
-            return str(result)
+            return self._parse_tool_result(result)
 
         return _wrapped
+
+    @staticmethod
+    def _get_result_field(value: Any, field_name: str, default: Any = None) -> Any:
+        """Read an MCP field from either a Pydantic model or a dict."""
+        if isinstance(value, dict):
+            return value.get(field_name, default)
+        return getattr(value, field_name, default)
+
+    @staticmethod
+    def _resource_name(uri: Any) -> Optional[str]:
+        if uri is None:
+            return None
+        return urlparse(str(uri)).path.rsplit("/", 1)[-1] or None
+
+    @classmethod
+    def _media_attachment(
+        cls, data: Any, mime_type: Any, name: Optional[str] = None
+    ) -> Image | Record | File | None:
+        if not isinstance(data, str) or not data:
+            return None
+
+        mime = mime_type if isinstance(mime_type, str) and mime_type else "application/octet-stream"
+        media = data if data.startswith(("data:", "http://", "https://", "file:///")) else f"data:{mime};base64,{data}"
+        if mime.startswith("image/"):
+            return Image(image=media, mime=mime, name=name)
+        if mime.startswith("audio/"):
+            return Record(record=media, mime=mime, name=name)
+        return File(file=media, mime=mime, name=name)
+
+    @classmethod
+    def _parse_tool_result(cls, result: Any) -> ToolResult:
+        """Convert an MCP tool result into KiraAI text and media attachments."""
+        content_blocks = cls._get_result_field(result, "content")
+        if not isinstance(content_blocks, list):
+            return ToolResult(text=str(result))
+
+        text_parts: list[str] = []
+        attachments: list[Image | Record | File] = []
+
+        for block in content_blocks:
+            block_type = cls._get_result_field(block, "type")
+            if block_type == "text":
+                text = cls._get_result_field(block, "text")
+                if isinstance(text, str) and text:
+                    text_parts.append(text)
+                continue
+
+            if block_type in ("image", "audio"):
+                attachment = cls._media_attachment(
+                    cls._get_result_field(block, "data"),
+                    cls._get_result_field(block, "mimeType"),
+                )
+                if attachment:
+                    attachments.append(attachment)
+                continue
+
+            if block_type == "resource":
+                resource = cls._get_result_field(block, "resource")
+                uri = cls._get_result_field(resource, "uri")
+                resource_text = cls._get_result_field(resource, "text")
+                if isinstance(resource_text, str):
+                    text_parts.append(resource_text)
+                    continue
+                attachment = cls._media_attachment(
+                    cls._get_result_field(resource, "blob"),
+                    cls._get_result_field(resource, "mimeType"),
+                    cls._resource_name(uri),
+                )
+                if attachment:
+                    attachments.append(attachment)
+                else:
+                    text_parts.append("[MCP returned an empty embedded resource]")
+                continue
+
+            if block_type == "resource_link":
+                uri = cls._get_result_field(block, "uri")
+                uri_string = str(uri) if uri is not None else ""
+                mime_type = cls._get_result_field(block, "mimeType")
+                if uri_string.startswith(("http://", "https://", "file:///")):
+                    attachment = cls._media_attachment(uri_string, mime_type, cls._resource_name(uri_string))
+                    if attachment:
+                        attachments.append(attachment)
+                        continue
+                if uri_string:
+                    text_parts.append(f"MCP resource: {uri_string}")
+                else:
+                    text_parts.append("[MCP returned a resource link without a URI]")
+                continue
+
+            text_parts.append(f"[MCP returned unsupported content block: {block_type or 'unknown'}]")
+
+        structured_content = cls._get_result_field(
+            result,
+            "structured_content",
+            cls._get_result_field(result, "structuredContent"),
+        )
+        if structured_content is not None:
+            try:
+                structured_text = json.dumps(structured_content, ensure_ascii=False, indent=2, default=str)
+            except (TypeError, ValueError):
+                structured_text = str(structured_content)
+            text_parts.append(f"Structured result:\n{structured_text}")
+
+        return ToolResult(text="\n".join(text_parts), attachments=attachments)
 
     async def list_tools(self, server: MCPServer, keep_connection: Optional[bool] = None):
         """Refresh server.tools.

--- a/core/logging_manager.py
+++ b/core/logging_manager.py
@@ -144,6 +144,10 @@ def setup_logging(log_level: str = "INFO", log_file_path: str = None, log_file_m
     _log_file_max_size = log_file_max_size
 
     level = _LEVEL_MAP.get(log_level.upper(), logging.INFO)
+
+    # MCP DEBUG responses can contain complete base64 media payloads.
+    logging.getLogger("mcp").setLevel(logging.WARNING)
+
     log_file = str(Path(_log_file_path or f"{get_data_path()}/log.log").resolve())
     max_bytes = _log_file_max_size * 1024 * 1024
 

--- a/tests/test_logging_manager.py
+++ b/tests/test_logging_manager.py
@@ -330,6 +330,15 @@ class TestSetupLogging:
         setup_logging(log_level="INVALID")
         assert logger.handlers[0].level == logging.INFO
 
+    def test_silences_mcp_debug_logger(self):
+        mcp_logger = logging.getLogger("mcp")
+        previous_level = mcp_logger.level
+        try:
+            mcp_logger.setLevel(logging.DEBUG)
+            setup_logging(log_level="DEBUG")
+            assert mcp_logger.level == logging.WARNING
+        finally:
+            mcp_logger.setLevel(previous_level)
     def test_invalid_max_size_defaults_to_10(self, tmp_path):
         setup_logging(log_file_max_size="not_a_number")
         assert lm._log_file_max_size == 10

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -102,7 +102,7 @@ async def test_server_recovers_after_crash(flaky_env):
         ping = manager._make_mcp_func(server, "ping_tool")
         transfer = manager._make_mcp_func(server, "transfer")
 
-        assert "pong" in await ping()
+        assert "pong" in (await ping()).text
 
         with pytest.raises(McpError):
             await transfer(amount=1)
@@ -111,7 +111,7 @@ async def test_server_recovers_after_crash(flaky_env):
         assert server.id not in manager._clients
 
         # a fresh subprocess is spawned and the server is usable again
-        assert "pong" in await ping()
+        assert "pong" in (await ping()).text
         assert _ledger_entries(ledger) == ["transfer 1"]
     finally:
         await manager.shutdown()

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -1,6 +1,10 @@
 """Tests for MCPManager persistent connection handling."""
 
 import pytest
+from mcp.types import AudioContent, BlobResourceContents, CallToolResult, EmbeddedResource, ImageContent, ResourceLink, TextContent
+
+from core.agent.tool import ToolResult
+from core.chat.message_elements import File, Image, Record
 
 import core.agent.mcp_mgr as mcp_mgr
 from core.agent.mcp_mgr import MCPManager, MCPServer
@@ -98,7 +102,7 @@ async def test_tool_calls_reuse_one_connection(manager):
     manager.add_server(server)
 
     func = manager._make_mcp_func(server, "echo")
-    await func(x=1)
+    result = await func(x=1)
     await func(x=2)
     await func(x=3)
 
@@ -108,6 +112,7 @@ async def test_tool_calls_reuse_one_connection(manager):
     assert client.enter_count == 1
     assert len(client.calls) == 3
     assert client.connected is True
+    assert result.text == 'result:echo'
 
 
 @pytest.mark.anyio
@@ -122,7 +127,7 @@ async def test_reconnects_after_connection_drop(manager):
     FakeClient.instances[0].connected = False
 
     result = await func(x=2)
-    assert result == "result:echo"
+    assert result.text == 'result:echo'
     # a fresh client was built for the reconnect
     assert len(FakeClient.instances) == 2
     assert FakeClient.instances[1].connected is True
@@ -192,7 +197,7 @@ async def test_next_call_recovers_after_connection_death(manager):
         await func(x=1)
 
     # the next call builds a fresh connection and succeeds
-    assert await func(x=2) == "result:echo"
+    assert (await func(x=2)).text == 'result:echo'
     assert len(FakeClient.instances) == 2
     assert manager._clients[server.id] is FakeClient.instances[1]
 
@@ -328,3 +333,40 @@ async def test_enable_server_fails_when_unreachable(manager, monkeypatch):
     assert manager.mcp_config["mcpServers"][server.id].get("enabled") is not True
     assert manager.tool_manager.registered == {}
     assert server.id not in manager._clients
+
+
+def test_mcp_result_is_converted_to_kira_tool_result():
+    result = CallToolResult(
+        content=[
+            TextContent(type="text", text="Generated media"),
+            ImageContent(type="image", data="aW1hZ2U=", mimeType="image/png"),
+            AudioContent(type="audio", data="YXVkaW8=", mimeType="audio/mpeg"),
+            EmbeddedResource(
+                type="resource",
+                resource=BlobResourceContents(
+                    uri="resource://reports/summary.pdf",
+                    mimeType="application/pdf",
+                    blob="ZmlsZQ==",
+                ),
+            ),
+            ResourceLink(
+                type="resource_link",
+                name="remote-image",
+                uri="https://example.com/generated.png",
+                mimeType="image/png",
+            ),
+        ],
+        structuredContent={"status": "ok"},
+    )
+
+    parsed = MCPManager._parse_tool_result(result)
+
+    assert isinstance(parsed, ToolResult)
+    assert parsed.text == 'Generated media\nStructured result:\n{\n  "status": "ok"\n}'
+    assert [type(attachment) for attachment in parsed.attachments] == [Image, Record, File, Image]
+    assert parsed.attachments[0].mime == "image/png"
+    assert parsed.attachments[1].mime == "audio/mpeg"
+    assert parsed.attachments[2].name == "summary.pdf"
+    assert parsed.attachments[3].file == "https://example.com/generated.png"
+    assert "aW1hZ2U=" not in parsed.text
+    assert "YXVkaW8=" not in parsed.text


### PR DESCRIPTION
## Summary

Fix MCP tool-result handling so media content is converted to KiraAI attachments instead of being serialized as large Python representations. Suppress third-party MCP DEBUG responses that can contain complete base64 payloads.

## Type of change

- [x] fix: Bug fix
- [ ] feat: New feature
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Convert MCP text, image, audio, embedded-resource, and resource-link responses into KiraAI `ToolResult` text and attachments.
- Keep structured MCP results as formatted JSON text instead of raw result representations.
- Rename the KiraAI MCP manager logger to `mcp_mgr` and silence the third-party `mcp` logger at WARNING to prevent base64 response logging.
- Update MCP and logging regression coverage for the new result type and logging behavior.

## Screenshots / Logs

Not applicable. Automated tests passed.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tool responses now provide structured text and support image, audio, file, and resource attachments.
  * Structured response content is preserved for improved downstream handling.

* **Bug Fixes**
  * Reduced logging of potentially large media payloads at debug level.
  * MCP health checks now correctly read response text.

* **Tests**
  * Added coverage for structured tool results, media attachments, and logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->