### PR TITLE
feat(config): scalar field options, session_select and dynamic multi_select sources

### DIFF
--- a/core/config/config_field.py
+++ b/core/config/config_field.py
@@ -7,7 +7,7 @@ class ConfigType(Enum):
     Float = "float"
     Sensitive = "sensitive"
     List = "list"
-    Enum = "enum"
+    Enum = "enum"  # Deprecated: use string/integer/float with options
     Switch = "switch"
     Json = "json"
     Markdown = "markdown"
@@ -51,26 +51,50 @@ class BaseConfigField:
             data["locales"] = self.locales
         return data
 
+    def _apply_options(self, data: dict) -> dict:
+        """Attach the options list to serialized data when the field defines choices."""
+        if getattr(self, "options", None):
+            data["options"] = list(self.options)
+        return data
+
 
 class StringField(BaseConfigField):
     type = ConfigType.String
 
-    def __init__(self, key: str, name: str, hint: str, default=None, locales: dict = None):
+    def __init__(self, key: str, name: str, hint: str, default=None, options: list = None, locales: dict = None):
+        if options:
+            default = default if default in options else options[0]
         super().__init__(key, name, hint, default, locales)
+        self.options = list(options) if options else None
+
+    def to_dict(self) -> dict:
+        return self._apply_options(super().to_dict())
 
 
 class IntField(BaseConfigField):
     type = ConfigType.Integer
 
-    def __init__(self, key: str, name: str, hint: str, default=None, locales: dict = None):
+    def __init__(self, key: str, name: str, hint: str, default=None, options: list = None, locales: dict = None):
+        if options:
+            default = default if default in options else options[0]
         super().__init__(key, name, hint, default, locales)
+        self.options = list(options) if options else None
+
+    def to_dict(self) -> dict:
+        return self._apply_options(super().to_dict())
 
 
 class FloatField(BaseConfigField):
     type = ConfigType.Float
 
-    def __init__(self, key: str, name: str, hint: str, default=None, locales: dict = None):
+    def __init__(self, key: str, name: str, hint: str, default=None, options: list = None, locales: dict = None):
+        if options:
+            default = default if default in options else options[0]
         super().__init__(key, name, hint, default, locales)
+        self.options = list(options) if options else None
+
+    def to_dict(self) -> dict:
+        return self._apply_options(super().to_dict())
 
 
 class SensitiveField(BaseConfigField):
@@ -89,6 +113,10 @@ class ListField(BaseConfigField):
 
 
 class EnumField(BaseConfigField):
+    """Deprecated: use StringField/IntField/FloatField with ``options`` instead.
+
+    Kept for backward compatibility with existing plugin config schemas.
+    """
     type = ConfigType.Enum
 
     def __init__(self, key: str, name: str, hint: str, options, default=None, locales: dict = None):
@@ -223,26 +251,25 @@ def create_field_from_schema(key: str, schema: dict) -> BaseConfigField:
     locales = schema.get("locales", {})
 
     if field_type in ("string", "text"):
-        if options:
-            return EnumField(key=key, name=name, hint=hint, options=options, default=default, locales=locales)
-        return StringField(key=key, name=name, hint=hint, default=default, locales=locales)
+        return StringField(key=key, name=name, hint=hint, default=default, options=options, locales=locales)
 
     if field_type == "sensitive":
         return SensitiveField(key=key, name=name, hint=hint, default=default, locales=locales)
 
     if field_type in ("integer", "int"):
-        return IntField(key=key, name=name, hint=hint, default=default, locales=locales)
+        return IntField(key=key, name=name, hint=hint, default=default, options=options, locales=locales)
 
     if field_type == "float":
-        return FloatField(key=key, name=name, hint=hint, default=default, locales=locales)
+        return FloatField(key=key, name=name, hint=hint, default=default, options=options, locales=locales)
 
     if field_type == "list":
         return ListField(key=key, name=name, hint=hint, default=default, locales=locales)
 
+    # Deprecated: use string/integer/float with options instead.
     if field_type == "enum":
         return EnumField(key=key, name=name, hint=hint, default=default, options=options, locales=locales)
 
-    if field_type == "switch":
+    if field_type in ("switch", "bool", "boolean"):
         return SwitchField(key=key, name=name, hint=hint, default=default, locales=locales)
 
     if field_type == "json":

--- a/core/config/config_field.py
+++ b/core/config/config_field.py
@@ -17,6 +17,7 @@ class ConfigType(Enum):
     ModelSelect = "model_select"
     MultiSelect = "multi_select"
     PersonaSelect = "persona_select"
+    SessionSelect = "session_select"
     Section = "section"
     Info = "info"
 
@@ -195,19 +196,39 @@ class ModelSelectField(BaseConfigField):
 class MultiSelectField(BaseConfigField):
     type = ConfigType.MultiSelect
 
-    def __init__(self, key: str, name: str, hint: str, options, default=None, locales: dict = None):
+    def __init__(self, key: str, name: str, hint: str, options=None, default=None, source: str = None, model_type: str = None, locales: dict = None):
+        """
+        Multi-select field with static options or dynamic ones.
+
+        :param source: Optional dynamic option source: "model", "persona" or "session".
+            When set, options are loaded at runtime and ``options`` may be empty.
+        :param model_type: Model category used when source is "model" (e.g. "llm", "tts").
+        """
         super().__init__(key, name, hint, default if isinstance(default, list) else [], locales)
-        self.options = list(options)
+        self.options = list(options) if options else []
+        self.source = source
+        self.model_type = model_type
 
     def to_dict(self) -> dict:
         data = super().to_dict()
         if self.options:
             data["options"] = list(self.options)
+        if self.source:
+            data["source"] = self.source
+            if self.source == "model" and self.model_type:
+                data["model_type"] = self.model_type
         return data
 
 
 class PersonaSelectField(BaseConfigField):
     type = ConfigType.PersonaSelect
+
+    def __init__(self, key: str, name: str, hint: str, default=None, locales: dict = None):
+        super().__init__(key, name, hint, default, locales)
+
+
+class SessionSelectField(BaseConfigField):
+    type = ConfigType.SessionSelect
 
     def __init__(self, key: str, name: str, hint: str, default=None, locales: dict = None):
         super().__init__(key, name, hint, default, locales)
@@ -293,10 +314,15 @@ def create_field_from_schema(key: str, schema: dict) -> BaseConfigField:
         return ModelSelectField(key=key, name=name, hint=hint, model_type=model_type, default=default, locales=locales)
 
     if field_type == "multi_select":
-        return MultiSelectField(key=key, name=name, hint=hint, options=options or [], default=default, locales=locales)
+        source = schema.get("source")
+        model_type = schema.get("model_type", "llm") if source == "model" else None
+        return MultiSelectField(key=key, name=name, hint=hint, options=options, default=default, source=source, model_type=model_type, locales=locales)
 
     if field_type == "persona_select":
         return PersonaSelectField(key=key, name=name, hint=hint, default=default, locales=locales)
+
+    if field_type == "session_select":
+        return SessionSelectField(key=key, name=name, hint=hint, default=default, locales=locales)
 
     if field_type == "section":
         collapsed = schema.get("collapsed", False)

