### PR TITLE
chore: 三次重复匹配合成一次

### DIFF
--- a/core/adapter/src/qq/napcat_client/utils.py
+++ b/core/adapter/src/qq/napcat_client/utils.py
@@ -104,11 +104,9 @@ class QQMessageChain:
                 elif ele.base64:
                     if ele.base64.startswith("base64://"):
                         file_param = ele.base64
-                    elif re.match(r"data:image/(jpg|jpeg|png|gif|bmp|webp|tiff|svg);base64,", ele.base64):
-                        m = re.match(r"data:image/(jpg|jpeg|png|gif|bmp|webp|tiff|svg);base64,(.*)", ele.base64)
-                        file_param = f"base64://{m.group(2)}"
                     else:
-                        file_param = ""
+                        m = re.match(r"data:image/(jpg|jpeg|png|gif|bmp|webp|tiff|svg);base64,(.*)", ele.base64)
+                        file_param = f"base64://{m.group(2)}" if m else ""
                 else:
                     file_param = ""
 
@@ -149,11 +147,9 @@ class QQMessageChain:
             elif isinstance(ele, QQMessageType.Sticker):
                 if ele.sticker_bs64.startswith("base64://"):
                     file_param = ele.sticker_bs64
-                elif re.match(r"data:image/(jpg|jpeg|png|gif|bmp|webp|tiff|svg);base64,", ele.sticker_bs64):
-                    m = re.match(r"data:image/(jpg|jpeg|png|gif|bmp|webp|tiff|svg);base64,(.*)", ele.sticker_bs64)
-                    file_param = f"base64://{m.group(2)}"
                 else:
-                    file_param = ""
+                    m = re.match(r"data:image/(jpg|jpeg|png|gif|bmp|webp|tiff|svg);base64,(.*)", ele.sticker_bs64)
+                    file_param = f"base64://{m.group(2)}" if m else ""
                 msg_list.append({
                     "type": "image",
                     "data": {
@@ -165,11 +161,9 @@ class QQMessageChain:
             elif isinstance(ele, QQMessageType.Record):
                 if ele.bs64.startswith("base64://"):
                     file_param = ele.bs64
-                elif re.match(r"data:(.*)/(.*);base64,", ele.bs64):
-                    m = re.match(r"data:(.*)/(.*);base64,(.*)", ele.bs64)
-                    file_param = f"base64://{m.group(3)}"
                 else:
-                    file_param = ""
+                    m = re.match(r"data:(.*)/(.*);base64,(.*)", ele.bs64)
+                    file_param = f"base64://{m.group(3)}" if m else ""
                 msg_list.append({
                     "type": "record",
                     "data": {


### PR DESCRIPTION
> **⚠️ Base branch must be `dev`.** PRs targeting `main` will be rejected.

## Summary

<!-- Briefly describe what this PR does and why. Link related issues: Fixes #123, Closes #456 -->
删除累赘的匹配，合成为一次
## Type of change

<!-- Check the one that applies. -->

- [ ] feat: New feature
- [ ] fix: Bug fix
- [x] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

<!-- List the key changes in this PR. -->
只修改了napcat_client的utils.py有关base64数据的正则表达式提取的重复累赘逻辑
-

## Screenshots / Logs

<!-- If applicable, add screenshots or relevant logs to help reviewers. -->

## Checklist

- [ ] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of image, sticker, and voice-record data URIs in message chains.
  - Valid data URIs are now converted consistently to the expected Base64 format.
  - Invalid or unmatched data URIs now produce an empty value instead of falling through to unintended handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->