### PR TITLE
fix: send images through QQ official bot

### DIFF
--- a/core/adapter/src/qq_official/qq_official.py
+++ b/core/adapter/src/qq_official/qq_official.py
@@ -453,11 +453,22 @@ class QQOfficialAdapter(IMAdapter):
                 parts.append(element.emoji_desc or "")
             elif isinstance(element, Reply):
                 continue
-            elif isinstance(element, File):
+            elif isinstance(element, (File, Image)):
                 continue
             else:
                 parts.append("[Unsupported message element]")
         return "".join(parts).strip()
+
+    @staticmethod
+    def _media_payload(upload_result: Any) -> Optional[dict[str, str]]:
+        """Build the rich-media payload expected by QQ's message API."""
+        if isinstance(upload_result, dict):
+            file_info = upload_result.get("file_info")
+        else:
+            file_info = getattr(upload_result, "file_info", None)
+        if not isinstance(file_info, str) or not file_info:
+            return None
+        return {"file_info": file_info}
 
     @staticmethod
     def _result_message_id(result: Any) -> Optional[str]:
@@ -468,36 +479,37 @@ class QQOfficialAdapter(IMAdapter):
         return str(value) if value is not None else None
 
     async def _upload_file(
-        self, target_id: str, file_element: File, is_group: bool
+        self, target_id: str, media_element: File | Image, is_group: bool
     ) -> Optional[Any]:
-        """Upload a file and return the QQ media payload."""
+        """Upload a file or image and return the QQ media payload."""
         if not self.client:
             return None
-        if file_element.file_type == "url":
+        file_type = 1 if isinstance(media_element, Image) else 4
+        if media_element.file_type == "url":
             if is_group:
                 return await self.client.api.post_group_file(
                     group_openid=target_id,
-                    file_type=4,
-                    url=file_element.file,
+                    file_type=file_type,
+                    url=media_element.file,
                     srv_send_msg=False,
                 )
             return await self.client.api.post_c2c_file(
                 openid=target_id,
-                file_type=4,
-                url=file_element.file,
+                file_type=file_type,
+                url=media_element.file,
                 srv_send_msg=False,
             )
 
         if Route is None:
             raise RuntimeError("qq-botpy is required to upload local files")
-        file_path = await file_element.to_path()
+        file_path = await media_element.to_path()
         file_data = await asyncio.to_thread(Path(file_path).read_bytes)
         payload: dict[str, Any] = {
-            "file_type": 4,
+            "file_type": file_type,
             "file_data": base64.b64encode(file_data).decode("ascii"),
             "srv_send_msg": False,
         }
-        file_name = file_element.guess_name()
+        file_name = media_element.guess_name()
         if file_name:
             payload["file_name"] = file_name
         if is_group:
@@ -566,12 +578,14 @@ class QQOfficialAdapter(IMAdapter):
         if not self.client or not self._client_task or self._client_task.done():
             return KiraIMSentResult(ok=False, err="QQ official bot is not connected")
         content = self._text_content(send_message_obj)
-        file_elements = [element for element in send_message_obj if isinstance(element, File)]
-        if len(file_elements) > 1:
+        media_elements = [
+            element for element in send_message_obj if isinstance(element, (File, Image))
+        ]
+        if len(media_elements) > 1:
             return KiraIMSentResult(
-                ok=False, err="QQ official bot can send only one file per message"
+                ok=False, err="QQ official bot can send only one media item per message"
             )
-        if not content and not file_elements:
+        if not content and not media_elements:
             return KiraIMSentResult(ok=False, err="QQ official bot cannot send an empty message")
         reply_id = self._resolve_reply_id(is_group, target_id, send_message_obj)
         if not reply_id:
@@ -580,17 +594,18 @@ class QQOfficialAdapter(IMAdapter):
                 err="QQ official bot needs a received message before replying to this conversation",
             )
         media = None
-        if file_elements:
+        if media_elements:
             try:
-                media = await self._upload_file(target_id, file_elements[0], is_group)
+                upload_result = await self._upload_file(target_id, media_elements[0], is_group)
+                media = self._media_payload(upload_result)
             except Exception as exc:
-                logger.error(f"Failed to upload QQ official file: {exc}")
+                logger.error(f"Failed to upload QQ official media: {exc}")
                 return KiraIMSentResult(
-                    ok=False, err=f"Failed to upload QQ official file: {exc}"
+                    ok=False, err=f"Failed to upload QQ official media: {exc}"
                 )
             if not media:
                 return KiraIMSentResult(
-                    ok=False, err="QQ official file upload returned no media"
+                    ok=False, err="QQ official media upload returned no file_info"
                 )
         send_key = (is_group, target_id, reply_id)
         lock = self._send_locks.setdefault(send_key, asyncio.Lock())