--- a/tests/test_config_field.py
+++ b/tests/test_config_field.py
@@ -16,6 +16,7 @@ from core.config.config_field import (
     TextareaField,
     ModelSelectField,
     MultiSelectField,
+    SessionSelectField,
     SectionField,
     InfoField,
     create_field_from_schema,
@@ -280,6 +281,34 @@ def test_create_field_model_select():
 def test_create_field_multi_select():
     f = create_field_from_schema("k", {"type": "multi_select", "options": ["a"]})
     assert isinstance(f, MultiSelectField)
+
+
+def test_create_field_multi_select_model_source():
+    f = create_field_from_schema("k", {"type": "multi_select", "source": "model", "model_type": "tts"})
+    assert isinstance(f, MultiSelectField)
+    d = f.to_dict()
+    assert d["source"] == "model"
+    assert d["model_type"] == "tts"
+    assert "options" not in d
+
+
+def test_create_field_multi_select_persona_source():
+    f = create_field_from_schema("k", {"type": "multi_select", "source": "persona"})
+    assert isinstance(f, MultiSelectField)
+    d = f.to_dict()
+    assert d["source"] == "persona"
+    assert "model_type" not in d
+
+
+def test_create_field_multi_select_without_source_has_no_source_key():
+    f = create_field_from_schema("k", {"type": "multi_select", "options": ["a"]})
+    assert "source" not in f.to_dict()
+
+
+def test_create_field_session_select():
+    f = create_field_from_schema("k", {"type": "session_select"})
+    assert isinstance(f, SessionSelectField)
+    assert f.to_dict()["type"] == "session_select"
 
 
 def test_create_field_section():

--- a/tests/test_config_field.py
+++ b/tests/test_config_field.py
@@ -149,9 +149,11 @@ def test_create_field_string():
     assert f.default == "v"
 
 
-def test_create_field_text_with_options_becomes_enum():
+def test_create_field_text_with_options():
     f = create_field_from_schema("k", {"type": "text", "options": ["a", "b"]})
-    assert isinstance(f, EnumField)
+    assert isinstance(f, StringField)
+    assert f.options == ["a", "b"]
+    assert f.default == "a"
 
 
 def test_create_field_sensitive():
@@ -189,6 +191,58 @@ def test_create_field_switch():
     f = create_field_from_schema("k", {"type": "switch", "default": True})
     assert isinstance(f, SwitchField)
     assert f.default is True
+
+
+def test_create_field_string_with_options():
+    f = create_field_from_schema("k", {"type": "string", "options": ["a", "b"], "default": "b"})
+    assert isinstance(f, StringField)
+    assert f.default == "b"
+    d = f.to_dict()
+    assert d["type"] == "string"
+    assert d["options"] == ["a", "b"]
+
+
+def test_create_field_string_with_options_default_fallback():
+    f = create_field_from_schema("k", {"type": "string", "options": ["a", "b"], "default": "zzz"})
+    assert isinstance(f, StringField)
+    assert f.default == "a"
+
+
+def test_create_field_integer_with_options():
+    f = create_field_from_schema("k", {"type": "integer", "options": [8080, 9090], "default": 9090})
+    assert isinstance(f, IntField)
+    assert f.default == 9090
+    assert f.to_dict()["options"] == [8080, 9090]
+
+
+def test_create_field_integer_with_options_default_fallback():
+    f = create_field_from_schema("k", {"type": "integer", "options": [8080, 9090]})
+    assert isinstance(f, IntField)
+    assert f.default == 8080
+
+
+def test_create_field_float_with_options():
+    f = create_field_from_schema("k", {"type": "float", "options": [0.5, 1.5], "default": 1.5})
+    assert isinstance(f, FloatField)
+    assert f.default == 1.5
+    assert f.to_dict()["options"] == [0.5, 1.5]
+
+
+def test_scalar_field_without_options_omits_options_key():
+    f = StringField("k", "Name", "hint", default="v")
+    assert "options" not in f.to_dict()
+
+
+def test_create_field_bool_alias():
+    f = create_field_from_schema("k", {"type": "bool", "default": True})
+    assert isinstance(f, SwitchField)
+    assert f.default is True
+
+
+def test_create_field_boolean_alias():
+    f = create_field_from_schema("k", {"type": "boolean"})
+    assert isinstance(f, SwitchField)
+    assert f.default is False
 
 
 def test_create_field_json():

--- a/webui/frontend/src/components/common/ConfigFieldInput.vue
+++ b/webui/frontend/src/components/common/ConfigFieldInput.vue
@@ -244,10 +244,12 @@ function serializeDraftValue(val: any, type: string): string | null {
     return val !== undefined && val !== null ? String(val) : ''
   }
   if (isMonacoLike(type)) {
-    return type === 'json' && typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val ?? '')
+    if (val === undefined || val === null) return ''
+    return type === 'json' && typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val)
   }
   if (isJsonLike(type)) {
-    return typeof val === 'object' ? JSON.stringify(val, null, 2) : (val ?? '')
+    if (val === undefined || val === null) return ''
+    return typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val)
   }
   return null
 }

--- a/webui/frontend/src/components/common/ConfigFieldInput.vue
+++ b/webui/frontend/src/components/common/ConfigFieldInput.vue
@@ -1,0 +1,382 @@
+<template>
+  <div v-if="field">
+    <label v-if="!isInfo" class="block text-sm font-medium text-theme-body mb-1">
+      {{ label }}
+    </label>
+
+    <CustomMultiSelect
+      v-if="isMultiSelectLike(field.type)"
+      :modelValue="(value as string[]) ?? []"
+      :options="optionsFor(field).map((opt: any) => ({ value: String(opt), label: String(opt) }))"
+      :placeholder="hint || 'Select...'"
+      @update:modelValue="update($event)"
+    />
+
+    <CustomSelect
+      v-else-if="hasOptions(field)"
+      :model-value="value ?? ''"
+      :options="optionsFor(field).map((opt: any) => ({ value: opt, label: String(opt) }))"
+      :placeholder="hint || 'Select...'"
+      @update:model-value="update($event)"
+    />
+
+    <CustomSelect
+      v-else-if="isModelSelectLike(field.type)"
+      :model-value="value ?? ''"
+      :options="modelOptions || []"
+      :placeholder="t('configuration.select_model')"
+      @update:model-value="update($event)"
+    />
+
+    <CustomSelect
+      v-else-if="isPersonaSelectLike(field.type)"
+      :model-value="value ?? ''"
+      :options="personaOptions || []"
+      :placeholder="t('config.select_persona')"
+      @update:model-value="update($event)"
+    />
+
+    <div v-else-if="isBoolLike(field.type)" class="flex items-center">
+      <input
+        :id="'config-switch-' + uid"
+        type="checkbox"
+        class="sr-only"
+        :checked="!!value"
+        @change="update(($event.target as HTMLInputElement).checked)"
+      >
+      <label
+        :for="'config-switch-' + uid"
+        class="relative inline-flex items-center h-5 w-9 rounded-full cursor-pointer transition-colors"
+        :class="value ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'"
+        @click.prevent="update(!value)"
+      >
+        <span
+          class="inline-block h-4 w-4 bg-white rounded-full shadow transform transition-transform"
+          :class="value ? 'translate-x-5' : 'translate-x-0'"
+        />
+      </label>
+    </div>
+
+    <UiInput
+      v-else-if="isNumberLike(field.type)"
+      type="number"
+      :model-value="draft"
+      :coerce-number="false"
+      :step="field.type === 'integer' ? '1' : '0.01'"
+      class="w-full rounded-lg px-3 py-2 transition-colors"
+      :placeholder="hint"
+      @update:model-value="draft = String($event)"
+      @blur="commitNumber"
+    />
+
+    <div v-else-if="field.type === 'sensitive'" class="relative">
+      <UiInput
+        :type="sensitiveVisible ? 'text' : 'password'"
+        :model-value="value ?? ''"
+        class="w-full rounded-lg px-3 py-2 pr-10 transition-colors"
+        :placeholder="hint"
+        @update:model-value="update($event)"
+      />
+      <button type="button" class="absolute right-3 top-1/2 -translate-y-1/2 text-theme-faint text-theme-faint-hover focus:outline-none" @click="toggleSensitive">
+        <IconEye v-if="!sensitiveVisible" class="w-4 h-4" />
+        <IconEyeOff v-else class="w-4 h-4" />
+      </button>
+    </div>
+
+    <div v-else-if="isMonacoLike(field.type)" style="height: 200px;">
+      <MonacoEditor
+        :modelValue="draft"
+        :language="monacoLanguage"
+        :height="200"
+        @update:modelValue="updateMonacoDraft($event)"
+      />
+    </div>
+
+    <TagInput
+      v-else-if="isListLike(field.type)"
+      :modelValue="(value as string[]) ?? []"
+      :placeholder="hint"
+      @update:modelValue="update($event)"
+    />
+
+    <UiTextarea
+      v-else-if="isTextareaLike(field.type)"
+      :model-value="value ?? ''"
+      rows="4"
+      class="w-full rounded-lg px-3 py-2 transition-colors"
+      :placeholder="hint"
+      @update:model-value="update($event)"
+    />
+
+    <div v-else-if="isJsonLike(field.type)">
+      <UiTextarea
+        :model-value="draft"
+        rows="5"
+        class="w-full rounded-lg px-3 py-2 transition-colors"
+        :placeholder="hint"
+        @update:model-value="onDraftInput($event)"
+        @blur="onDraftBlur"
+      />
+    </div>
+
+    <InfoCallout
+      v-else-if="isInfo"
+      :level="field.level"
+      :label="label"
+      :hint="hint"
+    />
+
+    <UiInput
+      v-else
+      :model-value="stringValue(value)"
+      class="w-full rounded-lg px-3 py-2 transition-colors"
+      :placeholder="hint"
+      @update:model-value="update($event)"
+    />
+
+    <p v-if="hint && !isInfo" class="text-xs text-theme-subtle mt-1">{{ hint }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useLocalized } from '@/composables/useLocalized'
+import {
+  hasOptions,
+  isBoolLike,
+  isInfoLike,
+  isJsonLike,
+  isListLike,
+  isModelSelectLike,
+  isMonacoLike,
+  isMultiSelectLike,
+  isNumberLike,
+  isPersonaSelectLike,
+  isTextareaLike,
+  optionsFor,
+} from '@/utils/configFieldTypes'
+import CustomSelect from '@/components/common/CustomSelect.vue'
+import CustomMultiSelect from '@/components/common/CustomMultiSelect.vue'
+import TagInput from '@/components/common/TagInput.vue'
+import MonacoEditor from '@/components/common/MonacoEditor.vue'
+import InfoCallout from '@/components/common/InfoCallout.vue'
+import UiInput from '@/components/ui/UiInput.vue'
+import UiTextarea from '@/components/ui/UiTextarea.vue'
+import { IconEye, IconEyeOff } from '@/components/icons'
+
+const props = defineProps<{
+  /** Field schema entry */
+  field: any
+  /** Field key within its scope, used as the label fallback */
+  fieldKey: string
+  /** Unique key across the whole form, used for element ids */
+  uid: string
+  /** Resolved current value (model value or field default) */
+  value: any
+  /** Options for model_select fields, loaded by the parent */
+  modelOptions?: { value: string; label: string }[]
+  /** Options for persona_select fields, loaded by the parent */
+  personaOptions?: { value: string; label: string }[]
+}>()
+
+const emit = defineEmits<{
+  change: [value: any]
+}>()
+
+const { t } = useI18n()
+const { localize } = useLocalized()
+
+/** In-progress text for draft-based types (number / monaco / json) */
+const draft = ref('')
+const lastSynced = ref('')
+const sensitiveVisible = ref(false)
+
+const isInfo = computed(() => isInfoLike(props.field?.type))
+
+const label = computed(() => {
+  const fallback = props.field?.name || props.field?.title || props.fieldKey
+  return localize(props.field, 'name', fallback)
+})
+
+const hint = computed(() => {
+  const fallback = props.field?.hint ?? props.field?.description ?? undefined
+  if (!fallback) return undefined
+  return localize(props.field, 'hint', fallback)
+})
+
+const monacoLanguage = computed(() => {
+  const type = props.field?.type
+  if (type === 'json') return 'json'
+  if (type === 'markdown') return 'markdown'
+  if (type === 'yaml') return 'yaml'
+  if (type === 'editor') return props.field?.language || 'plaintext'
+  return 'plaintext'
+})
+
+/** Serialized draft representation for draft-based types, null when not applicable */
+function serializeDraftValue(val: any, type: string): string | null {
+  if (isNumberLike(type)) {
+    return val !== undefined && val !== null ? String(val) : ''
+  }
+  if (isMonacoLike(type)) {
+    return type === 'json' && typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val ?? '')
+  }
+  if (isJsonLike(type)) {
+    return typeof val === 'object' ? JSON.stringify(val, null, 2) : (val ?? '')
+  }
+  return null
+}
+
+function initDraft() {
+  const serialized = serializeDraftValue(props.value, props.field?.type)
+  if (serialized === null) return
+  draft.value = serialized
+  lastSynced.value = serialized
+}
+
+watch(() => props.field, initDraft, { immediate: true, deep: true })
+
+// Sync external model value changes into the draft, unless the change
+// originated from this field's own commit (tracked by lastSynced)
+watch(() => props.value, (val) => {
+  const serialized = serializeDraftValue(val, props.field?.type)
+  if (serialized === null) return
+  if (serialized !== lastSynced.value) {
+    draft.value = serialized
+    lastSynced.value = serialized
+  }
+})
+
+function update(v: any) {
+  emit('change', v)
+}
+
+function stringValue(v: unknown): string {
+  if (v === null || v === undefined) return ''
+  return typeof v === 'object' ? JSON.stringify(v) : String(v)
+}
+
+function toggleSensitive() {
+  sensitiveVisible.value = !sensitiveVisible.value
+}
+
+function commitNumber() {
+  const raw = draft.value
+  const empty = raw === '' || raw === null || raw === undefined
+  const parsed = empty ? null : Number(raw)
+  if (!empty) {
+    if (!Number.isFinite(parsed)) return
+    if (props.field?.type === 'integer' && !Number.isInteger(parsed)) return
+  }
+  lastSynced.value = raw ?? ''
+  update(parsed)
+}
+
+function updateMonacoDraft(val: string) {
+  draft.value = val
+  if (props.field?.type === 'json') {
+    try {
+      const parsed = JSON.parse(val)
+      lastSynced.value = val
+      update(parsed)
+    } catch {
+      // Keep draft as-is; validation deferred to save
+    }
+  } else {
+    lastSynced.value = val
+    update(val)
+  }
+}
+
+function onDraftInput(val: string) {
+  draft.value = val
+  try {
+    const parsed = JSON.parse(val)
+    if (isValidType(parsed, props.field?.type)) {
+      lastSynced.value = val
+      update(parsed)
+    }
+  } catch {
+    // Allow typing — don't emit until valid
+  }
+}
+
+function onDraftBlur() {
+  if (!draft.value || !draft.value.trim()) {
+    update(null)
+    return
+  }
+  try {
+    const parsed = JSON.parse(draft.value)
+    if (isValidType(parsed, props.field?.type)) {
+      update(parsed)
+    }
+  } catch {
+    // Keep draft as-is; validation deferred to save
+  }
+}
+
+function isValidType(parsed: any, type: string): boolean {
+  if (type === 'object' || type === 'json') {
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+  }
+  if (type === 'array' || type === 'list') {
+    return Array.isArray(parsed)
+  }
+  return true
+}
+
+/**
+ * Commit pending drafts and check the field value.
+ * Returns the committed value (undefined when there is nothing to commit)
+ * so the parent can assemble a single modelValue update.
+ */
+function validate(): { valid: boolean; message?: string; value?: any } {
+  const type = props.field?.type
+
+  if (isNumberLike(type)) {
+    const raw = draft.value
+    if (raw === '' || raw === undefined) {
+      return { valid: true, value: null }
+    }
+    const parsed = Number(raw)
+    if (!Number.isFinite(parsed) || (type === 'integer' && !Number.isInteger(parsed))) {
+      return { valid: false, message: `${label.value}: ${t('configform.invalid_number')}` }
+    }
+    return { valid: true, value: parsed }
+  }
+
+  if (isMonacoLike(type) && type === 'json') {
+    const val = draft.value
+    if (!val || !val.trim()) {
+      return { valid: true, value: null }
+    }
+    try {
+      return { valid: true, value: JSON.parse(val) }
+    } catch {
+      return { valid: false, message: `${label.value}: ${t('configform.invalid_json')}` }
+    }
+  }
+
+  if (isJsonLike(type)) {
+    const val = draft.value
+    if (!val || !val.trim()) {
+      return { valid: true, value: null }
+    }
+    try {
+      const parsed = JSON.parse(val)
+      if (!isValidType(parsed, type)) {
+        return { valid: false, message: `${label.value}: ${t('configform.expected_type', { type })}` }
+      }
+      return { valid: true, value: parsed }
+    } catch {
+      return { valid: false, message: `${label.value}: ${t('configform.invalid_json')}` }
+    }
+  }
+
+  return { valid: true }
+}
+
+defineExpose({ validate })
+</script>

