### PR TITLE
fix(qq): send stickers with image sub type

### DIFF
--- a/core/adapter/src/qq/napcat_client/utils.py
+++ b/core/adapter/src/qq/napcat_client/utils.py
@@ -158,7 +158,8 @@ class QQMessageChain:
                     "type": "image",
                     "data": {
                         "file": file_param,
-                        "summary": "[动画表情]"
+                        "summary": "[动画表情]",
+                        "sub_type": 1,
                     }
                 })
             elif isinstance(ele, QQMessageType.Record):

--- a/core/adapter/src/qq/qq.py
+++ b/core/adapter/src/qq/qq.py
@@ -679,7 +679,12 @@ class QQAdapter(IMAdapter):
                     self.logger.warning(f"未定义的 Emoji ID: {ele.emoji_id}")
             elif isinstance(ele, Sticker):
                 sticker_base64 = await ele.to_base64()
-                message_chain_elements.append(QQMessageType.Image(f"base64://{sticker_base64}"))
+                message_chain_elements.append(
+                    QQMessageType.Sticker(
+                        ele.sticker_id or "",
+                        f"base64://{sticker_base64}",
+                    )
+                )
             elif isinstance(ele, At):
                 val = ele.pid
                 message_chain_elements.append(QQMessageType.At(val))


### PR DESCRIPTION
## Summary

Send QQ sticker-library items with NapCat's sticker image subtype so QQ renders them as stickers instead of regular images.

## Type of change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Route common `Sticker` elements through the QQ-specific sticker message type.
- Serialize QQ stickers as image segments with `summary: "[动画表情]"` and `sub_type: 1`.
- Keep regular QQ image payloads unchanged.

## Screenshots / Logs

- User manually verified sticker sending successfully in a running environment.
- `python -m pytest tests/test_message_elements.py tests/test_message_utils.py -q` — 83 passed.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sticker message handling for QQ.
  * Sticker content is now sent and identified as animated sticker content instead of a generic image.
  * Added metadata to improve compatibility when processing sticker payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->