--- a/tests/test_qq_official_adapter.py
+++ b/tests/test_qq_official_adapter.py
@@ -179,9 +179,82 @@ async def test_qq_official_uploads_and_sends_local_file():
     assert uploads[0]["file_name"] == "test.py"
     assert uploads[0]["file_data"]
     assert sent_payloads[0]["msg_type"] == 7
-    assert sent_payloads[0]["media"]["file_uuid"] == "file-uuid"
+    assert sent_payloads[0]["media"] == {"file_info": "file-info"}
     assert sent_payloads[0]["content"] is None
 
+
+@pytest.mark.asyncio
+async def test_qq_official_uploads_and_sends_local_image():
+    adapter = make_adapter()
+    uploads = []
+    sent_payloads = []
+
+    async def request(_, json):
+        uploads.append(json)
+        return {"file_uuid": "image-uuid", "file_info": "image-info", "ttl": 60}
+
+    async def post_c2c_message(**payload):
+        sent_payloads.append(payload)
+        return {"id": "sent-image"}
+
+    adapter.client = SimpleNamespace(
+        api=SimpleNamespace(
+            _http=SimpleNamespace(request=request),
+            post_c2c_message=post_c2c_message,
+        )
+    )
+    adapter._client_task = SimpleNamespace(done=lambda: False)
+    adapter._direct_reply_ids["user-openid"] = "incoming-message-id"
+
+    result = await adapter.send_direct_message(
+        "user-openid", MessageChain([Image(str(Path(__file__).resolve()), name="image.jpg")])
+    )
+
+    assert result.ok
+    assert uploads[0]["file_type"] == 1
+    assert uploads[0]["file_name"] == "image.jpg"
+    assert uploads[0]["file_data"]
+    assert sent_payloads[0]["msg_type"] == 7
+    assert sent_payloads[0]["media"] == {"file_info": "image-info"}
+
+
+@pytest.mark.asyncio
+async def test_qq_official_uploads_and_sends_image_url():
+    adapter = make_adapter()
+    uploads = []
+    sent_payloads = []
+
+    async def post_c2c_file(**payload):
+        uploads.append(payload)
+        return {"file_uuid": "image-uuid", "file_info": "image-info", "ttl": 60}
+
+    async def post_c2c_message(**payload):
+        sent_payloads.append(payload)
+        return {"id": "sent-image"}
+
+    adapter.client = SimpleNamespace(
+        api=SimpleNamespace(
+            post_c2c_file=post_c2c_file,
+            post_c2c_message=post_c2c_message,
+        )
+    )
+    adapter._client_task = SimpleNamespace(done=lambda: False)
+    adapter._direct_reply_ids["user-openid"] = "incoming-message-id"
+
+    result = await adapter.send_direct_message(
+        "user-openid", MessageChain([Image("https://example.com/image.png")])
+    )
+
+    assert result.ok
+    assert uploads == [{
+        "openid": "user-openid",
+        "file_type": 1,
+        "url": "https://example.com/image.png",
+        "srv_send_msg": False,
+    }]
+    assert sent_payloads[0]["msg_type"] == 7
+    assert sent_payloads[0]["media"] == {"file_info": "image-info"}
+    assert sent_payloads[0]["content"] is None
 
 @pytest.mark.asyncio
 async def test_qq_official_group_file_keeps_reply_message_id():
@@ -214,7 +287,7 @@ async def test_qq_official_group_file_keeps_reply_message_id():
     assert uploads[0]["group_openid"] == "group-openid"
     assert sent_payloads[0]["msg_type"] == 7
     assert sent_payloads[0]["msg_id"] == "incoming-group-message-id"
-    assert sent_payloads[0]["media"]["file_uuid"] == "file-uuid"
+    assert sent_payloads[0]["media"] == {"file_info": "file-info"}
 
 @pytest.mark.asyncio
 async def test_qq_official_uses_short_message_id_alias_for_llm_and_reply():


### PR DESCRIPTION
## Summary

Fix QQ Official Bot rich-media image delivery. Images are now uploaded using QQ's image media type, and the follow-up media message contains only the upload response's `file_info`.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Treat image elements as QQ rich media and upload local, Base64, and URL-backed images with `file_type=1`.
- Send only `media.file_info` in the rich-media message payload.
- Add coverage for local and URL image delivery alongside existing file delivery tests.

## Screenshots / Logs

Not applicable. Verified with the QQ Official adapter regression suite.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sending images in direct and group messages.
  * Images can be uploaded from local files or URLs.
  * Media messages now include the required file information payload.

* **Bug Fixes**
  * Images are no longer displayed as unsupported message elements.
  * Improved handling of media upload results and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->