### PR TITLE
fix(plugin): reset runtime before updates

### DIFF
--- a/core/plugin/plugin_registry.py
+++ b/core/plugin/plugin_registry.py
@@ -1959,6 +1959,21 @@ class PluginManager:
         if cleaned:
             logger.debug(f"Cleaned {cleaned} module(s) for plugin {plugin_id}")
 
+    async def prepare_plugin_reload(self, plugin_id: str) -> None:
+        """Stop a plugin and clear its runtime state before re-importing it."""
+        # 1. Terminate the running instance
+
+        plugin_id = str(plugin_id)
+        await self.terminate(plugin_id)
+        # 2. Remove class / schema / error registrations
+
+        _plugin_classes.pop(plugin_id, None)
+        _plugin_schemas.pop(plugin_id, None)
+        _plugin_load_errors.pop(plugin_id, None)
+        # 3. Purge the plugin's own modules from sys.modules
+
+        self._cleanup_plugin_modules(plugin_id)
+
     async def reload(self, plugin_id: Optional[str] = None):
         """
         Reload all plugins or reload a specific user plugin.
@@ -1968,17 +1983,7 @@ class PluginManager:
             plugin_id = str(plugin_id)
             logger.info(f"Reloading plugin {plugin_id}...")
 
-            # 1. Terminate the running instance
-            await self.terminate(plugin_id)
-
-            # 2. Remove class / schema / error registrations
-            _plugin_classes.pop(plugin_id, None)
-            _plugin_schemas.pop(plugin_id, None)
-            _plugin_load_errors.pop(plugin_id, None)
-
-            # 3. Purge the plugin's own modules from sys.modules
-            self._cleanup_plugin_modules(plugin_id)
-
+            await self.prepare_plugin_reload(plugin_id)
             # 4. Re-import from disk
             plugin_dir = _plugin_module_paths.get(plugin_id)
             if plugin_dir and plugin_dir.exists():

--- a/tests/test_plugin_reload.py
+++ b/tests/test_plugin_reload.py
@@ -1,0 +1,104 @@
+import asyncio
+import json
+
+from core.plugin.plugin_handlers import EventType, event_handler_reg
+from core.plugin import plugin_registry
+
+
+PLUGIN_ID = "multi_file_reload_plugin"
+
+
+def _write_plugin(plugin_root, helper_source: str, main_source: str) -> None:
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    (plugin_root / "manifest.json").write_text(
+        json.dumps({"plugin_id": PLUGIN_ID}), encoding="utf-8"
+    )
+    (plugin_root / "hooks.py").write_text(helper_source, encoding="utf-8")
+    (plugin_root / "main.py").write_text(main_source, encoding="utf-8")
+
+
+def test_loading_updated_multifile_plugin_evicts_helpers_and_old_hooks(tmp_path, monkeypatch):
+    monkeypatch.setattr(plugin_registry, "_plugin_classes", {})
+    monkeypatch.setattr(plugin_registry, "_plugin_components", {})
+    monkeypatch.setattr(plugin_registry, "_plugin_load_errors", {})
+    monkeypatch.setattr(plugin_registry, "_plugin_manifests", {})
+    monkeypatch.setattr(plugin_registry, "_plugin_module_dirs", {})
+    monkeypatch.setattr(plugin_registry, "_plugin_module_paths", {})
+    monkeypatch.setattr(plugin_registry, "_plugin_schemas", {})
+    monkeypatch.setattr(plugin_registry, "_plugin_infos", {})
+    monkeypatch.setattr(plugin_registry, "_module_to_plugin", {})
+    monkeypatch.setattr(event_handler_reg, "_handlers", {})
+
+    plugins_dir = tmp_path / "plugins"
+    plugin_root = plugins_dir / PLUGIN_ID
+    helper_v1 = '''
+from core.plugin.plugin_registry import on
+
+
+class HookMixin:
+    @on.im_message()
+    async def handle_message(self, event):
+        self.handled_version = "v1"
+'''
+    main_v1 = '''
+from core.plugin.plugin import BasePlugin
+from .hooks import HookMixin
+
+
+class TestPlugin(HookMixin, BasePlugin):
+    generation = "v1"
+
+    async def initialize(self):
+        pass
+
+    async def terminate(self):
+        pass
+'''
+    _write_plugin(plugin_root, helper_v1, main_v1)
+
+    async def run_test():
+        manager = plugin_registry.PluginManager()
+        manager.plugin_dir = plugins_dir
+        assert await manager.load_plugin_from_dir(plugin_root) == PLUGIN_ID
+
+        helper_v2 = '''
+from core.plugin.plugin_registry import on
+
+NEW_MARKER = "v2"
+
+
+class HookMixin:
+    @on.im_message()
+    async def handle_message(self, event):
+        self.handled_version = NEW_MARKER
+'''
+        main_v2 = '''
+from core.plugin.plugin import BasePlugin
+from .hooks import HookMixin, NEW_MARKER
+
+
+class TestPlugin(HookMixin, BasePlugin):
+    generation = NEW_MARKER
+
+    async def initialize(self):
+        pass
+
+    async def terminate(self):
+        pass
+'''
+        _write_plugin(plugin_root, helper_v2, main_v2)
+
+        await manager.prepare_plugin_reload(PLUGIN_ID)
+
+        assert await manager.load_plugin_from_dir(plugin_root) == PLUGIN_ID
+        instance = manager.get_plugin_inst(PLUGIN_ID)
+        assert instance.generation == "v2"
+
+        handlers = event_handler_reg.get_handlers(EventType.ON_IM_MESSAGE)
+        assert len(handlers) == 1
+        assert handlers[0].handler.__self__ is instance
+
+        await manager.terminate(PLUGIN_ID)
+        manager._cleanup_plugin_modules(PLUGIN_ID)
+
+    asyncio.run(run_test())

--- a/webui/routes/plugins.py
+++ b/webui/routes/plugins.py
@@ -773,6 +773,8 @@ class PluginsRoutes(Routes):
 
         warnings = await install_requirements(plugin_dir, pypi_mirror=self._get_pypi_mirror())
 
+        await plugin_manager.prepare_plugin_reload(plugin_id)
+
         new_plugin_id = await plugin_manager.load_plugin_from_dir(plugin_dir)
         if not new_plugin_id:
             raise HTTPException(status_code=500, detail="Plugin files were installed but failed to load after update")


### PR DESCRIPTION
## Summary

Fixes stale Python helper-module imports and duplicate hook registrations after updating a multi-file user plugin. The update flow now resets the old plugin runtime before loading the replacement files.

## Type of change

- [x] fix: Bug fix
- [ ] feat: New feature
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Extract the existing plugin reload teardown into a shared lifecycle method while preserving its documented steps.
- Run that teardown after a plugin archive has been replaced and before the updated plugin is imported.
- Add a regression test for a multi-file plugin whose helper module adds a new hook export during an update.

## Screenshots / Logs

`python -m pytest tests/test_plugin_installer.py tests/test_plugin_reload.py -v` — 7 passed.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed (not needed for this internal lifecycle fix)
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin updates and reloads to consistently activate the latest plugin code.
  * Prevented outdated plugin modules and event handlers from remaining active after a reload.
  * Added coverage for reloading multi-file plugins and confirming updated hooks are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->