### PR TITLE
feat(webui): improve responsive page layout

### DIFF
--- a/webui/frontend/src/assets/main.css
+++ b/webui/frontend/src/assets/main.css
@@ -84,14 +84,14 @@ button,
   pointer-events: auto;
 }
 
-@media (min-width: 769px) {
+@media (min-width: 1025px) {
   .sidebar-overlay {
     display: none;
   }
 }
 
 /* ==================== Sidebar Menu Button ==================== */
-@media (min-width: 769px) {
+@media (min-width: 1025px) {
   .sidebar-menu-btn {
     display: none !important;
   }

--- a/webui/frontend/src/assets/main.css
+++ b/webui/frontend/src/assets/main.css
@@ -90,13 +90,6 @@ button,
   }
 }
 
-/* ==================== Sidebar Menu Button ==================== */
-@media (min-width: 1025px) {
-  .sidebar-menu-btn {
-    display: none !important;
-  }
-}
-
 /* ==================== Navigation ==================== */
 .nav-item {
   color: var(--color-text-primary);

--- a/webui/frontend/src/components/layout/AppHeader.vue
+++ b/webui/frontend/src/components/layout/AppHeader.vue
@@ -4,6 +4,7 @@
       <button
         class="sidebar-menu-btn p-1.5 mr-3 rounded-lg bg-[#f5f5f5] hover:bg-[#e7e7e8] dark:bg-[#121215] dark:hover:bg-[#2b2b2e] text-theme-subtle transition-colors"
         aria-label="Toggle menu"
+        :aria-expanded="sidebarOpen"
         @click="$emit('toggle-sidebar')"
       >
         <IconHamburger class="w-6 h-6" />
@@ -149,7 +150,7 @@ import {
   IconHamburger, IconMoreVertical, IconDownload, IconBook, IconGithub, IconMoon, IconSun, IconLogout,
 } from '@/components/icons'
 
-defineProps<{ title: string }>()
+defineProps<{ title: string; sidebarOpen: boolean }>()
 defineEmits<{ 'toggle-sidebar': [] }>()
 
 const { t } = useI18n()

--- a/webui/frontend/src/components/layout/AppHeader.vue
+++ b/webui/frontend/src/components/layout/AppHeader.vue
@@ -282,7 +282,7 @@ async function handleLogout() {
   transform: translateY(-0.5rem) scale(0.96);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .header-actions {
     display: none;
   }

--- a/webui/frontend/src/components/layout/AppSidebar.vue
+++ b/webui/frontend/src/components/layout/AppSidebar.vue
@@ -121,7 +121,7 @@ function isActive(path: string): boolean {
   width: 16rem;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .sidebar-gradient {
     position: fixed;
     top: 0;

--- a/webui/frontend/src/components/layout/AppSidebar.vue
+++ b/webui/frontend/src/components/layout/AppSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="sidebar-gradient min-h-screen flex flex-col text-theme-strong" :class="{ 'sidebar-open': open }">
+  <aside class="sidebar-gradient min-h-screen flex flex-col text-theme-strong" :class="{ 'sidebar-open': open, 'sidebar-collapsed': !open }">
     <!-- Logo -->
     <div class="p-6 border-b border-blue-200/30">
       <h1 class="text-2xl font-bold text-theme-strong">{{ $t('app.title') }}</h1>
@@ -119,6 +119,15 @@ function isActive(path: string): boolean {
 <style scoped>
 .sidebar-gradient {
   width: 16rem;
+  overflow: hidden;
+  transition: width 0.25s ease;
+}
+
+@media (min-width: 1025px) {
+  .sidebar-gradient.sidebar-collapsed {
+    width: 0;
+    border-right-width: 0;
+  }
 }
 
 @media (max-width: 1024px) {
@@ -131,6 +140,7 @@ function isActive(path: string): boolean {
     transform: translateX(-100%);
     transition: transform 0.25s ease;
   }
+
   .sidebar-gradient.sidebar-open {
     transform: translateX(0);
   }

--- a/webui/frontend/src/components/layout/AppSidebar.vue
+++ b/webui/frontend/src/components/layout/AppSidebar.vue
@@ -1,5 +1,10 @@
 <template>
-  <aside class="sidebar-gradient min-h-screen flex flex-col text-theme-strong" :class="{ 'sidebar-open': open, 'sidebar-collapsed': !open }">
+  <aside
+    class="sidebar-gradient min-h-screen flex flex-col text-theme-strong"
+    :class="{ 'sidebar-open': open, 'sidebar-collapsed': !open }"
+    :inert="!open"
+    :aria-hidden="!open"
+  >
     <!-- Logo -->
     <div class="p-6 border-b border-blue-200/30">
       <h1 class="text-2xl font-bold text-theme-strong">{{ $t('app.title') }}</h1>

--- a/webui/frontend/src/components/layout/PageContainer.vue
+++ b/webui/frontend/src/components/layout/PageContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page-content p-6 flex flex-col">
+  <div class="page-content w-full max-w-[1280px] mx-auto p-6 flex flex-col">
     <slot />
   </div>
 </template>

--- a/webui/frontend/src/views/MainLayout.vue
+++ b/webui/frontend/src/views/MainLayout.vue
@@ -17,7 +17,7 @@
           :title="pageTitle"
           @toggle-sidebar="toggleSidebar"
         />
-        <PageContainer :class="{ 'flex-1 min-h-0 !p-0': route.meta.pluginPage }">
+        <PageContainer :class="{ 'flex-1 min-h-0 !p-0 !max-w-none': route.meta.pluginPage }">
           <router-view v-slot="{ Component, route: r }">
             <transition name="page-fade">
               <component :is="Component" :key="r.fullPath" />
@@ -60,7 +60,7 @@ function closeSidebar() {
 
 // Auto-close sidebar on navigation for mobile
 watch(() => route.path, () => {
-  if (window.innerWidth <= 768) {
+  if (window.innerWidth <= 1024) {
     sidebarOpen.value = false
   }
 })

--- a/webui/frontend/src/views/MainLayout.vue
+++ b/webui/frontend/src/views/MainLayout.vue
@@ -15,6 +15,7 @@
       <main class="flex-1 flex flex-col" :class="route.meta.pluginPage ? 'overflow-hidden' : 'overflow-auto'">
         <AppHeader
           :title="pageTitle"
+          :sidebar-open="sidebarOpen"
           @toggle-sidebar="toggleSidebar"
         />
         <PageContainer :class="{ 'flex-1 min-h-0 !p-0 !max-w-none': route.meta.pluginPage }">
@@ -31,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useRouteLoading } from '@/composables/useRouteLoading'
 import { useI18n } from 'vue-i18n'
@@ -48,7 +49,7 @@ const pluginMenuStore = usePluginMenuStore()
 
 const { phase: routePhase } = useRouteLoading()
 
-const sidebarOpen = ref(false)
+const sidebarOpen = ref(window.innerWidth > 1024)
 
 function toggleSidebar() {
   sidebarOpen.value = !sidebarOpen.value
@@ -57,6 +58,13 @@ function toggleSidebar() {
 function closeSidebar() {
   sidebarOpen.value = false
 }
+
+function handleResize() {
+  if (window.innerWidth <= 1024) closeSidebar()
+}
+
+onMounted(() => window.addEventListener('resize', handleResize))
+onUnmounted(() => window.removeEventListener('resize', handleResize))
 
 // Auto-close sidebar on navigation for mobile
 watch(() => route.path, () => {


### PR DESCRIPTION
## Summary

Constrain built-in WebUI content to 1280px on wide screens while keeping plugin-registered pages full width. Add a desktop-visible hamburger control that collapses or restores the normal left sidebar, with the existing drawer behavior retained for narrow screens.

## Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Limit built-in page content to 1280px and exempt plugin iframe pages.
- Keep the sidebar in the normal left layout above 1024px, with a hamburger control to collapse or restore it.
- Preserve the overlay drawer sidebar and compact header behavior at 1024px and below.

## Screenshots / Logs

No screenshots captured. Local verification: `npm run build` completed successfully.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] New dependencies have been added to `requirements.txt` (if applicable)
- [x] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar behavior now adapts at the 1024px breakpoint, supporting smoother collapsing and automatic closing when switching to smaller screens.
  * The sidebar toggle now communicates its expanded or collapsed state to assistive technologies.
* **Improvements**
  * Expanded desktop layouts now provide more available content space.
  * Page content is centered with a responsive full-width layout and a maximum width of 1280px.
  * Sidebar transitions are smoother when opening or closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->