### PR TITLE
fix(adapter): default permission mode to deny list

### DIFF
--- a/core/adapter/src/qq_official/schema.json
+++ b/core/adapter/src/qq_official/schema.json
@@ -42,7 +42,7 @@
     "name": "Permission Mode",
     "type": "string",
     "options": ["allow_list", "deny_list"],
-    "default": "allow_list",
+    "default": "deny_list",
     "hint": "Allow list or deny list",
     "locales": {
       "zh": { "name": "权限模式", "hint": "白名单或黑名单" }

--- a/core/adapter/src/weixin_oc/schema.json
+++ b/core/adapter/src/weixin_oc/schema.json
@@ -66,7 +66,7 @@
     "name": "Permission Mode",
     "type": "string",
     "options": ["allow_list", "deny_list"],
-    "default": "allow_list",
+    "default": "deny_list",
     "hint": "Allow list or deny list mode",
     "locales": {
       "zh": { "name": "权限模式", "hint": "白名单或黑名单模式" }


### PR DESCRIPTION
## Summary

Set the default permission mode to `deny_list` for the personal WeChat and QQ Official Bot adapters so newly created adapter configurations allow messages unless an ID is explicitly denied.

## Type of change

- [x] fix: Bug fix
- [ ] feat: New feature
- [ ] refactor: Code refactor (no functional change)
- [ ] docs: Documentation update
- [ ] chore: Build, CI, dependencies, or other maintenance
- [ ] style: Code style / formatting (no logic change)
- [ ] test: Adding or updating tests

## Changes

- Change `weixin_oc.permission_mode` default from `allow_list` to `deny_list`.
- Change `qq_official.permission_mode` default from `allow_list` to `deny_list`.

## Screenshots / Logs

Not applicable. Validated both updated schema files by parsing them as JSON and checked the diff for whitespace errors.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [ ] New dependencies have been added to `requirements.txt` (if applicable)
- [ ] If this PR introduces new features, they have been discussed with the owner or maintainer
- [x] This PR does not introduce breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the default permission mode for QQ Official and Weixin Official adapters from allow-list to deny-list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->