### PR TITLE
fix(webui): distinguish invalid-token vs backend-unreachable on login

### DIFF
--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -957,6 +957,8 @@ export default {
     token_hint: 'See your access token in the terminal output',
     submit: 'Login',
     error: 'Login failed. Please check your access token.',
+    server_unreachable: 'Cannot reach the server. Please confirm the KiraAI backend is running, or check the address and port.',
+    server_error: 'The server returned an error. Please retry later or check the backend logs.',
     token_required: 'Please enter an access token.',
   },
   onboarding: {

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -958,6 +958,8 @@ export default {
     token_hint: '在终端输出中查看您的令牌',
     submit: '登录',
     error: '登录失败，请检查您的访问令牌。',
+    server_unreachable: '无法连接服务器。请确认 KiraAI 后端已启动，或检查地址与端口是否正确。',
+    server_error: '服务器异常，无法登录。请稍后重试或查看后端日志。',
     token_required: '请输入访问令牌。',
   },
   onboarding: {

--- a/webui/frontend/src/views/LoginView.vue
+++ b/webui/frontend/src/views/LoginView.vue
@@ -116,12 +116,35 @@ async function handleLogin() {
   errorMsg.value = ''
   try {
     await authStore.login(trimmedToken)
+  } catch (error) {
+    errorMsg.value = loginErrorText(error)
+    loading.value = false
+    return
+  }
+  // Login succeeded: navigate. Keep navigation separate so a rejected
+  // router.push (navigation error / aborted navigation) is never misreported
+  // as a token or backend-unreachable failure - auth already succeeded here.
+  try {
     await router.push('/overview')
   } catch {
-    errorMsg.value = t('login.error')
+    // navigation failed after successful auth; leave any prior message intact
+    // rather than blaming the access token or the backend.
   } finally {
     loading.value = false
   }
+}
+
+// Distinguish login failure causes:
+//  - backend up, returned 401           → the access token is genuinely wrong/expired
+//  - backend up, other HTTP error (5xx) → backend error
+//  - no HTTP response at all            → unreachable (backend not running / wrong
+//                                         host or port / request timeout)
+function loginErrorText(error: unknown): string {
+  const e = error as { response?: { status?: number } } | undefined
+  if (e?.response && typeof e.response.status === 'number') {
+    return e.response.status === 401 ? t('login.error') : t('login.server_error')
+  }
+  return t('login.server_unreachable')
 }
 
 function toggleTheme() {


### PR DESCRIPTION
## Summary

Fixes the WebUI login page showing the same generic error ("Login failed. Please check your access token.") for **two very different failure cases**: a genuinely wrong/expired access token, vs. the backend being unreachable (not started / wrong host/port / request timeout).

Previously `LoginView.vue` swallowed all errors in a bare `catch {}`, so when the backend was down the user could never tell that the problem wasn't the token at all.

## Type of change

- [x] fix: Bug fix

## Changes

- **`webui/frontend/src/views/LoginView.vue`** - `handleLogin` now receives the error and classifies it via a new `loginErrorText()` helper:
  - HTTP `401` (backend up, token invalid/expired) -> keeps existing "check your access token" message (`login.error`)
  - Other HTTP error e.g. `5xx/503` (backend up but broken) -> new `login.server_error` message
  - No HTTP response at all (connection failure / timeout / backend not running - axios network errors have no `response.status`) -> new `login.server_unreachable` message
- **`webui/frontend/src/i18n/en.ts` / `zh.ts`** - added the two new i18n keys `server_unreachable` and `server_error`.

## Screenshots / Logs

Not applicable (no visual changes to login flow; only error messaging split). The failure classification relies on the presence/absence of an HTTP `response.status`, which already distinguishes live-backend-401 from no-backend-at-all in axios.

## Checklist

- [ ] I have tested these changes locally
- [x] I have reviewed the code change (login error path + i18n keys)
- [x] No docs update needed (no new exported/documented behavior)
- [x] No new dependencies added
- [x] Not a net-new feature; small fix, no behavior beyond existing login flow
- [x] No breaking changes

> Note: I could not run a full local `npm run build` in my environment (no Node toolchain), so local runtime testing was not performed - review please validate the frontend builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized login messages for unreachable servers and backend errors in English and Chinese.

* **Bug Fixes**
  * Login failures now display more specific messages based on the error type, including incorrect credentials, server errors, and unreachable or timed-out servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->