### PR TITLE
fix(webui): resolve relative URLs and match GitHub rendering in plugin README

### DIFF
--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -1285,6 +1285,9 @@ function renderMarkdown(text: string): string {
   const repoUrl = pluginDetailsRepo.value
   parsedDocument.querySelectorAll('a').forEach(link => {
     const href = link.getAttribute('href')
+    // Fragment-only links point at anchors inside the rendered README itself;
+    // keep them in the current document instead of opening a new tab.
+    if (href && href.startsWith('#')) return
     if (href && repoUrl) link.setAttribute('href', resolveReadmeUrl(href, repoUrl, false))
     link.target = '_blank'
     link.rel = 'noopener noreferrer'

--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -1282,11 +1282,63 @@ async function openPluginDetails(plugin: PluginItem | PluginStoreItem) {
 function renderMarkdown(text: string): string {
   const sanitized = DOMPurify.sanitize(marked.parse(text, { async: false }) as string)
   const parsedDocument = new DOMParser().parseFromString(sanitized, 'text/html')
+  const repoUrl = pluginDetailsRepo.value
   parsedDocument.querySelectorAll('a').forEach(link => {
+    const href = link.getAttribute('href')
+    if (href && repoUrl) link.setAttribute('href', resolveReadmeUrl(href, repoUrl, false))
     link.target = '_blank'
     link.rel = 'noopener noreferrer'
   })
+  parsedDocument.querySelectorAll('img').forEach(img => {
+    const src = img.getAttribute('src')
+    if (src && repoUrl) img.setAttribute('src', resolveReadmeUrl(src, repoUrl, true))
+  })
   return parsedDocument.body.innerHTML
+}
+
+// A plugin README is authored inside its repository, so relative URLs must be
+// rewritten against the repository base instead of resolving against the
+// WebUI origin. GitHub repos get default-branch URLs (raw for images, blob
+// for links); other hosts fall back to generic URL joining.
+function resolveReadmeUrl(raw: string, repoUrl: string, isImage: boolean): string {
+  let candidate = raw.trim()
+  if (!candidate || candidate.startsWith('#')) return raw
+  if (candidate.startsWith('//')) candidate = `https:${candidate}`
+  try {
+    // Parseable without a base means the URL is already absolute (http:, mailto:, ...).
+    new URL(candidate)
+    return raw
+  } catch {
+    // Relative reference — resolve it below.
+  }
+  try {
+    // Resolve ./, ../ and percent-encoding against a neutral root first.
+    const resolved = new URL(candidate, 'https://readme.invalid/')
+    const path = resolved.pathname + resolved.search + resolved.hash
+    const repo = parseGitHubRepoUrl(repoUrl)
+    if (repo) {
+      return isImage
+        ? `https://raw.githubusercontent.com/${repo.owner}/${repo.name}/HEAD${path}`
+        : `https://github.com/${repo.owner}/${repo.name}/blob/HEAD${path}`
+    }
+    const base = repoUrl.endsWith('/') ? repoUrl : `${repoUrl}/`
+    return new URL(candidate, base).toString()
+  } catch {
+    return raw
+  }
+}
+
+function parseGitHubRepoUrl(repoUrl: string): { owner: string; name: string } | null {
+  try {
+    const url = new URL(repoUrl)
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null
+    if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') return null
+    const segments = url.pathname.split('/').filter(Boolean)
+    if (segments.length < 2) return null
+    return { owner: segments[0], name: segments[1].replace(/\.git$/, '') }
+  } catch {
+    return null
+  }
 }
 
 function onConfirmAction() {

--- a/webui/frontend/src/views/PluginView.vue
+++ b/webui/frontend/src/views/PluginView.vue
@@ -2413,16 +2413,23 @@ onMounted(async () => {
 </script>
 
 <style>
+/* GitHub-style README rendering: h1/h2 carry a bottom rule, and images stay
+   inline so multi-image paragraphs (badge rows) flow on one line instead of
+   being stacked by Tailwind preflight's img { display: block }. */
 .plugin-readme h1,
 .plugin-readme h2,
 .plugin-readme h3 {
-  margin: 1em 0 0.5em;
+  margin: 1.5em 0 0.5em;
   font-weight: 600;
 }
 
-.plugin-readme h1 { font-size: 1.25em; }
-.plugin-readme h2 { font-size: 1.125em; }
-.plugin-readme h3 { font-size: 1em; }
+.plugin-readme h1 { font-size: 2em; padding-bottom: 0.3em; border-bottom: 1px solid rgb(229 231 235); }
+.plugin-readme h2 { font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid rgb(229 231 235); }
+.plugin-readme h3 { font-size: 1.25em; }
+.plugin-readme h4 { margin: 1.5em 0 0.5em; font-size: 1em; font-weight: 600; }
+
+.dark .plugin-readme h1,
+.dark .plugin-readme h2 { border-bottom-color: rgb(55 65 81); }
 
 .plugin-readme p,
 .plugin-readme ul,
@@ -2443,7 +2450,7 @@ onMounted(async () => {
 .plugin-readme th,
 .plugin-readme td { border: 1px solid rgb(229 231 235); padding: 0.5em 0.75em; text-align: left; }
 .plugin-readme th { background: rgb(249 250 251); font-weight: 600; }
-.plugin-readme img { max-width: 100%; height: auto; }
+.plugin-readme img { display: inline; vertical-align: middle; max-width: 100%; height: auto; }
 
 .dark .plugin-readme pre { background: rgb(31 41 55); color: rgb(229 231 235); }
 .dark .plugin-readme code { background: rgb(31 41 55); }


### PR DESCRIPTION
## Summary

The plugin details modal renders an installed plugin's README as markdown, but relative image/link URLs in the README resolved against the WebUI origin (e.g. `http://localhost:5267/docs/img.png`), producing broken images and dead links. Tailwind preflight also forces `img { display: block }`, so badge rows that GitHub renders inline stacked vertically, and heading styles diverged from GitHub's preview. This PR makes the rendered README resolve URLs and lay out content the same way GitHub does.

## Type of change

<!-- Check the one that applies. -->

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

<!-- List the key changes in this PR. -->

- `webui/frontend/src/views/PluginView.vue`: resolve relative `img[src]` / `a[href]` URLs in the README against the plugin's repository base (the `repo` field from `manifest.json`, already surfaced as `pluginDetailsRepo`) after DOMPurify sanitization. GitHub repos get default-branch URLs — `raw.githubusercontent.com/{owner}/{repo}/HEAD/...` for images and `github.com/{owner}/{repo}/blob/HEAD/...` for links; other hosts fall back to generic URL joining. Absolute URLs, protocol-relative URLs, and in-page `#anchors` are untouched; plugins without a `repo` field keep the previous behavior.
- `webui/frontend/src/views/PluginView.vue`: keep `.plugin-readme` images inline (`display: inline; vertical-align: middle`) so multi-image paragraphs (badge rows) flow on one line like GitHub instead of stacking.
- `webui/frontend/src/views/PluginView.vue`: adopt GitHub heading typography for `.plugin-readme` — h1/h2/h3 at 2em/1.5em/1.25em with a bottom rule on h1/h2, including the dark-mode border color.

## Screenshots / Logs

<!-- If applicable, add screenshots or relevant logs to help reviewers. -->

- `npm run build` (vue-tsc type check + vite build) passes. No i18n changes needed (no new user-facing strings).
- URL rewriter exercised against ten URL shapes (relative paths, `../` escapes, root-relative, absolute, protocol-relative, `#anchors`, `mailto:`, non-GitHub host) via a scratch Node test.
- Rendering verified in a browser using a static page built from the production CSS bundle and the Reminder plugin README: the three shields.io badges render inline on one centered row and h1/h2 show the GitHub-style bottom rule in dark mode, matching GitHub's preview.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * README links and images now correctly resolve to their repository locations, including GitHub repositories and other hosting services.

* **Style**
  * Improved README readability with larger headings, heading separators, dark-mode border colors, and better inline image display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->