--- a/webui/frontend/src/components/common/ConfigFieldInput.vue
+++ b/webui/frontend/src/components/common/ConfigFieldInput.vue
@@ -264,7 +264,9 @@ function initDraft() {
 watch(() => props.field, initDraft, { immediate: true, deep: true })
 
 // Sync external model value changes into the draft, unless the change
-// originated from this field's own commit (tracked by lastSynced)
+// originated from this field's own commit (tracked by lastSynced).
+// Deep watching keeps in-place nested edits (json/object values) in sync,
+// matching the pre-refactor whole-form deep watch behavior.
 watch(() => props.value, (val) => {
   const serialized = serializeDraftValue(val, props.field?.type)
   if (serialized === null) return
@@ -272,7 +274,7 @@ watch(() => props.value, (val) => {
     draft.value = serialized
     lastSynced.value = serialized
   }
-})
+}, { deep: true })
 
 function update(v: any) {
   emit('change', v)

--- a/webui/frontend/src/components/common/ConfigFieldInput.vue
+++ b/webui/frontend/src/components/common/ConfigFieldInput.vue
@@ -7,7 +7,7 @@
     <CustomMultiSelect
       v-if="isMultiSelectLike(field.type)"
       :modelValue="(value as string[]) ?? []"
-      :options="optionsFor(field).map((opt: any) => ({ value: String(opt), label: String(opt) }))"
+      :options="multiOptions"
       :placeholder="hint || 'Select...'"
       @update:modelValue="update($event)"
     />
@@ -33,6 +33,14 @@
       :model-value="value ?? ''"
       :options="personaOptions || []"
       :placeholder="t('config.select_persona')"
+      @update:model-value="update($event)"
+    />
+
+    <CustomSelect
+      v-else-if="isSessionSelectLike(field.type)"
+      :model-value="value ?? ''"
+      :options="sessionOptions || []"
+      :placeholder="t('config.select_session')"
       @update:model-value="update($event)"
     />
 
@@ -153,6 +161,7 @@ import {
   isMultiSelectLike,
   isNumberLike,
   isPersonaSelectLike,
+  isSessionSelectLike,
   isTextareaLike,
   optionsFor,
 } from '@/utils/configFieldTypes'
@@ -178,6 +187,8 @@ const props = defineProps<{
   modelOptions?: { value: string; label: string }[]
   /** Options for persona_select fields, loaded by the parent */
   personaOptions?: { value: string; label: string }[]
+  /** Options for session_select fields, loaded by the parent */
+  sessionOptions?: { value: string; label: string }[]
 }>()
 
 const emit = defineEmits<{
@@ -212,6 +223,19 @@ const monacoLanguage = computed(() => {
   if (type === 'yaml') return 'yaml'
   if (type === 'editor') return props.field?.language || 'plaintext'
   return 'plaintext'
+})
+
+/**
+ * Options for multi_select fields: a dynamic source (model / persona /
+ * session) reuses the option lists loaded by the parent, minus the
+ * single-select placeholder entry; otherwise falls back to static options.
+ */
+const multiOptions = computed<{ value: string; label: string }[]>(() => {
+  const field = props.field
+  if (field?.source === 'model') return (props.modelOptions || []).filter(o => o.value !== '')
+  if (field?.source === 'persona') return (props.personaOptions || []).filter(o => o.value !== '')
+  if (field?.source === 'session') return (props.sessionOptions || []).filter(o => o.value !== '')
+  return optionsFor(field).map((opt: any) => ({ value: String(opt), label: String(opt) }))
 })
 
 /** Serialized draft representation for draft-based types, null when not applicable */

--- a/webui/frontend/src/components/common/ConfigForm.vue
+++ b/webui/frontend/src/components/common/ConfigForm.vue
@@ -19,6 +19,7 @@
                 :value="sectionFieldValue(entry.key, key as string, field)"
                 :model-options="modelOptionsFor(field)"
                 :persona-options="personaSelectOptions"
+                :session-options="sessionSelectOptions"
                 @change="updateSectionField(entry.key, key as string, $event)"
               />
             </template>
@@ -37,6 +38,7 @@
         :value="fieldValue(entry.key, entry.field)"
         :model-options="modelOptionsFor(entry.field)"
         :persona-options="personaSelectOptions"
+        :session-options="sessionSelectOptions"
         @change="updateField(entry.key, $event)"
       />
     </template>
@@ -51,7 +53,8 @@ import ConfigFieldInput from '@/components/common/ConfigFieldInput.vue'
 import CollapsibleSection from '@/components/common/CollapsibleSection.vue'
 import { getProviders, getModels } from '@/api/provider'
 import { getPersonas } from '@/api/persona'
-import { isInfoLike, isModelSelectLike, isPersonaSelectLike, isSectionLike } from '@/utils/configFieldTypes'
+import { getSessions } from '@/api/session'
+import { isInfoLike, isModelSelectLike, isPersonaSelectLike, isSessionSelectLike, isSectionLike } from '@/utils/configFieldTypes'
 
 const props = defineProps<{
   modelValue: Record<string, any>
@@ -67,6 +70,7 @@ const { localize } = useLocalized()
 
 const modelSelectOptions = reactive<Record<string, { value: string; label: string }[]>>({})
 const personaSelectOptions = reactive<{ value: string; label: string }[]>([])
+const sessionSelectOptions = reactive<{ value: string; label: string }[]>([])
 const sectionCollapsed = reactive<Record<string, boolean>>({})
 
 /** Field input instances keyed by unique draft key, for validation */
@@ -194,7 +198,8 @@ async function loadModelSelectOptions() {
   const modelTypes = new Set<string>()
   for (const dk in schema) {
     const { field } = schema[dk]
-    if (field && isModelSelectLike(field.type)) {
+    if (!field) continue
+    if (isModelSelectLike(field.type) || field.source === 'model') {
       modelTypes.add(field.model_type || 'llm')
     }
   }
@@ -234,7 +239,7 @@ async function loadModelSelectOptions() {
 
 async function loadPersonaSelectOptions() {
   const schema = allDataFields.value
-  const hasPersonaSelect = Object.values(schema).some(({ field }) => field && isPersonaSelectLike(field.type))
+  const hasPersonaSelect = Object.values(schema).some(({ field }) => field && (isPersonaSelectLike(field.type) || field.source === 'persona'))
   if (!hasPersonaSelect || personaSelectOptions.length > 0) return
 
   try {
@@ -250,10 +255,29 @@ async function loadPersonaSelectOptions() {
   }
 }
 
+async function loadSessionSelectOptions() {
+  const schema = allDataFields.value
+  const hasSessionSelect = Object.values(schema).some(({ field }) => field && (isSessionSelectLike(field.type) || field.source === 'session'))
+  if (!hasSessionSelect || sessionSelectOptions.length > 0) return
+
+  try {
+    const res = await getSessions()
+    const sessions = res.data?.sessions || []
+    sessionSelectOptions.length = 0
+    sessionSelectOptions.push({ value: '', label: t('config.select_session') })
+    for (const s of sessions) {
+      sessionSelectOptions.push({ value: s.id, label: s.title || s.session_id || s.id })
+    }
+  } catch (e) {
+    console.warn('Failed to load session options:', e)
+  }
+}
+
 watch(() => effectiveSchema.value, () => {
   applyDefaults()
   loadModelSelectOptions()
   loadPersonaSelectOptions()
+  loadSessionSelectOptions()
   const schema = effectiveSchema.value
   for (const key in schema) {
     const field = schema[key]

--- a/webui/frontend/src/components/common/ConfigForm.vue
+++ b/webui/frontend/src/components/common/ConfigForm.vue
@@ -26,7 +26,7 @@
                 <CustomSelect
                   v-else-if="hasOptions(field)"
                   :model-value="sectionFieldValue(entry.key, key as string, field) ?? ''"
-                  :options="optionsFor(field).map((opt: any) => ({ value: String(opt), label: String(opt) }))"
+                  :options="optionsFor(field).map((opt: any) => ({ value: opt, label: String(opt) }))"
                   :placeholder="hintFor(field) || 'Select...'"
                   @update:model-value="updateSectionField(entry.key, key as string, $event)"
                 />
@@ -169,7 +169,7 @@
         <CustomSelect
           v-else-if="hasOptions(entry.field)"
           :model-value="fieldValue(entry.key, entry.field) ?? ''"
-          :options="optionsFor(entry.field).map((opt: any) => ({ value: String(opt), label: String(opt) }))"
+          :options="optionsFor(entry.field).map((opt: any) => ({ value: opt, label: String(opt) }))"
           :placeholder="hintFor(entry.field) || 'Select...'"
           @update:model-value="updateField(entry.key, $event)"
         />

--- a/webui/frontend/src/components/common/ConfigForm.vue
+++ b/webui/frontend/src/components/common/ConfigForm.vue
@@ -176,7 +176,12 @@ function applyDefaults() {
     const { field, sectionKey, fieldKey } = schema[dk]
     if (!field) continue
     if (sectionKey) {
-      if (!result[sectionKey] || typeof result[sectionKey] !== 'object') result[sectionKey] = {}
+      if (!result[sectionKey] || typeof result[sectionKey] !== 'object') {
+        result[sectionKey] = {}
+      } else if (result[sectionKey] === props.modelValue[sectionKey]) {
+        // copy before writing so the nested object inside props.modelValue is not mutated
+        result[sectionKey] = { ...result[sectionKey] }
+      }
       if (result[sectionKey][fieldKey] === undefined && field.default !== undefined) {
         result[sectionKey][fieldKey] = field.default
         changed = true

--- a/webui/frontend/src/components/common/ConfigForm.vue
+++ b/webui/frontend/src/components/common/ConfigForm.vue
@@ -266,7 +266,11 @@ async function loadSessionSelectOptions() {
     sessionSelectOptions.length = 0
     sessionSelectOptions.push({ value: '', label: t('config.select_session') })
     for (const s of sessions) {
-      sessionSelectOptions.push({ value: s.id, label: s.title || s.session_id || s.id })
+      const internalId = s.id || [s.adapter_name, s.session_type, s.session_id].filter(Boolean).join(':')
+      sessionSelectOptions.push({
+        value: internalId,
+        label: s.title ? `${s.title} (${internalId})` : internalId,
+      })
     }
   } catch (e) {
     console.warn('Failed to load session options:', e)

--- a/webui/frontend/src/components/common/ConfigForm.vue
+++ b/webui/frontend/src/components/common/ConfigForm.vue
@@ -10,286 +10,35 @@
         >
           <div class="flex flex-col gap-4">
             <template v-for="(field, key) in entry.fields" :key="key">
-              <div v-if="field" class="mb-0">
-                <label v-if="!isInfoLike(field.type)" class="block text-sm font-medium text-theme-body mb-1">
-                  {{ labelFor(field, key as string) }}
-                </label>
-
-                <CustomMultiSelect
-                  v-if="isMultiSelectLike(field.type)"
-                  :modelValue="(sectionFieldValue(entry.key, key as string, field) as string[]) ?? []"
-                  :options="optionsFor(field).map((opt: any) => ({ value: String(opt), label: String(opt) }))"
-                  :placeholder="hintFor(field) || 'Select...'"
-                  @update:modelValue="updateSectionField(entry.key, key as string, $event)"
-                />
-
-                <CustomSelect
-                  v-else-if="hasOptions(field)"
-                  :model-value="sectionFieldValue(entry.key, key as string, field) ?? ''"
-                  :options="optionsFor(field).map((opt: any) => ({ value: opt, label: String(opt) }))"
-                  :placeholder="hintFor(field) || 'Select...'"
-                  @update:model-value="updateSectionField(entry.key, key as string, $event)"
-                />
-
-                <CustomSelect
-                  v-else-if="isModelSelectLike(field.type)"
-                  :model-value="sectionFieldValue(entry.key, key as string, field) ?? ''"
-                  :options="modelSelectOptions[field.model_type || 'llm'] || []"
-                  :placeholder="t('configuration.select_model')"
-                  @update:model-value="updateSectionField(entry.key, key as string, $event)"
-                />
-
-                <CustomSelect
-                  v-else-if="isPersonaSelectLike(field.type)"
-                  :model-value="sectionFieldValue(entry.key, key as string, field) ?? ''"
-                  :options="personaSelectOptions"
-                  :placeholder="t('config.select_persona')"
-                  @update:model-value="updateSectionField(entry.key, key as string, $event)"
-                />
-
-                <div v-else-if="isBoolLike(field.type)" class="flex items-center">
-                  <input
-                    :id="'config-switch-' + entry.key + '-' + key"
-                    type="checkbox"
-                    class="sr-only"
-                    :checked="!!sectionFieldValue(entry.key, key as string, field)"
-                    @change="updateSectionField(entry.key, key as string, ($event.target as HTMLInputElement).checked)"
-                  >
-                  <label
-                    :for="'config-switch-' + entry.key + '-' + key"
-                    class="relative inline-flex items-center h-5 w-9 rounded-full cursor-pointer transition-colors"
-                    :class="sectionFieldValue(entry.key, key as string, field) ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'"
-                    @click.prevent="updateSectionField(entry.key, key as string, !sectionFieldValue(entry.key, key as string, field))"
-                  >
-                    <span
-                      class="inline-block h-4 w-4 bg-white rounded-full shadow transform transition-transform"
-                      :class="sectionFieldValue(entry.key, key as string, field) ? 'translate-x-5' : 'translate-x-0'"
-                    />
-                  </label>
-                </div>
-
-                <UiInput
-                  v-else-if="isNumberLike(field.type)"
-                  type="number"
-                  :model-value="drafts[entry.key + '.' + key] ?? ''"
-                  :coerce-number="false"
-                  :step="field.type === 'integer' ? '1' : '0.01'"
-                  class="w-full rounded-lg px-3 py-2 transition-colors"
-                  :placeholder="hintFor(field)"
-                  @update:model-value="drafts[entry.key + '.' + key] = String($event)"
-                  @blur="commitSectionNumberDraft(entry.key, key as string, field)"
-                />
-
-                <div v-else-if="field.type === 'sensitive'" class="relative">
-                  <UiInput
-                    :type="sensitiveVisible[entry.key + '.' + key] ? 'text' : 'password'"
-                    :model-value="sectionFieldValue(entry.key, key as string, field) ?? ''"
-                    class="w-full rounded-lg px-3 py-2 pr-10 transition-colors"
-                    :placeholder="hintFor(field)"
-                    @update:model-value="updateSectionField(entry.key, key as string, $event)"
-                  />
-                  <button type="button" class="absolute right-3 top-1/2 -translate-y-1/2 text-theme-faint text-theme-faint-hover focus:outline-none" @click="toggleSensitive(entry.key + '.' + key)">
-                    <IconEye v-if="!sensitiveVisible[entry.key + '.' + key]" class="w-4 h-4" />
-                    <IconEyeOff v-else class="w-4 h-4" />
-                  </button>
-                </div>
-
-                <div v-else-if="isMonacoLike(field.type)" style="height: 200px;">
-                  <MonacoEditor
-                    :modelValue="drafts[entry.key + '.' + key] ?? ''"
-                    :language="monacoLang(field)"
-                    :height="200"
-                    @update:modelValue="updateSectionMonacoDraft(entry.key, key as string, $event, field.type)"
-                  />
-                </div>
-
-                <TagInput
-                  v-else-if="isListLike(field.type)"
-                  :modelValue="(sectionFieldValue(entry.key, key as string, field) as string[]) ?? []"
-                  :placeholder="hintFor(field)"
-                  @update:modelValue="updateSectionField(entry.key, key as string, $event)"
-                />
-
-                <UiTextarea
-                  v-else-if="isTextareaLike(field.type)"
-                  :model-value="sectionFieldValue(entry.key, key as string, field) ?? ''"
-                  rows="4"
-                  class="w-full rounded-lg px-3 py-2 transition-colors"
-                  :placeholder="hintFor(field)"
-                  @update:model-value="updateSectionField(entry.key, key as string, $event)"
-                />
-
-                <div v-else-if="isJsonLike(field.type)">
-                  <UiTextarea
-                    :model-value="drafts[entry.key + '.' + key]"
-                    rows="5"
-                    class="w-full rounded-lg px-3 py-2 transition-colors"
-                    :placeholder="hintFor(field)"
-                    @update:model-value="onSectionDraftInput(entry.key, key as string, $event, field)"
-                    @blur="onSectionDraftBlur(entry.key, key as string, field)"
-                  />
-                </div>
-
-                <InfoCallout
-                  v-else-if="isInfoLike(field.type)"
-                  :level="field.level"
-                  :label="labelFor(field, key as string)"
-                  :hint="hintFor(field)"
-                />
-
-                <UiInput
-                  v-else
-                  :model-value="stringValue(sectionFieldValue(entry.key, key as string, field))"
-                  class="w-full rounded-lg px-3 py-2 transition-colors"
-                  :placeholder="hintFor(field)"
-                  @update:model-value="updateSectionField(entry.key, key as string, $event)"
-                />
-
-                <p v-if="hintFor(field) && !isInfoLike(field.type)" class="text-xs text-theme-subtle mt-1">{{ hintFor(field) }}</p>
-              </div>
+              <ConfigFieldInput
+                v-if="field"
+                :ref="(el: any) => setFieldRef(entry.key + '.' + key, el)"
+                :field="field"
+                :field-key="key as string"
+                :uid="entry.key + '.' + key"
+                :value="sectionFieldValue(entry.key, key as string, field)"
+                :model-options="modelOptionsFor(field)"
+                :persona-options="personaSelectOptions"
+                @change="updateSectionField(entry.key, key as string, $event)"
+              />
             </template>
           </div>
         </CollapsibleSection>
       </div>
 
       <!-- Ungrouped field -->
-      <div v-else class="mb-4">
-        <label v-if="!isInfoLike(entry.field.type)" class="block text-sm font-medium text-theme-body mb-1">
-          {{ labelFor(entry.field, entry.key) }}
-        </label>
-
-        <CustomMultiSelect
-          v-if="isMultiSelectLike(entry.field.type)"
-          :modelValue="(fieldValue(entry.key, entry.field) as string[]) ?? []"
-          :options="optionsFor(entry.field).map((opt: any) => ({ value: String(opt), label: String(opt) }))"
-          :placeholder="hintFor(entry.field) || 'Select...'"
-          @update:modelValue="updateField(entry.key, $event)"
-        />
-
-        <CustomSelect
-          v-else-if="hasOptions(entry.field)"
-          :model-value="fieldValue(entry.key, entry.field) ?? ''"
-          :options="optionsFor(entry.field).map((opt: any) => ({ value: opt, label: String(opt) }))"
-          :placeholder="hintFor(entry.field) || 'Select...'"
-          @update:model-value="updateField(entry.key, $event)"
-        />
-
-        <CustomSelect
-          v-else-if="isModelSelectLike(entry.field.type)"
-          :model-value="fieldValue(entry.key, entry.field) ?? ''"
-          :options="modelSelectOptions[entry.field.model_type || 'llm'] || []"
-          :placeholder="t('configuration.select_model')"
-          @update:model-value="updateField(entry.key, $event)"
-        />
-
-        <CustomSelect
-          v-else-if="isPersonaSelectLike(entry.field.type)"
-          :model-value="fieldValue(entry.key, entry.field) ?? ''"
-          :options="personaSelectOptions"
-          :placeholder="t('config.select_persona')"
-          @update:model-value="updateField(entry.key, $event)"
-        />
-
-        <div v-else-if="isBoolLike(entry.field.type)" class="flex items-center">
-          <input
-            :id="'config-switch-' + entry.key"
-            type="checkbox"
-            class="sr-only"
-            :checked="!!fieldValue(entry.key, entry.field)"
-            @change="updateField(entry.key, ($event.target as HTMLInputElement).checked)"
-          >
-          <label
-            :for="'config-switch-' + entry.key"
-            class="relative inline-flex items-center h-5 w-9 rounded-full cursor-pointer transition-colors"
-            :class="fieldValue(entry.key, entry.field) ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'"
-            @click.prevent="updateField(entry.key, !fieldValue(entry.key, entry.field))"
-          >
-            <span
-              class="inline-block h-4 w-4 bg-white rounded-full shadow transform transition-transform"
-              :class="fieldValue(entry.key, entry.field) ? 'translate-x-5' : 'translate-x-0'"
-            />
-          </label>
-        </div>
-
-        <UiInput
-          v-else-if="isNumberLike(entry.field.type)"
-          type="number"
-          :model-value="drafts[entry.key] ?? ''"
-          :coerce-number="false"
-          :step="entry.field.type === 'integer' ? '1' : '0.01'"
-          class="w-full rounded-lg px-3 py-2 transition-colors"
-          :placeholder="hintFor(entry.field)"
-          @update:model-value="drafts[entry.key] = String($event)"
-          @blur="commitNumberDraft(entry.key, entry.field)"
-        />
-
-        <div v-else-if="entry.field.type === 'sensitive'" class="relative">
-          <UiInput
-            :type="sensitiveVisible[entry.key] ? 'text' : 'password'"
-            :model-value="fieldValue(entry.key, entry.field) ?? ''"
-            class="w-full rounded-lg px-3 py-2 pr-10 transition-colors"
-            :placeholder="hintFor(entry.field)"
-            @update:model-value="updateField(entry.key, $event)"
-          />
-          <button type="button" class="absolute right-3 top-1/2 -translate-y-1/2 text-theme-faint text-theme-faint-hover focus:outline-none" @click="toggleSensitive(entry.key)">
-            <IconEye v-if="!sensitiveVisible[entry.key]" class="w-4 h-4" />
-            <IconEyeOff v-else class="w-4 h-4" />
-          </button>
-        </div>
-
-        <div v-else-if="isMonacoLike(entry.field.type)" style="height: 200px;">
-          <MonacoEditor
-            :modelValue="drafts[entry.key] ?? ''"
-            :language="monacoLang(entry.field)"
-            :height="200"
-            @update:modelValue="updateMonacoDraft(entry.key, $event, entry.field.type)"
-          />
-        </div>
-
-        <TagInput
-          v-else-if="isListLike(entry.field.type)"
-          :modelValue="(fieldValue(entry.key, entry.field) as string[]) ?? []"
-          :placeholder="hintFor(entry.field)"
-          @update:modelValue="updateField(entry.key, $event)"
-        />
-
-        <UiTextarea
-          v-else-if="isTextareaLike(entry.field.type)"
-          :model-value="fieldValue(entry.key, entry.field) ?? ''"
-          rows="4"
-          class="w-full rounded-lg px-3 py-2 transition-colors"
-          :placeholder="hintFor(entry.field)"
-          @update:model-value="updateField(entry.key, $event)"
-        />
-
-        <div v-else-if="isJsonLike(entry.field.type)">
-          <UiTextarea
-            :model-value="drafts[entry.key]"
-            rows="5"
-            class="w-full rounded-lg px-3 py-2 transition-colors"
-            :placeholder="hintFor(entry.field)"
-            @update:model-value="onDraftInput(entry.key, $event, entry.field)"
-            @blur="onDraftBlur(entry.key, entry.field)"
-          />
-        </div>
-
-        <InfoCallout
-          v-else-if="isInfoLike(entry.field.type)"
-          :level="entry.field.level"
-          :label="labelFor(entry.field, entry.key)"
-          :hint="hintFor(entry.field)"
-        />
-
-        <UiInput
-          v-else
-          :model-value="stringValue(fieldValue(entry.key, entry.field))"
-          class="w-full rounded-lg px-3 py-2 transition-colors"
-          :placeholder="hintFor(entry.field)"
-          @update:model-value="updateField(entry.key, $event)"
-        />
-
-        <p v-if="hintFor(entry.field) && !isInfoLike(entry.field.type)" class="text-xs text-theme-subtle mt-1">{{ hintFor(entry.field) }}</p>
-      </div>
+      <ConfigFieldInput
+        v-else
+        :ref="(el: any) => setFieldRef(entry.key, el)"
+        class="mb-4"
+        :field="entry.field"
+        :field-key="entry.key"
+        :uid="entry.key"
+        :value="fieldValue(entry.key, entry.field)"
+        :model-options="modelOptionsFor(entry.field)"
+        :persona-options="personaSelectOptions"
+        @change="updateField(entry.key, $event)"
+      />
     </template>
   </div>
 </template>
@@ -298,17 +47,11 @@
 import { reactive, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useLocalized } from '@/composables/useLocalized'
-import CustomSelect from '@/components/common/CustomSelect.vue'
-import CustomMultiSelect from '@/components/common/CustomMultiSelect.vue'
-import TagInput from '@/components/common/TagInput.vue'
+import ConfigFieldInput from '@/components/common/ConfigFieldInput.vue'
 import CollapsibleSection from '@/components/common/CollapsibleSection.vue'
-import MonacoEditor from '@/components/common/MonacoEditor.vue'
-import InfoCallout from '@/components/common/InfoCallout.vue'
-import UiInput from '@/components/ui/UiInput.vue'
-import UiTextarea from '@/components/ui/UiTextarea.vue'
-import { IconEye, IconEyeOff } from '@/components/icons'
 import { getProviders, getModels } from '@/api/provider'
 import { getPersonas } from '@/api/persona'
+import { isInfoLike, isModelSelectLike, isPersonaSelectLike, isSectionLike } from '@/utils/configFieldTypes'
 
 const props = defineProps<{
   modelValue: Record<string, any>
@@ -322,11 +65,12 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { localize } = useLocalized()
 
-const drafts = reactive<Record<string, string>>({})
-const sensitiveVisible = reactive<Record<string, boolean>>({})
 const modelSelectOptions = reactive<Record<string, { value: string; label: string }[]>>({})
 const personaSelectOptions = reactive<{ value: string; label: string }[]>([])
 const sectionCollapsed = reactive<Record<string, boolean>>({})
+
+/** Field input instances keyed by unique draft key, for validation */
+const fieldRefs = new Map<string, any>()
 
 const effectiveSchema = computed<Record<string, any>>(() => {
   const s = props.schema
@@ -356,7 +100,7 @@ interface DataFieldEntry {
   fieldKey: string
 }
 
-/** Map keyed by draftKey: "fieldKey" for ungrouped, "sectionKey.fieldKey" for section fields */
+/** Map keyed by unique key: "fieldKey" for ungrouped, "sectionKey.fieldKey" for section fields */
 const allDataFields = computed(() => {
   const { entries } = groupedSchema.value
   const all: Record<string, DataFieldEntry> = {}
@@ -375,14 +119,13 @@ const allDataFields = computed(() => {
   return all
 })
 
-const lastSynced = reactive<Record<string, string>>({})
-
-const TEXTAREA_TYPES = new Set(['textarea'])
-const MONACO_TYPES = new Set(['json', 'markdown', 'yaml', 'editor'])
-const LIST_TYPES = new Set(['list'])
-const NUMBER_TYPES = new Set(['integer', 'float', 'number'])
-const BOOL_TYPES = new Set(['switch', 'boolean'])
-const JSON_TYPES = new Set(['object', 'array'])
+function setFieldRef(key: string, el: any) {
+  if (el) {
+    fieldRefs.set(key, el)
+  } else {
+    fieldRefs.delete(key)
+  }
+}
 
 function labelFor(field: any, key: string): string {
   const fallback = field?.name || field?.title || key
@@ -395,57 +138,55 @@ function hintFor(field: any): string | undefined {
   return localize(field, 'hint', fallback)
 }
 
-function optionsFor(field: any): any[] {
-  const raw = field?.options ?? field?.enum
-  return Array.isArray(raw) ? raw : []
+function modelOptionsFor(field: any): { value: string; label: string }[] {
+  return modelSelectOptions[field?.model_type || 'llm'] || []
 }
 
-function hasOptions(field: any): boolean {
-  return optionsFor(field).length > 0
+/** Return modelValue[key] if present, otherwise field.default */
+function fieldValue(key: string, field: any): any {
+  if (props.modelValue[key] !== undefined) return props.modelValue[key]
+  return field?.default
 }
 
-function isTextareaLike(type: string): boolean {
-  return TEXTAREA_TYPES.has(type)
+function sectionFieldValue(sectionKey: string, key: string, field: any): any {
+  const section = props.modelValue[sectionKey]
+  if (section && typeof section === 'object' && section[key] !== undefined) return section[key]
+  return field?.default
 }
 
-function isMonacoLike(type: string): boolean {
-  return MONACO_TYPES.has(type)
+function updateField(key: string, value: any) {
+  emit('update:modelValue', { ...props.modelValue, [key]: value })
 }
 
-function isListLike(type: string): boolean {
-  return LIST_TYPES.has(type)
+function updateSectionField(sectionKey: string, key: string, value: any) {
+  const section = { ...(props.modelValue[sectionKey] || {}), [key]: value }
+  emit('update:modelValue', { ...props.modelValue, [sectionKey]: section })
 }
 
-function isNumberLike(type: string): boolean {
-  return NUMBER_TYPES.has(type)
-}
-
-function isBoolLike(type: string): boolean {
-  return BOOL_TYPES.has(type)
-}
-
-function isJsonLike(type: string): boolean {
-  return JSON_TYPES.has(type)
-}
-
-function isModelSelectLike(type: string): boolean {
-  return type === 'model_select'
-}
-
-function isPersonaSelectLike(type: string): boolean {
-  return type === 'persona_select'
-}
-
-function isMultiSelectLike(type: string): boolean {
-  return type === 'multi_select'
-}
-
-function isSectionLike(type: string): boolean {
-  return type === 'section'
-}
-
-function isInfoLike(type: string): boolean {
-  return type === 'info'
+/** Apply field.defaults to modelValue for any missing keys */
+function applyDefaults() {
+  const schema = allDataFields.value
+  const result = { ...props.modelValue }
+  let changed = false
+  for (const dk in schema) {
+    const { field, sectionKey, fieldKey } = schema[dk]
+    if (!field) continue
+    if (sectionKey) {
+      if (!result[sectionKey] || typeof result[sectionKey] !== 'object') result[sectionKey] = {}
+      if (result[sectionKey][fieldKey] === undefined && field.default !== undefined) {
+        result[sectionKey][fieldKey] = field.default
+        changed = true
+      }
+    } else {
+      if (result[fieldKey] === undefined && field.default !== undefined) {
+        result[fieldKey] = field.default
+        changed = true
+      }
+    }
+  }
+  if (changed) {
+    emit('update:modelValue', result)
+  }
 }
 
 async function loadModelSelectOptions() {
@@ -509,82 +250,7 @@ async function loadPersonaSelectOptions() {
   }
 }
 
-function monacoLang(field: any): string {
-  const type = field?.type
-  if (type === 'json') return 'json'
-  if (type === 'markdown') return 'markdown'
-  if (type === 'yaml') return 'yaml'
-  if (type === 'editor') return field?.language || 'plaintext'
-  return 'plaintext'
-}
-
-function stringValue(v: unknown): string {
-  if (v === null || v === undefined) return ''
-  return typeof v === 'object' ? JSON.stringify(v) : String(v)
-}
-
-/** Return modelValue[key] if present, otherwise field.default */
-function fieldValue(key: string, field: any): any {
-  if (props.modelValue[key] !== undefined) return props.modelValue[key]
-  return field?.default
-}
-
-function sectionFieldValue(sectionKey: string, key: string, field: any): any {
-  const section = props.modelValue[sectionKey]
-  if (section && typeof section === 'object' && section[key] !== undefined) return section[key]
-  return field?.default
-}
-
-/** Apply field.defaults to modelValue for any missing keys */
-function applyDefaults() {
-  const schema = allDataFields.value
-  const result = { ...props.modelValue }
-  let changed = false
-  for (const dk in schema) {
-    const { field, sectionKey, fieldKey } = schema[dk]
-    if (!field) continue
-    if (sectionKey) {
-      if (!result[sectionKey] || typeof result[sectionKey] !== 'object') result[sectionKey] = {}
-      if (result[sectionKey][fieldKey] === undefined && field.default !== undefined) {
-        result[sectionKey][fieldKey] = field.default
-        changed = true
-      }
-    } else {
-      if (result[fieldKey] === undefined && field.default !== undefined) {
-        result[fieldKey] = field.default
-        changed = true
-      }
-    }
-  }
-  if (changed) {
-    emit('update:modelValue', result)
-  }
-}
-
-function initDrafts() {
-  const schema = allDataFields.value
-
-  for (const dk in schema) {
-    const { field, sectionKey, fieldKey } = schema[dk]
-    if (!field) continue
-    const val = sectionKey ? sectionFieldValue(sectionKey, fieldKey, field) : fieldValue(fieldKey, field)
-    if (isNumberLike(field.type)) {
-      drafts[dk] = val !== undefined && val !== null ? String(val) : ''
-      lastSynced[dk] = drafts[dk]
-    } else if (isMonacoLike(field.type)) {
-      const serialized = field.type === 'json' && typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val ?? '')
-      drafts[dk] = serialized
-      lastSynced[dk] = serialized
-    } else if (isJsonLike(field.type)) {
-      const serialized = typeof val === 'object' ? JSON.stringify(val, null, 2) : (val ?? '')
-      drafts[dk] = serialized
-      lastSynced[dk] = serialized
-    }
-  }
-}
-
 watch(() => effectiveSchema.value, () => {
-  initDrafts()
   applyDefaults()
   loadModelSelectOptions()
   loadPersonaSelectOptions()
@@ -597,176 +263,7 @@ watch(() => effectiveSchema.value, () => {
   }
 }, { immediate: true, deep: true })
 
-watch(() => props.modelValue, () => {
-  const schema = allDataFields.value
-  for (const dk in schema) {
-    const { field, sectionKey, fieldKey } = schema[dk]
-    if (!field) continue
-    const val = sectionKey ? sectionFieldValue(sectionKey, fieldKey, field) : fieldValue(fieldKey, field)
-    if (isNumberLike(field.type)) {
-      const serialized = val !== undefined && val !== null ? String(val) : ''
-      if (serialized !== lastSynced[dk]) {
-        drafts[dk] = serialized
-        lastSynced[dk] = serialized
-      }
-    } else if (isMonacoLike(field.type)) {
-      const serialized = field.type === 'json' && typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val ?? '')
-      if (serialized !== lastSynced[dk]) {
-        drafts[dk] = serialized
-        lastSynced[dk] = serialized
-      }
-    } else if (isJsonLike(field.type)) {
-      const serialized = typeof val === 'object' ? JSON.stringify(val, null, 2) : (val ?? '')
-      if (serialized !== lastSynced[dk]) {
-        drafts[dk] = serialized
-        lastSynced[dk] = serialized
-      }
-    }
-  }
-}, { deep: true })
-
-function updateField(key: string, value: any) {
-  emit('update:modelValue', { ...props.modelValue, [key]: value })
-}
-
-function updateSectionField(sectionKey: string, key: string, value: any) {
-  const section = { ...(props.modelValue[sectionKey] || {}), [key]: value }
-  emit('update:modelValue', { ...props.modelValue, [sectionKey]: section })
-}
-
-function updateMonacoDraft(key: string, val: string, type: string) {
-  drafts[key] = val
-  if (type === 'json') {
-    try {
-      const parsed = JSON.parse(val)
-      lastSynced[key] = val
-      emit('update:modelValue', { ...props.modelValue, [key]: parsed })
-    } catch {
-      // Keep draft as-is; validation deferred to save
-    }
-  } else {
-    lastSynced[key] = val
-    emit('update:modelValue', { ...props.modelValue, [key]: val })
-  }
-}
-
-
-function commitNumberDraft(key: string, field: any) {
-  const raw = drafts[key]
-  const empty = raw === '' || raw === null || raw === undefined
-  const parsed = empty ? null : Number(raw)
-  if (!empty) {
-    if (!Number.isFinite(parsed)) return
-    if (field?.type === 'integer' && !Number.isInteger(parsed)) return
-  }
-  lastSynced[key] = raw ?? ''
-  emit('update:modelValue', { ...props.modelValue, [key]: parsed })
-}
-
-function onDraftInput(key: string, val: string, field: any) {
-  drafts[key] = val
-  try {
-    const parsed = JSON.parse(val)
-    if (isValidType(parsed, field.type)) {
-      lastSynced[key] = val
-      emit('update:modelValue', { ...props.modelValue, [key]: parsed })
-    }
-  } catch {
-    // Allow typing — don't emit until valid
-  }
-}
-
-function onDraftBlur(key: string, field: any) {
-  if (!drafts[key] || !drafts[key].trim()) {
-    emit('update:modelValue', { ...props.modelValue, [key]: null })
-    return
-  }
-  try {
-    const parsed = JSON.parse(drafts[key])
-    if (isValidType(parsed, field.type)) {
-      emit('update:modelValue', { ...props.modelValue, [key]: parsed })
-    }
-  } catch {
-    // Keep draft as-is; validation deferred to save
-  }
-}
-
-function isValidType(parsed: any, type: string): boolean {
-  if (type === 'object' || type === 'json') {
-    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
-  }
-  if (type === 'array' || type === 'list') {
-    return Array.isArray(parsed)
-  }
-  return true
-}
-
-function toggleSensitive(key: string) {
-  sensitiveVisible[key] = !sensitiveVisible[key]
-}
-
-function commitSectionNumberDraft(sectionKey: string, key: string, field: any) {
-  const dk = sectionKey + '.' + key
-  const raw = drafts[dk]
-  const empty = raw === '' || raw === null || raw === undefined
-  const parsed = empty ? null : Number(raw)
-  if (!empty) {
-    if (!Number.isFinite(parsed)) return
-    if (field?.type === 'integer' && !Number.isInteger(parsed)) return
-  }
-  lastSynced[dk] = raw ?? ''
-  updateSectionField(sectionKey, key, parsed)
-}
-
-function updateSectionMonacoDraft(sectionKey: string, key: string, val: string, type: string) {
-  const dk = sectionKey + '.' + key
-  drafts[dk] = val
-  if (type === 'json') {
-    try {
-      const parsed = JSON.parse(val)
-      lastSynced[dk] = val
-      updateSectionField(sectionKey, key, parsed)
-    } catch {
-      // Keep draft as-is; validation deferred to save
-    }
-  } else {
-    lastSynced[dk] = val
-    updateSectionField(sectionKey, key, val)
-  }
-}
-
-function onSectionDraftInput(sectionKey: string, key: string, val: string, field: any) {
-  const dk = sectionKey + '.' + key
-  drafts[dk] = val
-  try {
-    const parsed = JSON.parse(val)
-    if (isValidType(parsed, field.type)) {
-      lastSynced[dk] = val
-      updateSectionField(sectionKey, key, parsed)
-    }
-  } catch {
-    // Allow typing — don't emit until valid
-  }
-}
-
-function onSectionDraftBlur(sectionKey: string, key: string, field: any) {
-  const dk = sectionKey + '.' + key
-  if (!drafts[dk] || !drafts[dk].trim()) {
-    updateSectionField(sectionKey, key, null)
-    return
-  }
-  try {
-    const parsed = JSON.parse(drafts[dk])
-    if (isValidType(parsed, field.type)) {
-      updateSectionField(sectionKey, key, parsed)
-    }
-  } catch {
-    // Keep draft as-is; validation deferred to save
-  }
-}
-
 function validate(): { valid: boolean; message?: string } {
-  const schema = allDataFields.value
   const result = { ...props.modelValue }
   // Deep-copy section dicts so nested writes don't mutate props
   for (const entry of groupedSchema.value.entries) {
@@ -775,66 +272,20 @@ function validate(): { valid: boolean; message?: string } {
     }
   }
 
-  for (const dk in schema) {
-    const { field, sectionKey, fieldKey } = schema[dk]
-    if (!field) continue
-    const label = labelFor(field, fieldKey)
-
-    const setResult = (v: any) => {
+  for (const dk in allDataFields.value) {
+    const { sectionKey, fieldKey } = allDataFields.value[dk]
+    const child = fieldRefs.get(dk)
+    if (!child) continue
+    const res = child.validate()
+    if (!res.valid) {
+      return { valid: false, message: res.message }
+    }
+    if (res.value !== undefined) {
       if (sectionKey) {
         if (!result[sectionKey] || typeof result[sectionKey] !== 'object') result[sectionKey] = {}
-        result[sectionKey][fieldKey] = v
+        result[sectionKey][fieldKey] = res.value
       } else {
-        result[fieldKey] = v
-      }
-    }
-
-    // Number / integer / float
-    if (isNumberLike(field.type)) {
-      const raw = drafts[dk]
-      if (raw === '' || raw === undefined) {
-        setResult(null)
-      } else {
-        const parsed = Number(raw)
-        if (!Number.isFinite(parsed)) {
-          return { valid: false, message: `${label}: ${t('configform.invalid_number')}` }
-        }
-        if (field.type === 'integer' && !Number.isInteger(parsed)) {
-          return { valid: false, message: `${label}: ${t('configform.invalid_number')}` }
-        }
-        setResult(parsed)
-      }
-    }
-
-    // Monaco JSON
-    if (isMonacoLike(field.type) && field.type === 'json') {
-      const val = drafts[dk]
-      if (!val || !val.trim()) {
-        setResult(null)
-      } else {
-        try {
-          setResult(JSON.parse(val))
-        } catch {
-          return { valid: false, message: `${label}: ${t('configform.invalid_json')}` }
-        }
-      }
-    }
-
-    // Object / array
-    if (isJsonLike(field.type)) {
-      const val = drafts[dk]
-      if (!val || !val.trim()) {
-        setResult(null)
-      } else {
-        try {
-          const parsed = JSON.parse(val)
-          if (!isValidType(parsed, field.type)) {
-            return { valid: false, message: `${label}: ${t('configform.expected_type', { type: field.type })}` }
-          }
-          setResult(parsed)
-        } catch {
-          return { valid: false, message: `${label}: ${t('configform.invalid_json')}` }
-        }
+        result[fieldKey] = res.value
       }
     }
   }

--- a/webui/frontend/src/components/common/CustomSelect.vue
+++ b/webui/frontend/src/components/common/CustomSelect.vue
@@ -3,7 +3,7 @@
     <!-- Trigger -->
     <div
       class="custom-select-trigger"
-      :class="{ active: isOpen, 'has-value': !!modelValue, placeholder: !modelValue, disabled: props.disabled }"
+      :class="{ active: isOpen, 'has-value': hasValue, placeholder: !hasValue, disabled: props.disabled }"
       :style="props.height ? { height: props.height, minHeight: props.height } : undefined"
       @click.stop="toggleDropdown"
       @keydown.enter.prevent="onEnter"
@@ -90,6 +90,9 @@ const emit = defineEmits<{
 }>()
 
 const { isDark } = useTheme()
+
+// truthiness would treat a selected numeric 0 as empty
+const hasValue = computed(() => props.modelValue !== '' && props.modelValue !== null && props.modelValue !== undefined)
 
 const isOpen = ref(false)
 const containerRef = ref<HTMLElement>()

--- a/webui/frontend/src/components/common/CustomSelect.vue
+++ b/webui/frontend/src/components/common/CustomSelect.vue
@@ -71,14 +71,14 @@ import { IconCheck, IconChevronDown } from '@/components/icons'
 import { useTheme } from '@/composables/useTheme'
 
 interface Option {
-  value: string
+  value: string | number
   label: string
   icon?: string | null
   iconDark?: string | null
 }
 
 const props = defineProps<{
-  modelValue: string
+  modelValue: string | number
   options: Option[]
   placeholder?: string
   disabled?: boolean
@@ -86,7 +86,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  'update:modelValue': [value: string]
+  'update:modelValue': [value: any]
 }>()
 
 const { isDark } = useTheme()

--- a/webui/frontend/src/i18n/en.ts
+++ b/webui/frontend/src/i18n/en.ts
@@ -947,6 +947,7 @@ export default {
     load_error: 'Failed to load configuration',
     select_model: '— Select model —',
     select_persona: 'Select Persona',
+    select_session: 'Select Session',
     json_invalid: 'Invalid JSON in field "{field}": {error}',
   },
   login: {

--- a/webui/frontend/src/i18n/zh.ts
+++ b/webui/frontend/src/i18n/zh.ts
@@ -948,6 +948,7 @@ export default {
     load_error: '加载配置失败',
     select_model: '— 请选择模型 —',
     select_persona: '选择人设',
+    select_session: '选择会话',
     json_invalid: '字段"{field}"包含无效的 JSON：{error}',
   },
   login: {

--- a/webui/frontend/src/utils/configFieldTypes.ts
+++ b/webui/frontend/src/utils/configFieldTypes.ts
@@ -43,6 +43,10 @@ export function isPersonaSelectLike(type: string): boolean {
   return type === 'persona_select'
 }
 
+export function isSessionSelectLike(type: string): boolean {
+  return type === 'session_select'
+}
+
 export function isMultiSelectLike(type: string): boolean {
   return type === 'multi_select'
 }

--- a/webui/frontend/src/utils/configFieldTypes.ts
+++ b/webui/frontend/src/utils/configFieldTypes.ts
@@ -1,0 +1,66 @@
+/**
+ * Type classification helpers for schema-driven config fields.
+ * Shared by ConfigForm (grouping, defaults, validation) and
+ * ConfigFieldInput (single-field rendering).
+ */
+
+const TEXTAREA_TYPES = new Set(['textarea'])
+const MONACO_TYPES = new Set(['json', 'markdown', 'yaml', 'editor'])
+const LIST_TYPES = new Set(['list'])
+const NUMBER_TYPES = new Set(['integer', 'float', 'number'])
+const BOOL_TYPES = new Set(['switch', 'boolean', 'bool'])
+const JSON_TYPES = new Set(['object', 'array'])
+
+export function isTextareaLike(type: string): boolean {
+  return TEXTAREA_TYPES.has(type)
+}
+
+export function isMonacoLike(type: string): boolean {
+  return MONACO_TYPES.has(type)
+}
+
+export function isListLike(type: string): boolean {
+  return LIST_TYPES.has(type)
+}
+
+export function isNumberLike(type: string): boolean {
+  return NUMBER_TYPES.has(type)
+}
+
+export function isBoolLike(type: string): boolean {
+  return BOOL_TYPES.has(type)
+}
+
+export function isJsonLike(type: string): boolean {
+  return JSON_TYPES.has(type)
+}
+
+export function isModelSelectLike(type: string): boolean {
+  return type === 'model_select'
+}
+
+export function isPersonaSelectLike(type: string): boolean {
+  return type === 'persona_select'
+}
+
+export function isMultiSelectLike(type: string): boolean {
+  return type === 'multi_select'
+}
+
+export function isSectionLike(type: string): boolean {
+  return type === 'section'
+}
+
+export function isInfoLike(type: string): boolean {
+  return type === 'info'
+}
+
+/** Options may come from `options` or the legacy `enum` key. */
+export function optionsFor(field: any): any[] {
+  const raw = field?.options ?? field?.enum
+  return Array.isArray(raw) ? raw : []
+}
+
+export function hasOptions(field: any): boolean {
+  return optionsFor(field).length > 0
+}


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

Enhance the schema-driven config field system so plugins can express dropdown choices without the deprecated `enum` type, and add a `session_select` type plus dynamic option sources for `multi_select`.

- `string` / `integer` / `float` fields now support an `options` list and render as dropdowns on the WebUI, preserving value types (numeric options are saved as numbers, not strings). `bool` / `boolean` are accepted as aliases of `switch`. The `enum` type is deprecated but still fully supported for backward compatibility.
- New `session_select` field type for picking one session; option labels always show the internal session key (`adapter:type:id`, e.g. `qq:dm:123`).
- `multi_select` supports a dynamic `source` (`model` / `persona` / `session`) that loads options at runtime (`model_type` applies when `source=model`).
- WebUI config forms refactored: the per-field rendering dispatch (previously duplicated for section and ungrouped fields) moved into a reusable `ConfigFieldInput` component with shared type helpers and per-field validation; the external `ConfigForm` interface is unchanged.

## Type of change

<!-- Check the one that applies. -->

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- `core/config/config_field.py`: options support for `StringField`/`IntField`/`FloatField` (default falls back to the first option when not in the list), `bool`/`boolean` schema aliases, deprecation marking on `EnumField`, new `SessionSelectField`, dynamic `source`/`model_type` on `MultiSelectField`
- `webui/frontend`: new `ConfigFieldInput.vue` per-field renderer and shared `utils/configFieldTypes.ts`; session/persona/model option loading reused by dynamic `multi_select` sources; session options labeled with their internal id; `config.select_session` i18n strings (zh/en)
- `tests/test_config_field.py`: coverage for options support, aliases, enum backward compatibility, dynamic sources and `session_select`

## Screenshots / Logs

Not applicable — verified via `python -m pytest tests/` (416 passed) and `npm run build` (vue-tsc + vite).

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a unified configuration form supporting text, numeric, JSON, editor, password, tags, multi-select, model, persona, and session inputs.
  - Added session-based selection fields with English and Chinese labels.
  - Added configurable options for string, integer, float, and multi-select fields.
  - Added dynamic model, persona, and session option sources.
  - Select controls now support numeric option values.

- **Bug Fixes**
  - Invalid configured defaults now fall back to the first available option.
  - Improved validation and synchronization for editable configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->