### PR TITLE
fix(webui): distinguish backend unavailability from wrong token on login

### DIFF
--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -958,6 +958,8 @@ export default {
     submit: 'Login',
     error: 'Login failed. Please check your access token.',
     token_required: 'Please enter an access token.',
+    server_unreachable: 'Cannot reach the server. Please make sure the KiraAI backend is running, or check the address and port.',
+    server_error: 'Server error, unable to log in. Please try again later or check the backend logs.',
   },
   onboarding: {
     progress: 'Onboarding progress',

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -959,6 +959,8 @@ export default {
     submit: '登录',
     error: '登录失败，请检查您的访问令牌。',
     token_required: '请输入访问令牌。',
+    server_unreachable: '无法连接服务器。请确认 KiraAI 后端已启动，或检查地址与端口是否正确。',
+    server_error: '服务器异常，无法登录。请稍后重试或查看后端日志。',
   },
   onboarding: {
     progress: '引导进度',

--- a/webui/frontend/src/views/LoginView.vue
+++ b/webui/frontend/src/views/LoginView.vue
@@ -89,6 +89,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import { isAxiosError } from 'axios'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useAppStore } from '@/stores/app'
@@ -117,8 +118,20 @@ async function handleLogin() {
   try {
     await authStore.login(trimmedToken)
     await router.push('/overview')
-  } catch {
-    errorMsg.value = t('login.error')
+  } catch (err) {
+    if (isAxiosError(err)) {
+      // err.response present means the backend answered; its absence means the
+      // request never got through (backend not started, network failure, or timeout).
+      if (err.response?.status === 401) {
+        errorMsg.value = t('login.error')
+      } else if (err.response) {
+        errorMsg.value = t('login.server_error')
+      } else {
+        errorMsg.value = t('login.server_unreachable')
+      }
+    } else {
+      errorMsg.value = t('login.error')
+    }
   } finally {
     loading.value = false
   }


### PR DESCRIPTION
## Summary

The WebUI login page showed the same "please check your access token" message for every failure, which misleads users into checking their token when the backend is actually offline or not started. This PR classifies login failures so each situation gets an accurate message.

## Type of change

<!-- Check the one that applies. -->

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

<!-- List the key changes in this PR. -->

- `webui/frontend/src/views/LoginView.vue`: classify the axios error in `handleLogin` — HTTP 401 keeps the token hint; any other response reports a server error; a request with no response (backend not started, network failure, or timeout) now says the server is unreachable.
- `webui/frontend/src/i18n/zh.ts` / `en.ts`: add synced `login.server_unreachable` and `login.server_error` entries.

## Screenshots / Logs

<!-- If applicable, add screenshots or relevant logs to help reviewers. -->

- `npm run build` (vue-tsc type check + vite build) passes.
- Verified axios error shapes at runtime: connection refused yields no `error.response` (`ECONNREFUSED`), wrong token yields `error.response.status === 401` — the distinction the new branches rely on.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login error messaging by distinguishing invalid credentials, server errors, and unreachable servers.
  * Added English and Chinese translations for the new login error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->